### PR TITLE
refactor: Extract type operations to TypeResolver (Phases 5-7)

### DIFF
--- a/src/codegen/CodeGenerator.ts
+++ b/src/codegen/CodeGenerator.ts
@@ -2006,14 +2006,7 @@ export default class CodeGenerator {
     structType: string,
     memberName: string,
   ): { isArray: boolean; baseType: string } | undefined {
-    const fieldType = this.structFields.get(structType)?.get(memberName);
-    if (!fieldType) return undefined;
-
-    // Check if this field is marked as an array
-    const arrayFields = this.structFieldArrays.get(structType);
-    const isArray = arrayFields?.has(memberName) ?? false;
-
-    return { isArray, baseType: fieldType };
+    return this.typeResolver!.getMemberTypeInfo(structType, memberName);
   }
 
   /**
@@ -2099,33 +2092,7 @@ export default class CodeGenerator {
     targetType: string,
     sourceType: string | null,
   ): void {
-    // If we can't determine source type, skip validation
-    if (!sourceType) return;
-
-    // Skip if types are the same
-    if (sourceType === targetType) return;
-
-    // Only validate integer-to-integer conversions
-    if (!this.isIntegerType(sourceType) || !this.isIntegerType(targetType))
-      return;
-
-    // Check for narrowing conversion
-    if (this.isNarrowingConversion(sourceType, targetType)) {
-      const targetWidth = TYPE_WIDTH[targetType] || 0;
-      throw new Error(
-        `Error: Cannot assign ${sourceType} to ${targetType} (narrowing). ` +
-          `Use bit indexing: value[0, ${targetWidth}]`,
-      );
-    }
-
-    // Check for sign conversion
-    if (this.isSignConversion(sourceType, targetType)) {
-      const targetWidth = TYPE_WIDTH[targetType] || 0;
-      throw new Error(
-        `Error: Cannot assign ${sourceType} to ${targetType} (sign change). ` +
-          `Use bit indexing: value[0, ${targetWidth}]`,
-      );
-    }
+    this.typeResolver!.validateTypeConversion(targetType, sourceType);
   }
 
   /**


### PR DESCRIPTION
## Summary

Continue TypeResolver extraction (Phases 5-7) to reduce CodeGenerator complexity by moving type validation, inference, and lookup operations to a dedicated TypeResolver class.

**Progress:**
- CodeGenerator reduced from 7,616 to 7,404 lines (-212 lines, -2.8%)
- TypeResolver expanded from 58 to 365 lines
- All 270 tests pass with zero behavioral changes

## Changes by Phase

### Phase 5: Type Validation Methods
Extract core type validation operations:
- `isNarrowingConversion()` - Checks if type conversion narrows bit width
- `isSignConversion()` - Detects signed/unsigned conversions
- `validateLiteralFitsType()` - Validates literals fit in target type range
- Remove unused `TYPE_RANGES` import from CodeGenerator

### Phase 6: Type Inference Methods  
Extract AST-based type inference:
- `getLiteralType()` - Detects type from literal syntax
- `getExpressionType()` - Infers type from expression AST
- `getPostfixExpressionType()` - Handles postfix operations
- `getPrimaryExpressionType()` - Base expression type inference
- `getUnaryExpressionType()` - Unary operator type handling

TypeResolver accesses CodeGenerator via bracket notation for:
- `getPostfixExpression()` - AST navigation
- `resolveIdentifier()` - Identifier scoping
- `context.typeRegistry` - Type information lookup

### Phase 7: Type Validation & Lookup
Complete type validation extraction:
- `validateTypeConversion()` - Validates integer conversions
- `getMemberTypeInfo()` - Struct member type lookup

TypeResolver accesses CodeGenerator data:
- `structFields` - Struct field type mapping
- `structFieldArrays` - Array field tracking

## Architecture

**Separation of Concerns:**
- TypeResolver: Type classification, validation, and inference
- CodeGenerator: Code generation and AST traversal

**Clean Delegation:**
CodeGenerator retains thin wrapper methods that delegate to TypeResolver, maintaining a stable interface while centralizing type logic.

## Testing

- ✅ All 270 tests pass
- ✅ ESLint checks pass
- ✅ Prettier formatting applied
- ✅ Zero behavioral changes

## Extracted Methods Summary (15 total)

**Phase 1-4 (baseline):** 5 classification methods  
**Phase 5:** 3 validation methods  
**Phase 6:** 5 inference methods  
**Phase 7:** 2 validation+lookup methods

## Files Changed

```
src/codegen/CodeGenerator.ts | 232 ++-----------
src/codegen/TypeResolver.ts  | 307 +++++++++++++++++
2 files changed, 317 insertions(+), 222 deletions(-)
```

## Related Work

Builds on Phases 1-4 (PR #6) which established TypeResolver foundation.

🤖 Generated with Claude Code