### PR TITLE
Update ADR-010: Resolve open questions and document implementation status

### DIFF
--- a/docs/decisions/adr-010-c-interoperability.md
+++ b/docs/decisions/adr-010-c-interoperability.md
@@ -208,6 +208,7 @@ For embedded projects (Arduino, Teensy), option 1 or 2 works well since the buil
 ## Implementation Status
 
 **Completed:**
+
 - ✅ Phase 1: C11 and CPP14 grammars imported from grammars-v4
 - ✅ Phase 1: `CSymbolCollector` and `CppSymbolCollector` extract symbols from C/C++ files
 - ✅ Phase 2: `SymbolTable` class with cross-language conflict detection
@@ -219,6 +220,7 @@ For embedded projects (Arduino, Teensy), option 1 or 2 works well since the buil
 - ✅ CLI `--project` mode for multi-file builds
 
 **In Progress:**
+
 - 🔶 Phase 3: Cross-file resolution partially works
   - Symbol table is populated but not fully utilized
   - **Issue:** `CodeGenerator` doesn't use symbol table for type resolution
@@ -226,11 +228,13 @@ For embedded projects (Arduino, Teensy), option 1 or 2 works well since the buil
   - **Example:** `config.magic.length` where `AppConfig` is from C header → `length = 0 / 8`
 
 **Not Started:**
+
 - ❌ Remove `--project` flag (should always use unified parsing)
 - ❌ Make unified parsing the default behavior
 - ❌ Update CodeGenerator to use SymbolTable for type resolution
 
 **Known Issues:**
+
 - CodeGenerator line 5616 only checks local `structFields` map, ignores `symbolTable`
 - Single-file mode (`cnext file.cnx`) doesn't parse C headers
 - Array indexing on C header structs broken (related to [Issue #8](https://github.com/jlaustill/c-next/issues/8))


### PR DESCRIPTION
## Summary

Update ADR-010 to accurately reflect current implementation status and resolve all open questions.

Closes #39 (documentation portion)
Related: #44, #45, #46

## Changes

### 1. Update ADR-010 Status (commit e8e8424)
- Changed status from "Implemented" → "Partial (In Progress)"
- Added "Implementation Status" section documenting:
  - ✅ What's completed (Phase 1, 2, 4, 5, infrastructure)
  - 🔶 What's in progress (Phase 3 - CodeGenerator doesn't use SymbolTable)
  - ❌ What's not started (remove --project flag, use unified parsing)
- Documented known issues with line numbers
- Added tracking link to Issue #39

### 2. Resolve All Open Questions (commit e8e8424, b3a9b7b, 7706530)

All 4 open questions now have documented decisions:

**1. Preprocessor strategy** ✅
- Decision: Use system cpp (gcc/clang/arm-gcc)
- Implementation: Already working via Preprocessor class

**2. Symbol conflicts** ✅
- Decision: Errors (with exceptions for extern declarations and C++ overloads)
- Implementation: Already in SymbolTable

**3. Build system integration** ✅
- Decision: Remove --project flag, always use unified parsing
- Behavior: Parse only headers referenced by #include directives
- Include path: Smart discovery from #include statements
- File extensions:
  - ✅ Parse: .h, .hpp, .hh, .hxx, .h++, .inl, .cnx
  - ❌ Error: .c, .cpp, .cc, .cxx, .c++ (implementation files)

**4. C++ priority** ✅
- Decision: Context-dependent, both C and C++ are first-class citizens
- Rationale: User needs drive priority, may contribute fixes upstream

### 3. Benefits

**Clarity for implementers:**
- Clear breakdown of what's done vs what needs work
- Specific line numbers for known issues
- Concrete acceptance criteria in linked issues

**IntelliSense improvement:**
- Only parsing #included headers means only in-scope symbols show in autocomplete
- Matches standard C behavior

**Error prevention:**
- Explicit error on #including .c/.cpp files catches common mistake

## Testing

No code changes - documentation only. Verified:
- [x] ADR structure is complete
- [x] All sections are clear and actionable
- [x] Implementation issues (#44, #45, #46) reference this ADR
- [x] Status accurately reflects reality

## Next Steps

After this PR merges, implementation work can begin on:
1. #44 - Remove --project flag, always parse headers
2. #45 - Fix CodeGenerator to use SymbolTable
3. #46 - Update docs and tests
