### PR TITLE
Fix publish workflow: generate parser files before tests

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -26,6 +26,9 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Generate parser files
+        run: npm run antlr:all
+
       - name: Run tests
         run: npm test
 


### PR DESCRIPTION
## Problem

The publish workflow failed when attempting to publish v0.1.0 because ANTLR parser files weren't being generated in CI.

## Solution

Added the missing "Generate parser files" step (`npm run antlr:all`) that the PR checks workflow already has.

## Changes

- Added parser generation step before running tests in `publish.yml`
- This matches the existing pattern in `pr-checks.yml` (line 37-40)

## Testing

After this is merged, we'll:
1. Re-create the v0.1.0 tag
2. Push it to trigger the workflow again
3. Verify publish succeeds

🤖 Generated with Claude Code