### PR TITLE
Bump version to 0.1.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "c-next",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "c-next",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "MIT",
       "dependencies": {
         "antlr4ng": "^3.0.16",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "c-next",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "A safer C for embedded systems development. Transpiles to clean, readable C.",
   "main": "src/index.ts",
   "bin": {


### PR DESCRIPTION
## Summary

Bumps package.json version from 0.1.0 to 0.1.1 for release.

## Changes

- `package.json`: version bumped to 0.1.1

## After Merge

The v0.1.1 tag will be pushed to trigger the npm publish workflow, which will now successfully create both:
- ✅ npm package publication
- ✅ GitHub release (with fixed permissions)

🤖 Generated with Claude Code