### PR TITLE
Docs: Improve setup documentation to prevent prettier errors in PRs

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,49 @@
+## Summary
+
+<!-- 1-3 sentences describing what this PR does -->
+
+## Changes
+
+- Added/Modified: <!-- File --> - <!-- What changed -->
+- Added: <!-- Test files --> - <!-- What they test -->
+- Updated: <!-- Docs --> - <!-- What was updated -->
+
+## Pre-Submit Checklist
+
+**Code Quality** (Auto-checked by pre-commit hooks if you ran `npm install`)
+
+- [ ] Code is properly formatted (`npm run prettier:fix` or rely on pre-commit hook)
+- [ ] No ESLint errors in modified files (`npm run eslint:check`)
+- [ ] TypeScript compiles without errors (`npm run typecheck`)
+- [ ] All tests pass (`npm test`)
+
+**Documentation**
+
+- [ ] README.md updated (if feature-visible)
+- [ ] ADR updated with implementation details (if applicable)
+- [ ] `learn-cnext-in-y-minutes.md` updated (if syntax changed)
+- [ ] Test README created in `tests/[feature]/README.md`
+
+**Git Hygiene**
+
+- [ ] Only related files included (no unrelated changes)
+- [ ] No debug code left in source
+- [ ] Commit messages are descriptive
+
+## Testing
+
+- [ ] All existing tests pass
+- [ ] New tests added: **N** tests in `tests/[feature]/`
+- [ ] `.expected.c` files created for passing tests
+
+## Related Issues
+
+<!-- Use keywords: Closes #NNN, Fixes #NNN, Related to ADR-NNN -->
+
+---
+
+**Note:** If CI fails with prettier/eslint errors:
+
+1. Run `npm run prettier:fix && npm run eslint:fix`
+2. Commit and push the fixes
+3. Ensure you ran `npm install` to set up pre-commit hooks for future commits

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,6 +37,18 @@ npm test
 
 ### Development Setup
 
+**IMPORTANT: Run `npm install` after cloning to install pre-commit hooks!**
+
+The project uses [Husky](https://typicode.github.io/husky/) to automatically format code before every commit. This prevents prettier/eslint errors from reaching PRs.
+
+**What happens when you run `npm install`:**
+
+- ✅ Pre-commit hooks are installed via Husky
+- ✅ Prettier automatically formats staged files before commit
+- ✅ ESLint automatically fixes staged TypeScript files before commit
+
+**You don't need to manually run `prettier:fix` before commits** - the hook does it for you!
+
 ```bash
 # Create your feature branch
 git checkout -b feature/your-feature-name
@@ -44,11 +56,13 @@ git checkout -b feature/your-feature-name
 # Make changes and test
 npm test
 
-# Check code quality
+# Optional: Manually check code quality (hooks do this automatically)
 npm run prettier:fix
 npm run eslint:check
 npm run typecheck
 ```
+
+**Bypassing hooks:** Don't use `git commit --no-verify` unless absolutely necessary - this skips formatting and will cause CI failures.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -736,19 +736,38 @@ Decisions are documented in `/docs/decisions/`:
 | [ADR-031](docs/decisions/adr-031-inline-functions.md)            | Inline Functions    | Trust compiler; `inline` is just a hint anyway                          |
 | [ADR-033](docs/decisions/adr-033-packed-structs.md)              | Packed Structs      | Use ADR-004 register bindings or explicit serialization                 |
 
-## Development Commands
+## Development
+
+### Setup
+
+```bash
+# Clone and install (IMPORTANT: npm install sets up pre-commit hooks)
+git clone https://github.com/jlaustill/c-next.git
+cd c-next
+npm install  # Installs dependencies and Husky pre-commit hooks
+```
+
+**Pre-commit hooks:** The project uses [Husky](https://typicode.github.io/husky/) to automatically format code (Prettier) and fix linting (ESLint) before every commit. This prevents formatting errors in PRs.
+
+### Commands
 
 ```bash
 npm run antlr      # Regenerate parser from grammar
 npm run typecheck  # Type-check TypeScript (no build required)
 npm test           # Run all tests
+
+# Code quality (auto-run by pre-commit hooks)
+npm run prettier:fix   # Format all code
+npm run eslint:check   # Check for lint errors
 ```
 
 **Note:** C-Next runs directly via `tsx` without a build step. The `typecheck` command validates types only and does not generate any output files.
 
 ## Contributing
 
-Ideas and feedback welcome via issues.
+See [CONTRIBUTING.md](CONTRIBUTING.md) for the complete development workflow, testing requirements, and PR process.
+
+**Quick start:** Ideas and feedback welcome via issues.
 
 ## License
 


### PR DESCRIPTION
## Summary

Improves documentation to prevent prettier/eslint errors from reaching PRs by making pre-commit hook setup more visible and providing multiple reminders throughout the contribution workflow.

## Problem

PRs were being created with prettier/eslint errors despite working pre-commit hooks. Root cause analysis revealed:
- CONTRIBUTING.md was in `docs/` directory (less visible to contributors)
- README.md didn't mention `npm install` sets up pre-commit hooks
- No PR template to remind contributors about formatting checks
- Contributors might skip `npm install` or use `--no-verify`

## Changes

### 1. Moved CONTRIBUTING.md to root directory
- **Before:** `docs/CONTRIBUTING.md` (GitHub detects but less visible)
- **After:** `CONTRIBUTING.md` (root location, maximum visibility)
- Enhanced Development Setup section with clear hook documentation
- Added warning about `git commit --no-verify`

### 2. Enhanced README.md Development section
- Added Setup subsection emphasizing `npm install` requirement
- Explained what pre-commit hooks do automatically
- Added link to CONTRIBUTING.md for full workflow
- Listed code quality commands with context about automatic hooks

### 3. Created PR template
- Added `.github/pull_request_template.md` with pre-submit checklist
- Includes formatting verification reminder
- Explains troubleshooting steps if CI fails
- Reminds contributors to run `npm install`

## Impact

Creates **4 layers of defense** against formatting errors:

1. **Layer 1 - Documentation**: README tells new contributors about hooks upfront
2. **Layer 2 - Automation**: Pre-commit hooks auto-format before commit
3. **Layer 3 - Reminder**: PR template includes formatting checklist
4. **Layer 4 - Enforcement**: CI blocks merge if checks fail

## Testing

- [x] All existing tests pass
- [x] Pre-commit hooks still work (ran on this commit)
- [x] Documentation is clear and actionable
- [x] Links are correct

## Documentation

- [x] Moved: `docs/CONTRIBUTING.md` → `CONTRIBUTING.md`
- [x] Updated: `README.md` Development section
- [x] Added: `.github/pull_request_template.md`

## Related Issues

Addresses the issue where PRs were consistently failing CI due to prettier/eslint errors.