### PR TITLE
Add --quiet flag to test runner for AI-friendly output

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,6 +29,11 @@
 2. Verify transpiled output compiles cleanly with `npm run analyze`
 3. Run tests before considering a task complete
 
+**Test Commands:**
+
+- `npm test` — Run all tests with full output
+- `npm test -- --quiet` or `-q` — Minimal output (errors + summary only, ideal for AI)
+
 ### Test File Patterns
 
 There are **two types of tests** in C-Next:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -194,6 +194,9 @@ See [Testing Workflow](./TESTING-WORKFLOW.md) for comprehensive testing methodol
 # Run all tests
 npm test
 
+# Run all tests with minimal output (errors + summary only)
+npm test -- --quiet    # or: npm test -- -q
+
 # Run specific test category
 npm test -- tests/postfix-chains/
 

--- a/README.md
+++ b/README.md
@@ -755,6 +755,7 @@ npm install  # Installs dependencies and Husky pre-commit hooks
 npm run antlr      # Regenerate parser from grammar
 npm run typecheck  # Type-check TypeScript (no build required)
 npm test           # Run all tests
+npm test -- --quiet   # Minimal output (errors + summary only)
 
 # Code quality (auto-run by pre-commit hooks)
 npm run prettier:fix   # Format all code


### PR DESCRIPTION
## Summary

Adds a `--quiet` / `-q` flag to the test runner that suppresses verbose output, making it ideal for AI assistants and automated workflows.

## Changes

- **scripts/test.js**: Added `--quiet` flag implementation
  - Suppresses header (test directory, validation tools)
  - Suppresses PASS/UPDATED lines
  - Shows only FAIL results with full error details
  - Single-line summary: `344/344 tests passed` or `X/Y tests passed, Z failed`
- **README.md**: Added to Commands section
- **CONTRIBUTING.md**: Added to Test Commands section
- **CLAUDE.md**: Added Test Commands section with note that quiet mode is ideal for AI

## Example Output

**Normal mode:**
```
C-Next Integration Tests
Test directory: /home/jlaustill/code/c-next3/tests
Validation: gcc → cppcheck → clang-tidy → MISRA

PASS    tests/arithmetic/division-non-zero-const.test.cnx
PASS    tests/arithmetic/division-by-zero-literal.test.cnx
... (340+ more lines)

Results:
  Passed:  344
```

**Quiet mode (`--quiet` or `-q`):**
```
344/344 tests passed
```

## Test plan

- [x] `npm test -- --quiet` shows only summary line
- [x] `npm test -- -q` shorthand works
- [x] Normal `npm test` output unchanged
- [x] FAIL results still show with full details in quiet mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)