### PR TITLE
Add single file support to test runner

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,6 +33,8 @@
 
 - `npm test` — Run all tests with full output
 - `npm test -- --quiet` or `-q` — Minimal output (errors + summary only, ideal for AI)
+- `npm test -- tests/enum` — Run specific directory
+- `npm test -- tests/enum/my.test.cnx` — Run single test file
 
 ### Test File Patterns
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -197,10 +197,13 @@ npm test
 # Run all tests with minimal output (errors + summary only)
 npm test -- --quiet    # or: npm test -- -q
 
-# Run specific test category
+# Run specific test directory
 npm test -- tests/postfix-chains/
 
-# Transpile single test file
+# Run single test file
+npm test -- tests/postfix-chains/basic-chaining.test.cnx
+
+# Transpile single test file (without running full test validation)
 cnext tests/my-feature/basic.test.cnx
 
 # Verify output matches expected

--- a/README.md
+++ b/README.md
@@ -754,8 +754,10 @@ npm install  # Installs dependencies and Husky pre-commit hooks
 ```bash
 npm run antlr      # Regenerate parser from grammar
 npm run typecheck  # Type-check TypeScript (no build required)
-npm test           # Run all tests
-npm test -- --quiet   # Minimal output (errors + summary only)
+npm test                              # Run all tests
+npm test -- --quiet                   # Minimal output (errors + summary only)
+npm test -- tests/enum                # Run specific directory
+npm test -- tests/enum/my.test.cnx    # Run single test file
 
 # Code quality (auto-run by pre-commit hooks)
 npm run prettier:fix   # Format all code


### PR DESCRIPTION
## Summary
- Add ability to run individual test files: `npm test -- tests/enum/my.test.cnx`
- Detect file vs directory input using `statSync()` and branch accordingly
- Validate that single file paths end with `.test.cnx`
- Update documentation (README.md, CLAUDE.md, CONTRIBUTING.md)

## Test plan
- [x] Single file runs correctly: `npm test -- tests/basics/hello-world.test.cnx`
- [x] Directory mode unchanged: `npm test -- tests/basics`
- [x] Invalid extension error: `npm test -- tests/basics/hello-world.expected.c`
- [x] Nonexistent file error: `npm test -- tests/nonexistent.test.cnx`
- [x] Flags work with single file: `npm test -- tests/basics/hello-world.test.cnx --quiet`

🤖 Generated with [Claude Code](https://claude.com/claude-code)