### PR TITLE
Fix GitHub Actions to use oxlint instead of eslint

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -29,9 +29,9 @@ jobs:
         run: npm run prettier:check
         continue-on-error: true
 
-      - name: Check linting (ESLint)
-        id: eslint
-        run: npm run eslint:check
+      - name: Check linting (oxlint)
+        id: oxlint
+        run: npm run oxlint:check
         continue-on-error: true
 
       - name: Generate parser files
@@ -68,10 +68,11 @@ jobs:
             echo "✅ Prettier formatting check passed"
           fi
 
-          if [ "${{ steps.eslint.outcome }}" != "success" ]; then
-            echo "⚠️  ESLint check failed (38 legacy errors - non-blocking)"
+          if [ "${{ steps.oxlint.outcome }}" != "success" ]; then
+            echo "❌ oxlint check failed"
+            FAILED=1
           else
-            echo "✅ ESLint check passed"
+            echo "✅ oxlint check passed"
           fi
 
           if [ "${{ steps.generate.outcome }}" != "success" ]; then

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -33,7 +33,7 @@ jobs:
         run: npm test
 
       - name: Run linter
-        run: npm run eslint:check
+        run: npm run oxlint:check
 
       - name: Publish to npm
         run: npm publish --provenance --access public


### PR DESCRIPTION
## Summary

- Update `publish.yml` to use `oxlint:check` instead of `eslint:check`
- Update `pr-checks.yml` to use `oxlint:check` instead of `eslint:check`
- Make linting failures blocking in PR checks (no more legacy errors with oxlint)

This fixes the npm publish workflow which was failing because it still referenced the old `eslint:check` command after the ESLint to oxlint migration in PR #87.

## Test plan

- [x] Verify workflow syntax is valid
- [ ] Merge and confirm publish workflow succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)