### PR TITLE
Bump version to 0.1.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "c-next",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "A safer C for embedded systems development. Transpiles to clean, readable C.",
   "main": "src/index.ts",
   "bin": {


### PR DESCRIPTION
## Summary

- Bump package.json version from 0.1.2 to 0.1.3

Required for the npm publish workflow to publish the correct version.

## Test plan

- [x] Version updated in package.json
- [ ] Merge and retag v0.1.3

🤖 Generated with [Claude Code](https://claude.com/claude-code)