### PR TITLE
Enable and improve skipped scope tests (closes #10)

### DIFF
--- a/tests/scope/global-all-types.expected.c
+++ b/tests/scope/global-all-types.expected.c
@@ -16,7 +16,7 @@ uint16_t globalU16 = 65535;
 
 uint32_t globalU32 = 4294967295;
 
-uint64_t globalU64 = 0;
+uint64_t globalU64 = 18446744073709551615;
 
 // Signed integer globals
 int8_t globalI8 = -128;
@@ -25,7 +25,7 @@ int16_t globalI16 = -32768;
 
 int32_t globalI32 = -2147483648;
 
-int64_t globalI64 = 0;
+int64_t globalI64 = -9223372036854775808;
 
 // Floating point globals
 float globalF32 = 3.14;
@@ -89,8 +89,12 @@ void GlobalAccessTest_setGlobalBool(bool* val) {
     globalBool = (*val);
 }
 
-void GlobalAccessTest_setGlobalF64(double* val) {
-    globalF64 = (*val);
+void GlobalAccessTest_setGlobalF32(float val) {
+    globalF32 = val;
+}
+
+void GlobalAccessTest_setGlobalF64(double val) {
+    globalF64 = val;
 }
 
 int32_t main(void) {
@@ -98,38 +102,48 @@ int32_t main(void) {
         return 1;
     }
     if (GlobalAccessTest_getGlobalU16() != 65535) {
-        return 1;
+        return 2;
     }
     if (GlobalAccessTest_getGlobalU32() != 4294967295) {
-        return 1;
+        return 3;
     }
-    if (GlobalAccessTest_getGlobalU64() != 0) {
-        return 1;
+    if (GlobalAccessTest_getGlobalU64() != 18446744073709551615) {
+        return 4;
     }
     if (GlobalAccessTest_getGlobalI8() != -128) {
-        return 1;
+        return 5;
     }
     if (GlobalAccessTest_getGlobalI16() != -32768) {
-        return 1;
+        return 6;
     }
     if (GlobalAccessTest_getGlobalI32() != -2147483648) {
-        return 1;
+        return 7;
     }
-    if (GlobalAccessTest_getGlobalI64() != 0) {
-        return 1;
+    if (GlobalAccessTest_getGlobalI64() != -9223372036854775808) {
+        return 8;
+    }
+    float testF32 = 99.5;
+    GlobalAccessTest_setGlobalF32(testF32);
+    if (GlobalAccessTest_getGlobalF32() != testF32) {
+        return 9;
+    }
+    double testF64 = 123.456789012345;
+    GlobalAccessTest_setGlobalF64(testF64);
+    if (GlobalAccessTest_getGlobalF64() != testF64) {
+        return 10;
     }
     if (GlobalAccessTest_getGlobalBool() != true) {
-        return 1;
+        return 11;
     }
     uint8_t newU8Value = 100;
     GlobalAccessTest_setGlobalU8(&newU8Value);
     if (GlobalAccessTest_getGlobalU8() != 100) {
-        return 1;
+        return 12;
     }
     bool newBoolValue = false;
     GlobalAccessTest_setGlobalBool(&newBoolValue);
     if (GlobalAccessTest_getGlobalBool() != false) {
-        return 1;
+        return 13;
     }
     return 0;
 }

--- a/tests/scope/global-all-types.test.cnx
+++ b/tests/scope/global-all-types.test.cnx
@@ -6,13 +6,13 @@
 u8 globalU8 <- 255;
 u16 globalU16 <- 65535;
 u32 globalU32 <- 4294967295;
-u64 globalU64 <- 0;
+u64 globalU64 <- 18446744073709551615;
 
 // Signed integer globals
 i8 globalI8 <- -128;
 i16 globalI16 <- -32768;
 i32 globalI32 <- -2147483648;
-i64 globalI64 <- 0;
+i64 globalI64 <- -9223372036854775808;
 
 // Floating point globals
 f32 globalF32 <- 3.14;
@@ -79,6 +79,10 @@ scope GlobalAccessTest {
         global.globalBool <- val;
     }
 
+    public void setGlobalF32(f32 val) {
+        global.globalF32 <- val;
+    }
+
     public void setGlobalF64(f64 val) {
         global.globalF64 <- val;
     }
@@ -86,53 +90,68 @@ scope GlobalAccessTest {
 
 i32 main() {
     // Test all getter methods using global. accessor - verify returned values
+    // Each validation uses a unique error code for debugging
 
     // Unsigned integers
     if (GlobalAccessTest.getGlobalU8() != 255) {
         return 1;
     }
     if (GlobalAccessTest.getGlobalU16() != 65535) {
-        return 1;
+        return 2;
     }
     if (GlobalAccessTest.getGlobalU32() != 4294967295) {
-        return 1;
+        return 3;
     }
-    if (GlobalAccessTest.getGlobalU64() != 0) {
-        return 1;
+    if (GlobalAccessTest.getGlobalU64() != 18446744073709551615) {
+        return 4;
     }
 
     // Signed integers
     if (GlobalAccessTest.getGlobalI8() != -128) {
-        return 1;
+        return 5;
     }
     if (GlobalAccessTest.getGlobalI16() != -32768) {
-        return 1;
+        return 6;
     }
     if (GlobalAccessTest.getGlobalI32() != -2147483648) {
-        return 1;
+        return 7;
     }
-    if (GlobalAccessTest.getGlobalI64() != 0) {
-        return 1;
+    if (GlobalAccessTest.getGlobalI64() != -9223372036854775808) {
+        return 8;
+    }
+
+    // Floating point - test via setter/getter roundtrip to avoid literal comparison issues
+    // Direct comparison of float to double literals has precision issues (see Issue #26)
+    f32 testF32 <- 99.5;
+    GlobalAccessTest.setGlobalF32(testF32);
+    if (GlobalAccessTest.getGlobalF32() != testF32) {
+        return 9;
+    }
+
+    f64 testF64 <- 123.456789012345;
+    GlobalAccessTest.setGlobalF64(testF64);
+    if (GlobalAccessTest.getGlobalF64() != testF64) {
+        return 10;
     }
 
     // Boolean
     if (GlobalAccessTest.getGlobalBool() != true) {
-        return 1;
+        return 11;
     }
 
     // Test setters - modify and verify
     u8 newU8Value <- 100;
     GlobalAccessTest.setGlobalU8(newU8Value);
     if (GlobalAccessTest.getGlobalU8() != 100) {
-        return 1;
+        return 12;
     }
 
     bool newBoolValue <- false;
     GlobalAccessTest.setGlobalBool(newBoolValue);
     if (GlobalAccessTest.getGlobalBool() != false) {
-        return 1;
+        return 13;
     }
 
-    // All tests passed
+    // All tests passed (13 validations total)
     return 0;
 }

--- a/tests/scope/this-all-types.expected.c
+++ b/tests/scope/this-all-types.expected.c
@@ -13,11 +13,11 @@
 uint8_t AllTypesTest_valU8 = 255;
 uint16_t AllTypesTest_valU16 = 65535;
 uint32_t AllTypesTest_valU32 = 4294967295;
-uint64_t AllTypesTest_valU64 = 0;
+uint64_t AllTypesTest_valU64 = 18446744073709551615;
 int8_t AllTypesTest_valI8 = -128;
 int16_t AllTypesTest_valI16 = -32768;
 int32_t AllTypesTest_valI32 = -2147483648;
-int64_t AllTypesTest_valI64 = 0;
+int64_t AllTypesTest_valI64 = -9223372036854775808;
 float AllTypesTest_valF32 = 3.14;
 double AllTypesTest_valF64 = 3.141592653589793;
 bool AllTypesTest_valBool = true;
@@ -74,8 +74,12 @@ void AllTypesTest_setBool(bool* val) {
     AllTypesTest_valBool = (*val);
 }
 
-void AllTypesTest_setF64(double* val) {
-    AllTypesTest_valF64 = (*val);
+void AllTypesTest_setF32(float val) {
+    AllTypesTest_valF32 = val;
+}
+
+void AllTypesTest_setF64(double val) {
+    AllTypesTest_valF64 = val;
 }
 
 int32_t main(void) {
@@ -83,38 +87,48 @@ int32_t main(void) {
         return 1;
     }
     if (AllTypesTest_getU16() != 65535) {
-        return 1;
+        return 2;
     }
     if (AllTypesTest_getU32() != 4294967295) {
-        return 1;
+        return 3;
     }
-    if (AllTypesTest_getU64() != 0) {
-        return 1;
+    if (AllTypesTest_getU64() != 18446744073709551615) {
+        return 4;
     }
     if (AllTypesTest_getI8() != -128) {
-        return 1;
+        return 5;
     }
     if (AllTypesTest_getI16() != -32768) {
-        return 1;
+        return 6;
     }
     if (AllTypesTest_getI32() != -2147483648) {
-        return 1;
+        return 7;
     }
-    if (AllTypesTest_getI64() != 0) {
-        return 1;
+    if (AllTypesTest_getI64() != -9223372036854775808) {
+        return 8;
+    }
+    float testF32 = 99.5;
+    AllTypesTest_setF32(testF32);
+    if (AllTypesTest_getF32() != testF32) {
+        return 9;
+    }
+    double testF64 = 123.456789012345;
+    AllTypesTest_setF64(testF64);
+    if (AllTypesTest_getF64() != testF64) {
+        return 10;
     }
     if (AllTypesTest_getBool() != true) {
-        return 1;
+        return 11;
     }
     uint8_t newU8Value = 100;
     AllTypesTest_setU8(&newU8Value);
     if (AllTypesTest_getU8() != 100) {
-        return 1;
+        return 12;
     }
     bool newBoolValue = false;
     AllTypesTest_setBool(&newBoolValue);
     if (AllTypesTest_getBool() != false) {
-        return 1;
+        return 13;
     }
     return 0;
 }

--- a/tests/scope/this-all-types.test.cnx
+++ b/tests/scope/this-all-types.test.cnx
@@ -7,13 +7,13 @@ scope AllTypesTest {
     u8 valU8 <- 255;
     u16 valU16 <- 65535;
     u32 valU32 <- 4294967295;
-    u64 valU64 <- 0;
+    u64 valU64 <- 18446744073709551615;
 
     // Signed integers
     i8 valI8 <- -128;
     i16 valI16 <- -32768;
     i32 valI32 <- -2147483648;
-    i64 valI64 <- 0;
+    i64 valI64 <- -9223372036854775808;
 
     // Floating point
     f32 valF32 <- 3.14;
@@ -79,6 +79,10 @@ scope AllTypesTest {
         this.valBool <- val;
     }
 
+    public void setF32(f32 val) {
+        this.valF32 <- val;
+    }
+
     public void setF64(f64 val) {
         this.valF64 <- val;
     }
@@ -86,53 +90,68 @@ scope AllTypesTest {
 
 i32 main() {
     // Test all getter methods using this. accessor - verify returned values
+    // Each validation uses a unique error code for debugging
 
     // Unsigned integers
     if (AllTypesTest.getU8() != 255) {
         return 1;
     }
     if (AllTypesTest.getU16() != 65535) {
-        return 1;
+        return 2;
     }
     if (AllTypesTest.getU32() != 4294967295) {
-        return 1;
+        return 3;
     }
-    if (AllTypesTest.getU64() != 0) {
-        return 1;
+    if (AllTypesTest.getU64() != 18446744073709551615) {
+        return 4;
     }
 
     // Signed integers
     if (AllTypesTest.getI8() != -128) {
-        return 1;
+        return 5;
     }
     if (AllTypesTest.getI16() != -32768) {
-        return 1;
+        return 6;
     }
     if (AllTypesTest.getI32() != -2147483648) {
-        return 1;
+        return 7;
     }
-    if (AllTypesTest.getI64() != 0) {
-        return 1;
+    if (AllTypesTest.getI64() != -9223372036854775808) {
+        return 8;
+    }
+
+    // Floating point - test via setter/getter roundtrip to avoid literal comparison issues
+    // Direct comparison of float to double literals has precision issues (see Issue #26)
+    f32 testF32 <- 99.5;
+    AllTypesTest.setF32(testF32);
+    if (AllTypesTest.getF32() != testF32) {
+        return 9;
+    }
+
+    f64 testF64 <- 123.456789012345;
+    AllTypesTest.setF64(testF64);
+    if (AllTypesTest.getF64() != testF64) {
+        return 10;
     }
 
     // Boolean
     if (AllTypesTest.getBool() != true) {
-        return 1;
+        return 11;
     }
 
     // Test setters - modify and verify
     u8 newU8Value <- 100;
     AllTypesTest.setU8(newU8Value);
     if (AllTypesTest.getU8() != 100) {
-        return 1;
+        return 12;
     }
 
     bool newBoolValue <- false;
     AllTypesTest.setBool(newBoolValue);
     if (AllTypesTest.getBool() != false) {
-        return 1;
+        return 13;
     }
 
-    // All tests passed
+    // All tests passed (13 validations total)
     return 0;
 }


### PR DESCRIPTION
## Summary
- Re-enables `global-all-types` and `this-all-types` scope tests that were previously skipped
- Improves test quality with unique error codes, boundary values, and proper float validation
- Closes #10

## Changes
- **Unique error codes**: Each validation now returns a distinct code (1-13) for easier debugging
- **Boundary values**: u64/i64 now test with max/min values instead of 0
- **Float validation**: Tests f32/f64 via setter/getter roundtrip to avoid literal comparison precision issues (see Issue #26)
- **Added methods**: `setGlobalF32`/`setF32` for complete float coverage

## Test plan
- [x] Both tests pass compilation (gcc, cppcheck, clang-tidy, MISRA)
- [x] Both tests pass execution with 13 validated assertions each
- [x] Full test suite passes (423/423)

🤖 Generated with [Claude Code](https://claude.com/claude-code)