### PR TITLE
Accept ADR-052: Safe Numeric Literal Generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -661,50 +661,50 @@ Decisions are documented in `/docs/decisions/`:
 
 ### Implemented
 
-| ADR                                                          | Title                   | Description                                                  |
-| ------------------------------------------------------------ | ----------------------- | ------------------------------------------------------------ |
-| [ADR-001](docs/decisions/adr-001-assignment-operator.md)     | Assignment Operator     | `<-` for assignment, `=` for comparison                      |
-| [ADR-003](docs/decisions/adr-003-static-allocation.md)       | Static Allocation       | No dynamic memory after init                                 |
-| [ADR-004](docs/decisions/adr-004-register-bindings.md)       | Register Bindings       | Type-safe hardware access                                    |
-| [ADR-006](docs/decisions/adr-006-simplified-references.md)   | Simplified References   | Pass by reference, no pointer syntax                         |
-| [ADR-007](docs/decisions/adr-007-type-aware-bit-indexing.md) | Type-Aware Bit Indexing | Integers as bit arrays, `.length` property                   |
-| [ADR-010](docs/decisions/adr-010-c-interoperability.md)      | C Interoperability      | Unified ANTLR parser architecture                            |
-| [ADR-011](docs/decisions/adr-011-vscode-extension.md)        | VS Code Extension       | Live C preview with syntax highlighting                      |
-| [ADR-012](docs/decisions/adr-012-static-analysis.md)         | Static Analysis         | cppcheck integration for generated C                         |
-| [ADR-013](docs/decisions/adr-013-const-qualifier.md)         | Const Qualifier         | Compile-time const enforcement                               |
-| [ADR-014](docs/decisions/adr-014-structs.md)                 | Structs                 | Data containers without methods                              |
-| [ADR-015](docs/decisions/adr-015-null-state.md)              | Null State              | Zero initialization for all variables                        |
-| [ADR-016](docs/decisions/adr-016-scope.md)                   | Scope                   | `this.`/`global.` explicit qualification                     |
-| [ADR-017](docs/decisions/adr-017-enums.md)                   | Enums                   | Type-safe enums with C-style casting                         |
-| [ADR-030](docs/decisions/adr-030-forward-declarations.md)    | Define-Before-Use       | Functions must be defined before called                      |
-| [ADR-037](docs/decisions/adr-037-preprocessor.md)            | Preprocessor            | Flag-only defines, const for values                          |
-| [ADR-043](docs/decisions/adr-043-comments.md)                | Comments                | Comment preservation with MISRA compliance                   |
-| [ADR-044](docs/decisions/adr-044-primitive-types.md)         | Primitive Types         | Fixed-width types with `clamp`/`wrap` overflow               |
-| [ADR-024](docs/decisions/adr-024-type-casting.md)            | Type Casting            | Widening implicit, narrowing uses bit indexing               |
-| [ADR-022](docs/decisions/adr-022-conditional-expressions.md) | Conditional Expressions | Ternary with required parens, boolean condition, no nesting  |
-| [ADR-025](docs/decisions/adr-025-switch-statements.md)       | Switch Statements       | Safe switch with braces, `\|\|` syntax, counted `default(n)` |
-| [ADR-029](docs/decisions/adr-029-function-pointers.md)       | Callbacks               | Function-as-Type pattern with nominal typing                 |
-| [ADR-045](docs/decisions/adr-045-string-type.md)             | Bounded Strings         | `string<N>` with compile-time safety                         |
-| [ADR-023](docs/decisions/adr-023-sizeof.md)                  | Sizeof                  | Type/value size queries with safety checks                   |
-| [ADR-027](docs/decisions/adr-027-do-while.md)                | Do-While                | `do { } while ()` with boolean condition (E0701)             |
-| [ADR-032](docs/decisions/adr-032-nested-structs.md)          | Nested Structs          | Named nested structs only (no anonymous)                     |
-| [ADR-035](docs/decisions/adr-035-array-initializers.md)      | Array Initializers      | `[1, 2, 3]` syntax with `[0*]` fill-all                      |
-| [ADR-036](docs/decisions/adr-036-multidimensional-arrays.md) | Multi-dim Arrays        | `arr[i][j]` with compile-time bounds enforcement             |
-| [ADR-040](docs/decisions/adr-040-isr-declaration.md)         | ISR Type                | Built-in `ISR` type for `void(void)` function pointers       |
-| [ADR-034](docs/decisions/adr-034-bit-fields.md)              | Bitmap Types            | `bitmap8`/`bitmap16`/`bitmap32` for portable bit-packed data |
-| [ADR-048](docs/decisions/adr-048-cli-executable.md)          | CLI Executable          | `cnext` command with smart defaults                          |
-| [ADR-049](docs/decisions/adr-049-atomic-types.md)            | Atomic Types            | `atomic` keyword with LDREX/STREX or PRIMASK fallback        |
-| [ADR-050](docs/decisions/adr-050-critical-sections.md)       | Critical Sections       | `critical { }` blocks with PRIMASK save/restore              |
-| [ADR-108](docs/decisions/adr-108-volatile-keyword.md)        | Volatile Variables      | `volatile` keyword prevents compiler optimization            |
-| [ADR-047](docs/decisions/adr-047-nullable-types.md)          | NULL for C Interop      | `NULL` keyword for C stream function comparisons             |
+| ADR                                                                  | Title                   | Description                                                  |
+| -------------------------------------------------------------------- | ----------------------- | ------------------------------------------------------------ |
+| [ADR-001](docs/decisions/adr-001-assignment-operator.md)             | Assignment Operator     | `<-` for assignment, `=` for comparison                      |
+| [ADR-003](docs/decisions/adr-003-static-allocation.md)               | Static Allocation       | No dynamic memory after init                                 |
+| [ADR-004](docs/decisions/adr-004-register-bindings.md)               | Register Bindings       | Type-safe hardware access                                    |
+| [ADR-006](docs/decisions/adr-006-simplified-references.md)           | Simplified References   | Pass by reference, no pointer syntax                         |
+| [ADR-007](docs/decisions/adr-007-type-aware-bit-indexing.md)         | Type-Aware Bit Indexing | Integers as bit arrays, `.length` property                   |
+| [ADR-010](docs/decisions/adr-010-c-interoperability.md)              | C Interoperability      | Unified ANTLR parser architecture                            |
+| [ADR-011](docs/decisions/adr-011-vscode-extension.md)                | VS Code Extension       | Live C preview with syntax highlighting                      |
+| [ADR-012](docs/decisions/adr-012-static-analysis.md)                 | Static Analysis         | cppcheck integration for generated C                         |
+| [ADR-013](docs/decisions/adr-013-const-qualifier.md)                 | Const Qualifier         | Compile-time const enforcement                               |
+| [ADR-014](docs/decisions/adr-014-structs.md)                         | Structs                 | Data containers without methods                              |
+| [ADR-015](docs/decisions/adr-015-null-state.md)                      | Null State              | Zero initialization for all variables                        |
+| [ADR-016](docs/decisions/adr-016-scope.md)                           | Scope                   | `this.`/`global.` explicit qualification                     |
+| [ADR-017](docs/decisions/adr-017-enums.md)                           | Enums                   | Type-safe enums with C-style casting                         |
+| [ADR-030](docs/decisions/adr-030-forward-declarations.md)            | Define-Before-Use       | Functions must be defined before called                      |
+| [ADR-037](docs/decisions/adr-037-preprocessor.md)                    | Preprocessor            | Flag-only defines, const for values                          |
+| [ADR-043](docs/decisions/adr-043-comments.md)                        | Comments                | Comment preservation with MISRA compliance                   |
+| [ADR-044](docs/decisions/adr-044-primitive-types.md)                 | Primitive Types         | Fixed-width types with `clamp`/`wrap` overflow               |
+| [ADR-024](docs/decisions/adr-024-type-casting.md)                    | Type Casting            | Widening implicit, narrowing uses bit indexing               |
+| [ADR-022](docs/decisions/adr-022-conditional-expressions.md)         | Conditional Expressions | Ternary with required parens, boolean condition, no nesting  |
+| [ADR-025](docs/decisions/adr-025-switch-statements.md)               | Switch Statements       | Safe switch with braces, `\|\|` syntax, counted `default(n)` |
+| [ADR-029](docs/decisions/adr-029-function-pointers.md)               | Callbacks               | Function-as-Type pattern with nominal typing                 |
+| [ADR-045](docs/decisions/adr-045-string-type.md)                     | Bounded Strings         | `string<N>` with compile-time safety                         |
+| [ADR-023](docs/decisions/adr-023-sizeof.md)                          | Sizeof                  | Type/value size queries with safety checks                   |
+| [ADR-027](docs/decisions/adr-027-do-while.md)                        | Do-While                | `do { } while ()` with boolean condition (E0701)             |
+| [ADR-032](docs/decisions/adr-032-nested-structs.md)                  | Nested Structs          | Named nested structs only (no anonymous)                     |
+| [ADR-035](docs/decisions/adr-035-array-initializers.md)              | Array Initializers      | `[1, 2, 3]` syntax with `[0*]` fill-all                      |
+| [ADR-036](docs/decisions/adr-036-multidimensional-arrays.md)         | Multi-dim Arrays        | `arr[i][j]` with compile-time bounds enforcement             |
+| [ADR-040](docs/decisions/adr-040-isr-declaration.md)                 | ISR Type                | Built-in `ISR` type for `void(void)` function pointers       |
+| [ADR-034](docs/decisions/adr-034-bit-fields.md)                      | Bitmap Types            | `bitmap8`/`bitmap16`/`bitmap32` for portable bit-packed data |
+| [ADR-048](docs/decisions/adr-048-cli-executable.md)                  | CLI Executable          | `cnext` command with smart defaults                          |
+| [ADR-049](docs/decisions/adr-049-atomic-types.md)                    | Atomic Types            | `atomic` keyword with LDREX/STREX or PRIMASK fallback        |
+| [ADR-050](docs/decisions/adr-050-critical-sections.md)               | Critical Sections       | `critical { }` blocks with PRIMASK save/restore              |
+| [ADR-108](docs/decisions/adr-108-volatile-keyword.md)                | Volatile Variables      | `volatile` keyword prevents compiler optimization            |
+| [ADR-047](docs/decisions/adr-047-nullable-types.md)                  | NULL for C Interop      | `NULL` keyword for C stream function comparisons             |
+| [ADR-052](docs/decisions/adr-052-safe-numeric-literal-generation.md) | Safe Numeric Literals   | `type_MIN`/`type_MAX` constants + safe hex conversion        |
 
 ### Research (v1 Roadmap)
 
-| ADR                                                                  | Title                         | Description                                     |
-| -------------------------------------------------------------------- | ----------------------------- | ----------------------------------------------- |
-| [ADR-008](docs/decisions/adr-008-language-bug-prevention.md)         | Language-Level Bug Prevention | Top 15 embedded bugs and prevention             |
-| [ADR-009](docs/decisions/adr-009-isr-safety.md)                      | ISR Safety                    | Safe interrupts without `unsafe` blocks         |
-| [ADR-052](docs/decisions/adr-052-safe-numeric-literal-generation.md) | Safe Numeric Literals         | Portable C generation for hex/negative literals |
+| ADR                                                          | Title                         | Description                             |
+| ------------------------------------------------------------ | ----------------------------- | --------------------------------------- |
+| [ADR-008](docs/decisions/adr-008-language-bug-prevention.md) | Language-Level Bug Prevention | Top 15 embedded bugs and prevention     |
+| [ADR-009](docs/decisions/adr-009-isr-safety.md)              | ISR Safety                    | Safe interrupts without `unsafe` blocks |
 
 ### Research (v2 Roadmap)
 

--- a/docs/decisions/adr-052-safe-numeric-literal-generation.md
+++ b/docs/decisions/adr-052-safe-numeric-literal-generation.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-**Research**
+**Accepted**
 
 ## Related
 
@@ -88,6 +88,46 @@ This issue affects any context where numeric literals are generated:
 | Some 16-bit    | 2             | `0x8000` to `0xFFFF`         |
 | 64-bit (LP64)  | 4             | Same as 32-bit               |
 | 64-bit (ILP64) | 8             | Much larger values           |
+
+### The Decimal Edge Case
+
+Converting to decimal does **not** fully solve the problem. In C, there is no such thing as a negative integer literal — `-2147483648` is the unary minus operator applied to the positive literal `2147483648`.
+
+**The issue:** On 32-bit int systems, `2147483648` exceeds `INT_MAX` (2147483647), so the compiler promotes it to a wider type (`long int` or `long long int`). This means `-2147483648` may not have type `int` as expected.
+
+**Why decimal is still safer than hex:**
+
+The type sequence for **decimal** literals is: `int` → `long int` → `long long int` (no unsigned types)
+
+The type sequence for **hex** literals is: `int` → `unsigned int` → `long int` → `unsigned long int` → ...
+
+Since decimal never promotes to unsigned, the value remains correct even if the type is wider than expected. With hex, promotion to `unsigned int` causes the unary minus to wrap incorrectly.
+
+**The standard library solution:**
+
+This is why `<limits.h>` defines `INT_MIN` as:
+
+```c
+#define INT_MIN (-2147483647 - 1)  // NOT -2147483648
+```
+
+Both `2147483647` and `1` fit in `int`, so the expression has type `int` and value `-2147483648`.
+
+**Implication for C-Next:**
+
+For boundary values (type MIN values), the safest generated C is the `(-MAX - 1)` pattern:
+
+| C-Next Value                | Generated C                    |
+| --------------------------- | ------------------------------ |
+| `-0x80000000` (i32)         | `(-2147483647 - 1)`            |
+| `-0x8000000000000000` (i64) | `(-9223372036854775807LL - 1)` |
+| `-0x8000` (i16)             | `(-32767 - 1)`                 |
+| Other negative values       | `-decimal_value` (safe)        |
+
+**References:**
+
+- [INT_MIN - Hard to C](http://hardtoc.com/2009/07/16/int-min.html)
+- [Integer constant - cppreference.com](https://en.cppreference.com/w/c/language/integer_constant.html)
 
 ---
 
@@ -209,7 +249,7 @@ case -0x80000000 { }
 
 ```c
 int32_t val = (int32_t)(-0x80000000);
-case (int32_t)(-0x80000000): { break; }  // ❌ Invalid: case requires constant expression
+case (int32_t)(-0x80000000): { break; }
 ```
 
 **Pros:**
@@ -219,13 +259,17 @@ case (int32_t)(-0x80000000): { break; }  // ❌ Invalid: case requires constant 
 
 **Cons:**
 
-- **Invalid for case labels** - C requires integer constant expressions, casts may not qualify
+- **Does not fix the problem** - The cast is applied _after_ the unsigned interpretation has already occurred:
+  1. `0x80000000` is evaluated as `unsigned int` (2147483648)
+  2. Unary `-` is applied: `-(2147483648u)` wraps to `2147483648u`
+  3. Cast to `int32_t`: converts `2147483648u` → implementation-defined behavior
+- The damage happens before the cast can help
 - Verbose output
-- May generate warnings
+- May generate warnings on some compilers
 
-### Option D: Hybrid Approach
+### Option D: Convert Problematic Hex to Decimal
 
-**Approach:** Use decimal for problematic values, preserve hex for safe values.
+**Approach:** For non-boundary problematic hex values, convert to decimal.
 
 **Logic:**
 
@@ -235,56 +279,178 @@ case (int32_t)(-0x80000000): { break; }  // ❌ Invalid: case requires constant 
 **C-Next input:**
 
 ```cnx
-case -0x7F { }       // Safe: 127 fits in signed int
-case -0x80000000 { } // Unsafe: would be unsigned
+case -0x7F { }    // Safe: 127 fits in signed int
+case -0x1000 { }  // Unsafe hex, not a boundary value
 ```
 
 **Generated C:**
 
 ```c
-case -0x7F: { break; }      // Preserved
-case -2147483648: { break; } // Converted
+case -0x7F: { break; }   // Preserved (safe)
+case -4096: { break; }   // Converted to decimal (safe)
 ```
 
 **Pros:**
 
 - Preserves formatting when safe
 - Correct semantics always
-- Best of both worlds
+- Simple implementation for non-boundary values
 
 **Cons:**
 
-- More complex implementation
-- Threshold depends on target type
+- Loses hex formatting for problematic values
+- Silent transformation (user may not realize)
+
+### Option E: Require Explicit MIN/MAX Constants
+
+**Approach:** For boundary values (TYPE_MIN and TYPE_MAX), emit a compiler error requiring explicit named constants.
+
+**C-Next input:**
+
+```cnx
+case -0x80000000 { }  // ❌ Error
+case i32_MIN { }      // ✅ Valid
+case 0x7FFFFFFF { }   // ❌ Error (when used as i32)
+case i32_MAX { }      // ✅ Valid
+```
+
+**Compiler errors:**
+
+```
+error: Literal -0x80000000 equals i32 minimum value.
+       Use 'i32_MIN' for portable, unambiguous code.
+
+error: Literal 0x7FFFFFFF equals i32 maximum value.
+       Use 'i32_MAX' for portable, unambiguous code.
+```
+
+**Generated C (for valid code):**
+
+```c
+#include <stdint.h>
+case INT32_MIN: { break; }
+case INT32_MAX: { break; }
+```
+
+**Constant mapping:**
+
+| C-Next Constant | C Output (`<stdint.h>`) |
+| --------------- | ----------------------- |
+| `i8_MIN`        | `INT8_MIN`              |
+| `i8_MAX`        | `INT8_MAX`              |
+| `i16_MIN`       | `INT16_MIN`             |
+| `i16_MAX`       | `INT16_MAX`             |
+| `i32_MIN`       | `INT32_MIN`             |
+| `i32_MAX`       | `INT32_MAX`             |
+| `i64_MIN`       | `INT64_MIN`             |
+| `i64_MAX`       | `INT64_MAX`             |
+| `u8_MAX`        | `UINT8_MAX`             |
+| `u16_MAX`       | `UINT16_MAX`            |
+| `u32_MAX`       | `UINT32_MAX`            |
+| `u64_MAX`       | `UINT64_MAX`            |
+
+**Pros:**
+
+- Educational: teaches users about the boundary trap
+- Forces explicit intent: if you mean MIN, say MIN
+- Portable by default: `<stdint.h>` handles all platforms
+- More readable code: `i32_MIN` clearer than `-2147483648`
+- No silent transformations for critical values
+
+**Cons:**
+
+- Breaking change if existing code uses literal boundary values
+- Requires new language constants
 
 ---
 
 ## Recommendation
 
-**Option D (Hybrid)** provides the best balance:
+**Combined approach: Option E (boundaries) + Option D (other values)**
 
-1. **Correctness first:** Always generates semantically correct C
-2. **Readability preserved:** Keeps hex formatting when it's safe
-3. **No platform variance:** Decimal literals are unambiguous
-4. **No suffix complexity:** Avoids `L` vs `LL` platform differences
+This provides two layers of safety:
+
+| Scenario                       | Behavior                                         |
+| ------------------------------ | ------------------------------------------------ |
+| Literal equals `TYPE_MIN`      | **Compiler error** — require `type_MIN` constant |
+| Literal equals `TYPE_MAX`      | **Compiler error** — require `type_MAX` constant |
+| Problematic hex (not boundary) | **Silent conversion** to decimal                 |
+| Safe hex values                | **Preserved** as-is                              |
+
+**Rationale:**
+
+1. **Boundary values are special** — they're the most dangerous edge cases and deserve explicit handling
+2. **Educational errors** — help users understand the C type system pitfalls
+3. **Non-boundary values** — silently fix without burdening the user
+4. **Portable output** — uses `<stdint.h>` constants that work everywhere
 
 ### Implementation Sketch
 
 ```typescript
+// Boundary values for each signed type
+const SIGNED_BOUNDS: Record<string, { min: bigint; max: bigint }> = {
+  i8: { min: -128n, max: 127n },
+  i16: { min: -32768n, max: 32767n },
+  i32: { min: -2147483648n, max: 2147483647n },
+  i64: { min: -9223372036854775808n, max: 9223372036854775807n },
+};
+
+// Boundary values for unsigned types (only MAX, MIN is always 0)
+const UNSIGNED_BOUNDS: Record<string, { max: bigint }> = {
+  u8: { max: 255n },
+  u16: { max: 65535n },
+  u32: { max: 4294967295n },
+  u64: { max: 18446744073709551615n },
+};
+
+function checkBoundaryLiteral(
+  value: bigint,
+  targetType: CNextType,
+  location: SourceLocation,
+): void {
+  const signed = SIGNED_BOUNDS[targetType];
+  if (signed) {
+    if (value === signed.min) {
+      throw new CompilerError(
+        `Literal ${value} equals ${targetType} minimum value. ` +
+          `Use '${targetType}_MIN' for portable, unambiguous code.`,
+        location,
+      );
+    }
+    if (value === signed.max) {
+      throw new CompilerError(
+        `Literal ${value} equals ${targetType} maximum value. ` +
+          `Use '${targetType}_MAX' for portable, unambiguous code.`,
+        location,
+      );
+    }
+  }
+
+  const unsigned = UNSIGNED_BOUNDS[targetType];
+  if (unsigned && value === unsigned.max) {
+    throw new CompilerError(
+      `Literal ${value} equals ${targetType} maximum value. ` +
+        `Use '${targetType}_MAX' for portable, unambiguous code.`,
+      location,
+    );
+  }
+}
+
 function generateNumericLiteral(
   value: bigint,
   isHex: boolean,
   targetType: CNextType,
 ): string {
-  const isNegative = value < 0n;
-  const absValue = isNegative ? -value : value;
+  // Boundary values should have been caught earlier — this handles non-boundary
 
   // Determine if hex would be misinterpreted
   const signedMax = getSignedMaxForType(targetType);
+  const isNegative = value < 0n;
+  const absValue = isNegative ? -value : value;
   const wouldBeUnsigned = isHex && absValue > signedMax;
 
   if (isNegative && wouldBeUnsigned) {
-    // Convert to decimal to avoid unsigned interpretation
+    // Convert to decimal (safe for non-boundary values)
     return value.toString();
   }
 
@@ -318,14 +484,39 @@ All numeric literals generate correct, portable C code regardless of:
 
 ## Decision
 
-**TBD** - Awaiting review and acceptance.
+**Combined approach: Option E + Option D**
+
+1. **Option E (Boundary values):** Emit compiler errors when literals equal TYPE_MIN or TYPE_MAX, requiring explicit named constants (`i32_MIN`, `u64_MAX`, etc.) that map to `<stdint.h>`.
+
+2. **Option D (Other problematic values):** Silently convert non-boundary problematic hex literals to decimal in generated C code.
+
+This provides educational safety for the most dangerous edge cases while automatically handling other problematic values without burdening the user.
 
 ## Acceptance Criteria
 
-- [ ] Negative hex literals generate correct C code
-- [ ] Add test for `-0x80000000` specifically
-- [ ] Add test for `-0x8000` (16-bit boundary)
+### Option E: MIN/MAX Constants
+
+- [ ] Add `type_MIN` and `type_MAX` constants to the language (i8, i16, i32, i64, u8, u16, u32, u64)
+- [ ] Map constants to `<stdint.h>` values (INT8_MIN, INT32_MAX, UINT64_MAX, etc.)
+- [ ] Emit compiler error when literal equals a boundary value
+- [ ] Error message suggests the appropriate constant to use
+- [ ] Test: `i32_MIN` in switch case generates `INT32_MIN`
+- [ ] Test: `-0x80000000` as i32 emits educational error
+- [ ] Test: `0x7FFFFFFF` as i32 emits educational error
+- [ ] Test: `0xFF` as u8 emits educational error (u8_MAX)
+
+### Option D: Problematic Hex Conversion
+
+- [ ] Detect hex literals that would be interpreted as unsigned in C
+- [ ] Convert problematic hex to decimal in generated C
+- [ ] Preserve safe hex literals as-is
+- [ ] Test: `-0x1000` converts to `-4096`
+- [ ] Test: `-0x7F` preserved as `-0x7F`
+- [ ] Test: `-0xC0000000` converts to decimal
+
+### General
+
 - [ ] Verify generated C compiles without warnings
 - [ ] Verify runtime behavior matches C-Next semantics
-- [ ] Document approach in this ADR
+- [ ] Update documentation (learn-cnext-in-y-minutes.md) with MIN/MAX constants
 - [ ] Update #111 with implementation details


### PR DESCRIPTION
## Summary

- Accept ADR-052 with combined approach (Option E + Option D)
- Move ADR-052 from Research to Accepted in README
- Update ADR with research findings and implementation details

## Decision

**Option E (Boundary values):**
- Compiler errors when literals equal `TYPE_MIN` or `TYPE_MAX`
- Require explicit named constants (`i32_MIN`, `u64_MAX`, etc.)
- Map to `<stdint.h>` for portability

**Option D (Other problematic values):**
- Silently convert non-boundary problematic hex to decimal
- Preserves safe hex values as-is

## Example Behavior

```cnx
case -0x80000000 { }  // ❌ Error: Use 'i32_MIN' instead
case i32_MIN { }      // ✅ Generates: case INT32_MIN:
case -0xC0000000 { }  // ✅ Generates: case -3221225472:
case -0x7F { }        // ✅ Preserved: case -0x7F:
```

## Key Research Findings

1. **Fixed Option C analysis:** Casts don't help because unsigned interpretation happens *before* the cast is applied
2. **Documented decimal edge case:** `-2147483648` also has type promotion issues; standard libraries use `(-MAX - 1)` pattern

## Closes

- Closes #111

🤖 Generated with [Claude Code](https://claude.com/claude-code)