### PR TITLE
Fix release script to regenerate parser after pull

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -70,6 +70,11 @@ echo ""
 echo -e "${YELLOW}Pulling latest changes from origin/main...${NC}"
 git pull origin main
 
+# Regenerate parser (in case grammar changed)
+echo ""
+echo -e "${YELLOW}Regenerating parser from grammar...${NC}"
+npm run antlr:all
+
 # Run tests
 echo ""
 echo -e "${YELLOW}Running tests...${NC}"


### PR DESCRIPTION
## Summary

Fixes the release script failing when the grammar has been updated but the local parser files are stale.

## Problem

Parser files (`src/parser/`) are gitignored and regenerated from grammar. When pulling changes that modify `grammar/CNext.g4`, the local parser files become stale, causing test failures.

This happened when trying to run `./scripts/release.sh 0.1.4` - the negative switch case tests failed because the grammar had been updated to support negative literals, but the local parser hadn't been regenerated.

## Solution

Added `npm run antlr:all` step after `git pull` to ensure the parser is always in sync with the grammar before running tests.

## Test plan

- [x] Release script updated
- [ ] Run release script after merge to verify fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)