### PR TITLE
Add coverage tracking tool for test coverage visibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,11 @@
     "oxlint:check": "oxlint src/",
     "oxlint:fix": "oxlint src/ --fix",
     "prepare": "husky",
-    "prepublishOnly": "npm run prettier:check && npm run oxlint:check && npm test"
+    "prepublishOnly": "npm run prettier:check && npm run oxlint:check && npm test",
+    "coverage:check": "tsx scripts/coverage-checker.ts check",
+    "coverage:report": "tsx scripts/coverage-checker.ts report",
+    "coverage:gaps": "tsx scripts/coverage-checker.ts gaps",
+    "coverage:ids": "tsx scripts/coverage-checker.ts ids"
   },
   "keywords": [
     "c",

--- a/scripts/coverage-checker.ts
+++ b/scripts/coverage-checker.ts
@@ -1,0 +1,136 @@
+#!/usr/bin/env tsx
+/**
+ * C-Next Coverage Tracking Tool
+ *
+ * Maps coverage.md checkboxes to test file annotations,
+ * providing visibility into test coverage status.
+ *
+ * Usage:
+ *   npm run coverage:check   - Show coverage report (default)
+ *   npm run coverage:report  - Generate markdown report
+ *   npm run coverage:gaps    - Show only untested items
+ *   npm run coverage:ids     - List all coverage IDs
+ */
+
+import { join, dirname } from "path";
+import { fileURLToPath } from "url";
+import { existsSync } from "fs";
+
+import coverageParser from "./coverage-parser";
+import scanTestFiles from "./test-scanner";
+import reportGenerator from "./report-generator";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const rootDir = join(__dirname, "..");
+
+// ANSI colors
+const colors = {
+  reset: "\x1b[0m",
+  red: "\x1b[31m",
+  green: "\x1b[32m",
+  yellow: "\x1b[33m",
+};
+
+function printUsage(): void {
+  console.log(`
+Usage: tsx scripts/coverage-checker.ts <mode>
+
+Modes:
+  check   - Display coverage report (default)
+  report  - Generate COVERAGE-STATUS.md file
+  gaps    - Show only untested items
+  ids     - List all coverage IDs for annotation
+
+Options:
+  --help  - Show this help message
+`);
+}
+
+async function main(): Promise<void> {
+  const args = process.argv.slice(2);
+  const mode = args[0] || "check";
+
+  if (args.includes("--help") || args.includes("-h")) {
+    printUsage();
+    process.exit(0);
+  }
+
+  const coveragePath = join(rootDir, "coverage.md");
+  const testsDir = join(rootDir, "tests");
+  const reportPath = join(rootDir, "COVERAGE-STATUS.md");
+
+  // Verify paths exist
+  if (!existsSync(coveragePath)) {
+    console.error(
+      `${colors.red}Error: coverage.md not found at ${coveragePath}${colors.reset}`,
+    );
+    process.exit(1);
+  }
+
+  if (!existsSync(testsDir)) {
+    console.error(
+      `${colors.red}Error: tests/ directory not found at ${testsDir}${colors.reset}`,
+    );
+    process.exit(1);
+  }
+
+  // Parse coverage.md
+  console.log(`${colors.yellow}Parsing coverage.md...${colors.reset}`);
+  const coverageItems = coverageParser.parseCoverageDocument(coveragePath);
+  console.log(`  Found ${coverageItems.length} coverage items`);
+
+  // Check for duplicate IDs
+  const duplicates = coverageParser.checkForDuplicates(coverageItems);
+  if (duplicates.size > 0) {
+    console.log(
+      `${colors.yellow}Warning: ${duplicates.size} duplicate IDs found:${colors.reset}`,
+    );
+    for (const [id, lines] of duplicates) {
+      console.log(`  - "${id}" at lines ${lines.join(", ")}`);
+    }
+  }
+
+  // Scan test files for annotations
+  console.log(`${colors.yellow}Scanning test files...${colors.reset}`);
+  const annotations = scanTestFiles(testsDir);
+  console.log(`  Found ${annotations.length} coverage annotations`);
+
+  // Build report
+  const report = reportGenerator.buildReport(coverageItems, annotations);
+
+  // Execute requested mode
+  switch (mode) {
+    case "check":
+      reportGenerator.generateConsoleReport(report);
+      if (report.mismatches.length > 0) {
+        process.exit(1);
+      }
+      break;
+
+    case "report":
+      reportGenerator.generateMarkdownReport(report, reportPath);
+      console.log(
+        `${colors.green}Report written to ${reportPath}${colors.reset}`,
+      );
+      break;
+
+    case "gaps":
+      reportGenerator.generateGapsReport(report);
+      break;
+
+    case "ids":
+      reportGenerator.listAllIds(coverageItems);
+      break;
+
+    default:
+      console.error(`${colors.red}Unknown mode: ${mode}${colors.reset}`);
+      printUsage();
+      process.exit(1);
+  }
+}
+
+main().catch((err) => {
+  console.error(`${colors.red}Error: ${err.message}${colors.reset}`);
+  process.exit(1);
+});

--- a/scripts/coverage-parser.ts
+++ b/scripts/coverage-parser.ts
@@ -1,0 +1,283 @@
+/**
+ * Parser for coverage.md
+ * Extracts all coverage items with generated unique IDs
+ */
+
+import { readFileSync } from "fs";
+import ICoverageItem from "./types/ICoverageItem";
+
+/**
+ * Normalize a string to kebab-case for ID generation
+ */
+function toKebabCase(str: string): string {
+  return str
+    .toLowerCase()
+    .replace(/\*\*\(error\)\*\*/gi, "") // Remove error marker
+    .replace(/[^a-z0-9]+/g, "-") // Replace non-alphanumeric with hyphens
+    .replace(/^-+|-+$/g, "") // Trim leading/trailing hyphens
+    .replace(/-+/g, "-"); // Collapse multiple hyphens
+}
+
+/**
+ * Extract section number from heading (e.g., "## 1. Primitive Types" -> "1")
+ */
+function extractSectionNumber(heading: string): string {
+  const match = heading.match(/^##\s*(\d+)\./);
+  return match ? match[1] : "";
+}
+
+/**
+ * Extract subsection number from heading (e.g., "### 1.1 Unsigned Integers" -> "1")
+ */
+function extractSubsectionNumber(heading: string): string {
+  const match = heading.match(/^###\s*\d+\.(\d+)/);
+  return match ? match[1] : "";
+}
+
+/**
+ * Extract section title (e.g., "## 1. Primitive Types" -> "1. Primitive Types")
+ */
+function extractSectionTitle(heading: string): string {
+  const match = heading.match(/^##\s*(.+)$/);
+  return match ? match[1].trim() : "";
+}
+
+/**
+ * Extract subsection title (e.g., "### 1.1 Unsigned Integers" -> "1.1 Unsigned Integers")
+ */
+function extractSubsectionTitle(heading: string): string {
+  const match = heading.match(/^###\s*(.+)$/);
+  return match ? match[1].trim() : "";
+}
+
+/**
+ * Extract type header (e.g., "#### u8" -> "u8")
+ */
+function extractTypeHeader(heading: string): string {
+  const match = heading.match(/^####\s*(\S+)/);
+  return match ? match[1].trim() : "";
+}
+
+/**
+ * Generate a unique coverage ID
+ */
+function generateCoverageId(
+  sectionNum: string,
+  subsectionNum: string,
+  typeHeader: string | undefined,
+  context: string,
+): string {
+  const contextKebab = toKebabCase(context);
+
+  if (typeHeader) {
+    return `${sectionNum}.${subsectionNum}-${typeHeader.toLowerCase()}-${contextKebab}`;
+  }
+  return `${sectionNum}.${subsectionNum}-${contextKebab}`;
+}
+
+/**
+ * Parse a table row and extract coverage item data
+ * Expected format: | Context | [x] or [ ] | `test-file.test.cnx` |
+ */
+function parseTableRow(
+  line: string,
+  sectionNum: string,
+  section: string,
+  subsectionNum: string,
+  subsection: string,
+  typeHeader: string | undefined,
+  lineNumber: number,
+): ICoverageItem | null {
+  // Split by | and filter empty parts
+  const parts = line
+    .split("|")
+    .map((p) => p.trim())
+    .filter((p) => p.length > 0);
+
+  if (parts.length < 2) return null;
+
+  const context = parts[0];
+  const statusCell = parts[1];
+
+  // Skip header row (contains "Status" or dashes)
+  if (
+    statusCell.toLowerCase() === "status" ||
+    statusCell.match(/^-+$/) ||
+    context.match(/^-+$/)
+  ) {
+    return null;
+  }
+
+  // Check for [x] or [ ]
+  const tested = statusCell.includes("[x]");
+  const isUntested = statusCell.includes("[ ]");
+
+  if (!tested && !isUntested) return null;
+
+  // Extract test file if present (third column, backtick-wrapped)
+  let testFile: string | undefined;
+  if (parts.length >= 3) {
+    const testFileMatch = parts[2].match(/`([^`]+)`/);
+    if (testFileMatch) {
+      testFile = testFileMatch[1];
+    }
+  }
+
+  // Check for error test marker
+  const isErrorTest = context.includes("**(ERROR)**");
+  const cleanContext = context.replace(/\*\*\(ERROR\)\*\*/g, "").trim();
+
+  const id = generateCoverageId(
+    sectionNum,
+    subsectionNum,
+    typeHeader,
+    cleanContext,
+  );
+
+  return {
+    id,
+    section,
+    subsection,
+    typeHeader,
+    context: cleanContext,
+    tested,
+    testFile,
+    lineNumber,
+    isErrorTest,
+  };
+}
+
+/**
+ * Sections to skip during parsing
+ */
+const SKIP_SECTIONS = [
+  "Table of Contents",
+  "How to Use This Document",
+  "Recent Updates",
+  "Statistics",
+  "Priority Summary",
+  "Coverage by Test File",
+];
+
+/**
+ * Check if we're in a section that should be skipped
+ */
+function shouldSkipSection(sectionTitle: string): boolean {
+  return SKIP_SECTIONS.some(
+    (skip) =>
+      sectionTitle.toLowerCase().includes(skip.toLowerCase()) ||
+      skip.toLowerCase().includes(sectionTitle.toLowerCase()),
+  );
+}
+
+/**
+ * Parse the coverage.md file and extract all coverage items
+ */
+function parseCoverageDocument(filePath: string): ICoverageItem[] {
+  const content = readFileSync(filePath, "utf-8");
+  const lines = content.split("\n");
+  const items: ICoverageItem[] = [];
+
+  let currentSection = "";
+  let currentSectionNum = "";
+  let currentSubsection = "";
+  let currentSubsectionNum = "";
+  let currentTypeHeader: string | undefined;
+  let inSkipSection = false;
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    const lineNumber = i + 1;
+
+    // Track main section (## N. Title)
+    if (line.match(/^##\s+\d+\./)) {
+      currentSection = extractSectionTitle(line);
+      currentSectionNum = extractSectionNumber(line);
+      currentSubsection = "";
+      currentSubsectionNum = "";
+      currentTypeHeader = undefined;
+      inSkipSection = shouldSkipSection(currentSection);
+      continue;
+    }
+
+    // Track non-numbered sections (skip them)
+    if (line.match(/^##\s+[^0-9]/)) {
+      const title = extractSectionTitle(line);
+      inSkipSection = shouldSkipSection(title);
+      currentSection = "";
+      currentSectionNum = "";
+      continue;
+    }
+
+    if (inSkipSection) continue;
+
+    // Track subsection (### N.N Title)
+    if (line.match(/^###\s+\d+\.\d+/)) {
+      currentSubsection = extractSubsectionTitle(line);
+      currentSubsectionNum = extractSubsectionNumber(line);
+      currentTypeHeader = undefined;
+      continue;
+    }
+
+    // Track type header (#### type)
+    if (line.match(/^####\s+\w+/)) {
+      currentTypeHeader = extractTypeHeader(line);
+      continue;
+    }
+
+    // Parse table rows with checkboxes
+    if (line.includes("|") && (line.includes("[x]") || line.includes("[ ]"))) {
+      if (!currentSection || !currentSubsection) continue;
+
+      const item = parseTableRow(
+        line,
+        currentSectionNum,
+        currentSection,
+        currentSubsectionNum,
+        currentSubsection,
+        currentTypeHeader,
+        lineNumber,
+      );
+
+      if (item) {
+        items.push(item);
+      }
+    }
+  }
+
+  return items;
+}
+
+/**
+ * Check for duplicate IDs and log warnings
+ */
+function checkForDuplicates(items: ICoverageItem[]): Map<string, number[]> {
+  const idMap = new Map<string, number[]>();
+
+  for (const item of items) {
+    const existing = idMap.get(item.id);
+    if (existing) {
+      existing.push(item.lineNumber);
+    } else {
+      idMap.set(item.id, [item.lineNumber]);
+    }
+  }
+
+  const duplicates = new Map<string, number[]>();
+  for (const [id, lines] of idMap) {
+    if (lines.length > 1) {
+      duplicates.set(id, lines);
+    }
+  }
+
+  return duplicates;
+}
+
+const coverageParser = {
+  parseCoverageDocument,
+  checkForDuplicates,
+  generateCoverageId,
+  toKebabCase,
+};
+
+export default coverageParser;

--- a/scripts/report-generator.ts
+++ b/scripts/report-generator.ts
@@ -1,0 +1,382 @@
+/**
+ * Report generator for coverage analysis
+ * Generates console and markdown reports
+ */
+
+import { writeFileSync } from "fs";
+import ICoverageItem from "./types/ICoverageItem";
+import ITestAnnotation from "./types/ITestAnnotation";
+import ICoverageReport, {
+  ICoverageSummary,
+  IMismatch,
+  ISectionSummary,
+} from "./types/ICoverageReport";
+
+// ANSI color codes for console output
+const colors = {
+  reset: "\x1b[0m",
+  bright: "\x1b[1m",
+  dim: "\x1b[2m",
+  red: "\x1b[31m",
+  green: "\x1b[32m",
+  yellow: "\x1b[33m",
+  blue: "\x1b[34m",
+  cyan: "\x1b[36m",
+};
+
+/**
+ * Build a complete coverage report
+ */
+function buildReport(
+  items: ICoverageItem[],
+  annotations: ITestAnnotation[],
+): ICoverageReport {
+  // Create a map of coverage IDs to items
+  const itemMap = new Map<string, ICoverageItem>();
+  for (const item of items) {
+    itemMap.set(item.id, item);
+  }
+
+  // Create a map of coverage IDs to annotations
+  const annotationMap = new Map<string, ITestAnnotation[]>();
+  for (const annotation of annotations) {
+    const existing = annotationMap.get(annotation.coverageId) || [];
+    existing.push(annotation);
+    annotationMap.set(annotation.coverageId, existing);
+  }
+
+  // Find mismatches
+  const mismatches: IMismatch[] = [];
+
+  // Check for annotations with unknown IDs
+  for (const annotation of annotations) {
+    if (!itemMap.has(annotation.coverageId)) {
+      mismatches.push({
+        annotation,
+        issue: `Unknown coverage ID "${annotation.coverageId}" in ${annotation.relativePath}:${annotation.lineNumber}`,
+        type: "unknown_id",
+      });
+    }
+  }
+
+  // Check for status mismatches (annotation exists but not marked tested)
+  for (const [id, annotationList] of annotationMap) {
+    const item = itemMap.get(id);
+    if (item && !item.tested) {
+      mismatches.push({
+        coverageItem: item,
+        annotation: annotationList[0],
+        issue: `Item "${id}" has annotation but is marked [ ] in coverage.md (line ${item.lineNumber})`,
+        type: "status_mismatch",
+      });
+    }
+  }
+
+  // Find gaps (untested items)
+  const gaps = items.filter((item) => !item.tested);
+
+  // Count annotated items (items that have at least one annotation)
+  const annotatedIds = new Set(annotations.map((a) => a.coverageId));
+  const annotatedItems = items.filter((item) => annotatedIds.has(item.id));
+
+  // Build section summaries
+  const sectionMap = new Map<string, ICoverageItem[]>();
+  for (const item of items) {
+    const existing = sectionMap.get(item.section) || [];
+    existing.push(item);
+    sectionMap.set(item.section, existing);
+  }
+
+  const sections: ISectionSummary[] = [];
+  for (const [name, sectionItems] of sectionMap) {
+    const tested = sectionItems.filter((i) => i.tested).length;
+    const annotated = sectionItems.filter((i) => annotatedIds.has(i.id)).length;
+    sections.push({
+      name,
+      total: sectionItems.length,
+      tested,
+      annotated,
+      percentage: Math.round((tested / sectionItems.length) * 100),
+    });
+  }
+
+  // Sort sections by section number
+  sections.sort((a, b) => {
+    const numA = parseInt(a.name.match(/^(\d+)/)?.[1] || "0");
+    const numB = parseInt(b.name.match(/^(\d+)/)?.[1] || "0");
+    return numA - numB;
+  });
+
+  // Build summary
+  const summary: ICoverageSummary = {
+    totalItems: items.length,
+    testedItems: items.filter((i) => i.tested).length,
+    untestedItems: gaps.length,
+    annotatedItems: annotatedItems.length,
+    mismatchCount: mismatches.length,
+    coveragePercentage: Math.round(
+      (items.filter((i) => i.tested).length / items.length) * 100,
+    ),
+    sections,
+  };
+
+  return {
+    generated: new Date(),
+    summary,
+    items,
+    annotations,
+    mismatches,
+    gaps,
+  };
+}
+
+/**
+ * Generate console report
+ */
+function generateConsoleReport(report: ICoverageReport): void {
+  const { summary, mismatches, gaps } = report;
+
+  console.log("");
+  console.log(
+    `${colors.bright}═══════════════════════════════════════════════════════${colors.reset}`,
+  );
+  console.log(
+    `${colors.bright}  C-Next Coverage Tracking Report${colors.reset}`,
+  );
+  console.log(
+    `${colors.bright}═══════════════════════════════════════════════════════${colors.reset}`,
+  );
+  console.log("");
+
+  // Summary
+  console.log(`${colors.cyan}Summary:${colors.reset}`);
+  console.log(
+    `  Total Coverage Points:  ${colors.bright}${summary.totalItems}${colors.reset}`,
+  );
+  console.log(
+    `  Tested (coverage.md):   ${colors.green}${summary.testedItems}${colors.reset} (${summary.coveragePercentage}%)`,
+  );
+  console.log(
+    `  With Annotations:       ${colors.blue}${summary.annotatedItems}${colors.reset}`,
+  );
+  console.log(
+    `  Gaps Remaining:         ${colors.yellow}${summary.untestedItems}${colors.reset}`,
+  );
+  console.log("");
+
+  // Section breakdown
+  console.log(`${colors.cyan}Section Breakdown:${colors.reset}`);
+  for (const section of summary.sections) {
+    const pctColor =
+      section.percentage >= 80
+        ? colors.green
+        : section.percentage >= 50
+          ? colors.yellow
+          : colors.red;
+    const sectionDisplay = section.name.substring(0, 35).padEnd(35);
+    console.log(
+      `  ${sectionDisplay} ${pctColor}${section.tested}/${section.total}${colors.reset} (${section.percentage}%)`,
+    );
+  }
+  console.log("");
+
+  // Mismatches
+  if (mismatches.length > 0) {
+    console.log(
+      `${colors.red}Mismatches Found: ${mismatches.length}${colors.reset}`,
+    );
+    for (const mismatch of mismatches.slice(0, 10)) {
+      console.log(`  ${colors.yellow}⚠${colors.reset}  ${mismatch.issue}`);
+    }
+    if (mismatches.length > 10) {
+      console.log(
+        `  ${colors.dim}... and ${mismatches.length - 10} more${colors.reset}`,
+      );
+    }
+    console.log("");
+  } else {
+    console.log(`${colors.green}No mismatches found.${colors.reset}`);
+    console.log("");
+  }
+
+  // Top gaps
+  if (gaps.length > 0) {
+    console.log(`${colors.cyan}Top 10 Gaps:${colors.reset}`);
+    for (const gap of gaps.slice(0, 10)) {
+      console.log(`  ${colors.dim}[ ]${colors.reset} ${gap.id}`);
+    }
+    if (gaps.length > 10) {
+      console.log(
+        `  ${colors.dim}... and ${gaps.length - 10} more untested items${colors.reset}`,
+      );
+    }
+  }
+
+  console.log("");
+}
+
+/**
+ * Generate gaps-only report
+ */
+function generateGapsReport(report: ICoverageReport): void {
+  const { gaps } = report;
+
+  console.log("");
+  console.log(
+    `${colors.bright}Coverage Gaps (${gaps.length} untested items)${colors.reset}`,
+  );
+  console.log("");
+
+  // Group by section
+  const bySection = new Map<string, ICoverageItem[]>();
+  for (const gap of gaps) {
+    const existing = bySection.get(gap.section) || [];
+    existing.push(gap);
+    bySection.set(gap.section, existing);
+  }
+
+  // Sort sections
+  const sortedSections = Array.from(bySection.keys()).sort((a, b) => {
+    const numA = parseInt(a.match(/^(\d+)/)?.[1] || "0");
+    const numB = parseInt(b.match(/^(\d+)/)?.[1] || "0");
+    return numA - numB;
+  });
+
+  for (const section of sortedSections) {
+    const sectionGaps = bySection.get(section)!;
+    console.log(
+      `${colors.cyan}${section}${colors.reset} (${sectionGaps.length} gaps)`,
+    );
+    for (const gap of sectionGaps) {
+      console.log(`  [ ] ${gap.id}`);
+    }
+    console.log("");
+  }
+}
+
+/**
+ * Generate markdown report file
+ */
+function generateMarkdownReport(
+  report: ICoverageReport,
+  outputPath: string,
+): void {
+  const { summary, mismatches, gaps } = report;
+  const lines: string[] = [];
+
+  lines.push("# C-Next Coverage Report");
+  lines.push("");
+  lines.push(`Generated: ${report.generated.toISOString().split("T")[0]}`);
+  lines.push("");
+
+  // Summary table
+  lines.push("## Summary");
+  lines.push("");
+  lines.push("| Metric | Count | Percentage |");
+  lines.push("|--------|-------|------------|");
+  lines.push(`| Total Points | ${summary.totalItems} | 100% |`);
+  lines.push(
+    `| Tested | ${summary.testedItems} | ${summary.coveragePercentage}% |`,
+  );
+  lines.push(`| With Annotations | ${summary.annotatedItems} | - |`);
+  lines.push(`| Gaps | ${summary.untestedItems} | - |`);
+  lines.push("");
+
+  // Section breakdown
+  lines.push("## Section Breakdown");
+  lines.push("");
+  lines.push("| Section | Tested | Total | Coverage |");
+  lines.push("|---------|--------|-------|----------|");
+  for (const section of summary.sections) {
+    lines.push(
+      `| ${section.name} | ${section.tested} | ${section.total} | ${section.percentage}% |`,
+    );
+  }
+  lines.push("");
+
+  // Mismatches
+  if (mismatches.length > 0) {
+    lines.push("## Mismatches");
+    lines.push("");
+    lines.push("| Type | Issue |");
+    lines.push("|------|-------|");
+    for (const mismatch of mismatches) {
+      lines.push(`| ${mismatch.type} | ${mismatch.issue} |`);
+    }
+    lines.push("");
+  }
+
+  // Gaps by section
+  lines.push("## Gaps by Section");
+  lines.push("");
+
+  const bySection = new Map<string, ICoverageItem[]>();
+  for (const gap of gaps) {
+    const existing = bySection.get(gap.section) || [];
+    existing.push(gap);
+    bySection.set(gap.section, existing);
+  }
+
+  const sortedSections = Array.from(bySection.keys()).sort((a, b) => {
+    const numA = parseInt(a.match(/^(\d+)/)?.[1] || "0");
+    const numB = parseInt(b.match(/^(\d+)/)?.[1] || "0");
+    return numA - numB;
+  });
+
+  for (const section of sortedSections) {
+    const sectionGaps = bySection.get(section)!;
+    lines.push(`### ${section}`);
+    lines.push("");
+    for (const gap of sectionGaps) {
+      lines.push(`- [ ] \`${gap.id}\``);
+    }
+    lines.push("");
+  }
+
+  writeFileSync(outputPath, lines.join("\n"));
+}
+
+/**
+ * List all coverage IDs (for adding annotations)
+ */
+function listAllIds(items: ICoverageItem[]): void {
+  console.log("");
+  console.log(
+    `${colors.bright}All Coverage IDs (${items.length} total)${colors.reset}`,
+  );
+  console.log("");
+
+  // Group by section
+  const bySection = new Map<string, ICoverageItem[]>();
+  for (const item of items) {
+    const existing = bySection.get(item.section) || [];
+    existing.push(item);
+    bySection.set(item.section, existing);
+  }
+
+  const sortedSections = Array.from(bySection.keys()).sort((a, b) => {
+    const numA = parseInt(a.match(/^(\d+)/)?.[1] || "0");
+    const numB = parseInt(b.match(/^(\d+)/)?.[1] || "0");
+    return numA - numB;
+  });
+
+  for (const section of sortedSections) {
+    const sectionItems = bySection.get(section)!;
+    console.log(`${colors.cyan}${section}${colors.reset}`);
+    for (const item of sectionItems) {
+      const status = item.tested ? colors.green + "[x]" : colors.dim + "[ ]";
+      console.log(`  ${status}${colors.reset} ${item.id}`);
+    }
+    console.log("");
+  }
+}
+
+const reportGenerator = {
+  buildReport,
+  generateConsoleReport,
+  generateGapsReport,
+  generateMarkdownReport,
+  listAllIds,
+};
+
+export default reportGenerator;

--- a/scripts/test-scanner.ts
+++ b/scripts/test-scanner.ts
@@ -1,0 +1,97 @@
+/**
+ * Scanner for test files
+ * Extracts coverage annotations from .test.cnx files
+ */
+
+import { readFileSync, readdirSync, statSync } from "fs";
+import { join, relative } from "path";
+import ITestAnnotation from "./types/ITestAnnotation";
+
+/**
+ * Recursively find all .test.cnx files in a directory
+ */
+function findTestFiles(dir: string): string[] {
+  const files: string[] = [];
+
+  function walk(currentDir: string): void {
+    const entries = readdirSync(currentDir);
+
+    for (const entry of entries) {
+      const fullPath = join(currentDir, entry);
+      const stat = statSync(fullPath);
+
+      if (stat.isDirectory()) {
+        walk(fullPath);
+      } else if (entry.endsWith(".test.cnx")) {
+        files.push(fullPath);
+      }
+    }
+  }
+
+  walk(dir);
+  return files;
+}
+
+/**
+ * Extract coverage annotations from a single test file
+ * Looks for: /\* test-coverage: ID *\/
+ */
+function extractAnnotations(
+  content: string,
+  filePath: string,
+  testsDir: string,
+): ITestAnnotation[] {
+  const annotations: ITestAnnotation[] = [];
+  const lines = content.split("\n");
+
+  // Pattern: /* test-coverage: ID */ or /* test-coverage: ID1, ID2 */
+  const pattern = /\/\*\s*test-coverage:\s*([^*]+)\s*\*\//g;
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    let match;
+
+    while ((match = pattern.exec(line)) !== null) {
+      // Handle comma-separated IDs in a single annotation
+      const ids = match[1].split(",").map((id) => id.trim());
+
+      for (const coverageId of ids) {
+        if (coverageId) {
+          annotations.push({
+            coverageId,
+            testFile: filePath,
+            relativePath: relative(testsDir, filePath),
+            lineNumber: i + 1,
+          });
+        }
+      }
+    }
+
+    // Reset regex lastIndex for next line
+    pattern.lastIndex = 0;
+  }
+
+  return annotations;
+}
+
+/**
+ * Scan all test files and extract coverage annotations
+ */
+function scanTestFiles(testsDir: string): ITestAnnotation[] {
+  const annotations: ITestAnnotation[] = [];
+  const testFiles = findTestFiles(testsDir);
+
+  for (const file of testFiles) {
+    try {
+      const content = readFileSync(file, "utf-8");
+      const fileAnnotations = extractAnnotations(content, file, testsDir);
+      annotations.push(...fileAnnotations);
+    } catch (err) {
+      console.error(`Warning: Could not read ${file}: ${err}`);
+    }
+  }
+
+  return annotations;
+}
+
+export default scanTestFiles;

--- a/scripts/types/ICoverageItem.ts
+++ b/scripts/types/ICoverageItem.ts
@@ -1,0 +1,33 @@
+/**
+ * Represents a single coverage item parsed from coverage.md
+ */
+interface ICoverageItem {
+  /** Generated unique ID (e.g., "1.1-u8-global-variable-declaration") */
+  id: string;
+
+  /** Main section (e.g., "1. Primitive Types") */
+  section: string;
+
+  /** Subsection (e.g., "1.1 Unsigned Integers") */
+  subsection: string;
+
+  /** Type header if applicable (e.g., "u8", "u16") */
+  typeHeader?: string;
+
+  /** Context/description from table (e.g., "Global variable declaration") */
+  context: string;
+
+  /** Whether checked [x] or unchecked [ ] in coverage.md */
+  tested: boolean;
+
+  /** Test file referenced in coverage.md (if any) */
+  testFile?: string;
+
+  /** Line number in coverage.md for reference */
+  lineNumber: number;
+
+  /** Whether this is an error test (marked with **(ERROR)**) */
+  isErrorTest: boolean;
+}
+
+export default ICoverageItem;

--- a/scripts/types/ICoverageReport.ts
+++ b/scripts/types/ICoverageReport.ts
@@ -1,0 +1,29 @@
+import ICoverageItem from "./ICoverageItem";
+import ICoverageSummary from "./ICoverageSummary";
+import IMismatch from "./IMismatch";
+import ITestAnnotation from "./ITestAnnotation";
+
+/**
+ * Complete coverage report
+ */
+interface ICoverageReport {
+  /** When the report was generated */
+  generated: Date;
+
+  /** Summary statistics */
+  summary: ICoverageSummary;
+
+  /** All coverage items from coverage.md */
+  items: ICoverageItem[];
+
+  /** All annotations found in test files */
+  annotations: ITestAnnotation[];
+
+  /** Detected mismatches */
+  mismatches: IMismatch[];
+
+  /** Untested items (gaps) */
+  gaps: ICoverageItem[];
+}
+
+export default ICoverageReport;

--- a/scripts/types/ICoverageSummary.ts
+++ b/scripts/types/ICoverageSummary.ts
@@ -1,0 +1,29 @@
+import ISectionSummary from "./ISectionSummary";
+
+/**
+ * Overall coverage summary
+ */
+interface ICoverageSummary {
+  /** Total coverage items in coverage.md */
+  totalItems: number;
+
+  /** Items marked as tested [x] */
+  testedItems: number;
+
+  /** Items not tested [ ] */
+  untestedItems: number;
+
+  /** Items that have annotations in test files */
+  annotatedItems: number;
+
+  /** Number of mismatches found */
+  mismatchCount: number;
+
+  /** Overall coverage percentage */
+  coveragePercentage: number;
+
+  /** Per-section breakdown */
+  sections: ISectionSummary[];
+}
+
+export default ICoverageSummary;

--- a/scripts/types/IMismatch.ts
+++ b/scripts/types/IMismatch.ts
@@ -1,0 +1,21 @@
+import ICoverageItem from "./ICoverageItem";
+import ITestAnnotation from "./ITestAnnotation";
+
+/**
+ * A mismatch between coverage.md and test annotations
+ */
+interface IMismatch {
+  /** The coverage item (if found) */
+  coverageItem?: ICoverageItem;
+
+  /** The annotation (if found) */
+  annotation?: ITestAnnotation;
+
+  /** Description of the mismatch */
+  issue: string;
+
+  /** Type of mismatch */
+  type: "unknown_id" | "status_mismatch" | "missing_test_file";
+}
+
+export default IMismatch;

--- a/scripts/types/ISectionSummary.ts
+++ b/scripts/types/ISectionSummary.ts
@@ -1,0 +1,21 @@
+/**
+ * Summary statistics for a section
+ */
+interface ISectionSummary {
+  /** Section name (e.g., "1. Primitive Types") */
+  name: string;
+
+  /** Total coverage items in section */
+  total: number;
+
+  /** Items marked as tested [x] */
+  tested: number;
+
+  /** Items with test annotations */
+  annotated: number;
+
+  /** Coverage percentage */
+  percentage: number;
+}
+
+export default ISectionSummary;

--- a/scripts/types/ITestAnnotation.ts
+++ b/scripts/types/ITestAnnotation.ts
@@ -1,0 +1,18 @@
+/**
+ * Represents a coverage annotation found in a test file
+ */
+interface ITestAnnotation {
+  /** The coverage ID from the annotation (e.g., "1.1-u8-in-ternary-expression") */
+  coverageId: string;
+
+  /** Absolute path to the test file */
+  testFile: string;
+
+  /** Relative path from tests/ directory */
+  relativePath: string;
+
+  /** Line number where annotation appears */
+  lineNumber: number;
+}
+
+export default ITestAnnotation;

--- a/tests/arithmetic/u64-arithmetic.expected.c
+++ b/tests/arithmetic/u64-arithmetic.expected.c
@@ -5,6 +5,7 @@
 
 #include <stdint.h>
 
+/* test-coverage: 1.1-u64-in-arithmetic-expression */
 /* test-execution */
 // Tests: u64 arithmetic operations (+, -, *, /, %)
 // Validates all basic arithmetic operations with u64 type

--- a/tests/arithmetic/u64-arithmetic.test.cnx
+++ b/tests/arithmetic/u64-arithmetic.test.cnx
@@ -1,3 +1,4 @@
+/* test-coverage: 1.1-u64-in-arithmetic-expression */
 /* test-execution */
 // Tests: u64 arithmetic operations (+, -, *, /, %)
 // Validates all basic arithmetic operations with u64 type

--- a/tests/atomic/atomic-all-types.expected.c
+++ b/tests/atomic/atomic-all-types.expected.c
@@ -3,6 +3,8 @@
  * A safer C for embedded systems
  */
 
+/* test-coverage: 1.1-u8-with-atomic-modifier, 1.1-u16-with-atomic-modifier */
+/* test-coverage: 1.1-u32-with-atomic-modifier */
 // ADR-049: Atomic variables with all integer types
 // Tests: atomic works with u8, u16, u32, u64
 

--- a/tests/atomic/atomic-all-types.test.cnx
+++ b/tests/atomic/atomic-all-types.test.cnx
@@ -1,3 +1,5 @@
+/* test-coverage: 1.1-u8-with-atomic-modifier, 1.1-u16-with-atomic-modifier */
+/* test-coverage: 1.1-u32-with-atomic-modifier */
 // ADR-049: Atomic variables with all integer types
 // Tests: atomic works with u8, u16, u32, u64
 

--- a/tests/bitwise/u8-bitwise-ops.expected.c
+++ b/tests/bitwise/u8-bitwise-ops.expected.c
@@ -5,6 +5,7 @@
 
 #include <stdint.h>
 
+/* test-coverage: 1.1-u8-in-bitwise-operation */
 /* test-execution */
 // Test u8 bitwise operations: AND, OR, XOR, NOT
 // Coverage: Section 5.1-5.4 for u8 type

--- a/tests/bitwise/u8-bitwise-ops.test.cnx
+++ b/tests/bitwise/u8-bitwise-ops.test.cnx
@@ -1,3 +1,4 @@
+/* test-coverage: 1.1-u8-in-bitwise-operation */
 /* test-execution */
 // Test u8 bitwise operations: AND, OR, XOR, NOT
 // Coverage: Section 5.1-5.4 for u8 type

--- a/tests/comparison/u64-comparison.expected.c
+++ b/tests/comparison/u64-comparison.expected.c
@@ -14,6 +14,7 @@ static inline uint64_t cnx_clamp_add_u64(uint64_t a, uint64_t b) {
     return a + (uint64_t)b;
 }
 
+/* test-coverage: 1.1-u64-in-comparison */
 /* test-execution */
 // Tests: u64 comparison operations (<, >, <=, >=, =, !=)
 // Validates all comparison operators with u64 type

--- a/tests/comparison/u64-comparison.test.cnx
+++ b/tests/comparison/u64-comparison.test.cnx
@@ -1,3 +1,4 @@
+/* test-coverage: 1.1-u64-in-comparison */
 /* test-execution */
 // Tests: u64 comparison operations (<, >, <=, >=, =, !=)
 // Validates all comparison operators with u64 type

--- a/tests/const/const-variable.expected.c
+++ b/tests/const/const-variable.expected.c
@@ -5,6 +5,7 @@
 
 #include <stdint.h>
 
+/* test-coverage: 1.1-u8-with-const-modifier, 1.1-u32-with-const-modifier */
 // ADR-013: Const variable usage
 // Tests: const variable can be read but not written
 const uint32_t MAX_SIZE = 100;

--- a/tests/const/const-variable.test.cnx
+++ b/tests/const/const-variable.test.cnx
@@ -1,3 +1,4 @@
+/* test-coverage: 1.1-u8-with-const-modifier, 1.1-u32-with-const-modifier */
 // ADR-013: Const variable usage
 // Tests: const variable can be read but not written
 

--- a/tests/enum/basic-enum.expected.c
+++ b/tests/enum/basic-enum.expected.c
@@ -5,6 +5,7 @@
 
 #include <stdint.h>
 
+/* test-coverage: 3.1-enum-enum-same-type */
 /* test-execution */
 // ADR-017: Basic Enum Test
 // Tests basic enum declaration, usage, and code generation

--- a/tests/enum/basic-enum.test.cnx
+++ b/tests/enum/basic-enum.test.cnx
@@ -1,3 +1,4 @@
+/* test-coverage: 3.1-enum-enum-same-type */
 /* test-execution */
 // ADR-017: Basic Enum Test
 // Tests basic enum declaration, usage, and code generation

--- a/tests/floats/f32-all-contexts.expected.c
+++ b/tests/floats/f32-all-contexts.expected.c
@@ -5,6 +5,10 @@
 
 #include <stdint.h>
 
+/* test-coverage: 1.3-f32-global-variable-declaration, 1.3-f32-global-variable-with-init */
+/* test-coverage: 1.3-f32-local-variable-declaration, 1.3-f32-local-variable-with-init */
+/* test-coverage: 1.3-f32-function-parameter, 1.3-f32-function-return-type */
+/* test-coverage: 1.3-f32-struct-member, 1.3-f32-array-element-type */
 // Test f32 in all language contexts
 // Global variable declarations
 float global_f = 3.14;

--- a/tests/floats/f32-all-contexts.test.cnx
+++ b/tests/floats/f32-all-contexts.test.cnx
@@ -1,3 +1,7 @@
+/* test-coverage: 1.3-f32-global-variable-declaration, 1.3-f32-global-variable-with-init */
+/* test-coverage: 1.3-f32-local-variable-declaration, 1.3-f32-local-variable-with-init */
+/* test-coverage: 1.3-f32-function-parameter, 1.3-f32-function-return-type */
+/* test-coverage: 1.3-f32-struct-member, 1.3-f32-array-element-type */
 // Test f32 in all language contexts
 
 // Global variable declarations

--- a/tests/for-loops/for-u8-counter.expected.c
+++ b/tests/for-loops/for-u8-counter.expected.c
@@ -13,6 +13,7 @@ static inline uint8_t cnx_clamp_add_u8(uint8_t a, uint32_t b) {
     return a + (uint8_t)b;
 }
 
+/* test-coverage: 1.1-u8-as-loop-counter */
 /* test-execution */
 // For loop tests: u8 as loop counter
 // Tests: u8 type can be used as for-loop counter

--- a/tests/for-loops/for-u8-counter.test.cnx
+++ b/tests/for-loops/for-u8-counter.test.cnx
@@ -1,3 +1,4 @@
+/* test-coverage: 1.1-u8-as-loop-counter */
 /* test-execution */
 // For loop tests: u8 as loop counter
 // Tests: u8 type can be used as for-loop counter

--- a/tests/primitives/all-types.expected.c
+++ b/tests/primitives/all-types.expected.c
@@ -6,6 +6,10 @@
 #include <stdint.h>
 #include <stdbool.h>
 
+/* test-coverage: 1.1-u8-global-variable-declaration, 1.1-u16-global-variable-declaration */
+/* test-coverage: 1.1-u32-global-variable-declaration, 1.1-u64-global-variable-declaration */
+/* test-coverage: 1.2-i8-global-variable-declaration, 1.2-i16-global-variable-declaration */
+/* test-coverage: 1.2-i32-global-variable-declaration, 1.2-i64-global-variable-declaration */
 // ADR-044: Test all primitive types transpile correctly
 // Unsigned integers
 uint8_t byte = 255;

--- a/tests/primitives/all-types.test.cnx
+++ b/tests/primitives/all-types.test.cnx
@@ -1,3 +1,7 @@
+/* test-coverage: 1.1-u8-global-variable-declaration, 1.1-u16-global-variable-declaration */
+/* test-coverage: 1.1-u32-global-variable-declaration, 1.1-u64-global-variable-declaration */
+/* test-coverage: 1.2-i8-global-variable-declaration, 1.2-i16-global-variable-declaration */
+/* test-coverage: 1.2-i32-global-variable-declaration, 1.2-i64-global-variable-declaration */
 // ADR-044: Test all primitive types transpile correctly
 
 // Unsigned integers

--- a/tests/ternary/ternary-u64.expected.c
+++ b/tests/ternary/ternary-u64.expected.c
@@ -5,6 +5,7 @@
 
 #include <stdint.h>
 
+/* test-coverage: 1.1-u64-in-ternary-expression */
 /* test-execution */
 // ADR-022: Ternary operator test for u64
 // Tests: ternary with u64 in conditions and branches

--- a/tests/ternary/ternary-u64.test.cnx
+++ b/tests/ternary/ternary-u64.test.cnx
@@ -1,3 +1,4 @@
+/* test-coverage: 1.1-u64-in-ternary-expression */
 /* test-execution */
 // ADR-022: Ternary operator test for u64
 // Tests: ternary with u64 in conditions and branches


### PR DESCRIPTION
## Summary

Implements Issue #34 - Coverage Tracking Tool that maps coverage.md checkboxes to test file annotations.

- Parses coverage.md and extracts 663 coverage items with unique IDs
- Scans test files for `/* test-coverage: ID */` annotations
- Generates console and markdown reports showing coverage statistics
- Identifies mismatches and gaps in test coverage

## New npm scripts

- `npm run coverage:check` - Display coverage report with statistics
- `npm run coverage:report` - Generate COVERAGE-STATUS.md file
- `npm run coverage:gaps` - Show only untested items  
- `npm run coverage:ids` - List all coverage IDs for annotation

## Files changed

**New scripts (7):**
- `scripts/coverage-checker.ts` - Main CLI entry point
- `scripts/coverage-parser.ts` - Parses coverage.md
- `scripts/test-scanner.ts` - Scans test files for annotations
- `scripts/report-generator.ts` - Console + markdown reports
- `scripts/types/` - Type definitions (6 files)

**Annotated test files (10):**
Added 27 coverage annotations as proof-of-concept across arithmetic, ternary, comparison, floats, bitwise, const, primitives, atomic, and enum tests.

## Test plan

- [x] `npm run coverage:check` - Shows 663 items, 77% coverage, 27 annotations
- [x] `npm run coverage:report` - Generates COVERAGE-STATUS.md
- [x] `npm run coverage:gaps` - Lists 155 untested items by section
- [x] `npm run coverage:ids` - Lists all coverage IDs
- [x] `npm test` - 446/454 tests pass (8 pre-existing switch failures unrelated to this PR)

Closes #34

🤖 Generated with [Claude Code](https://claude.com/claude-code)