### PR TITLE
Remove unused generic types grammar and references

### DIFF
--- a/coverage.md
+++ b/coverage.md
@@ -59,8 +59,7 @@ This document tracks test coverage for every language construct in every valid c
 30. [C Interoperability](#30-c-interoperability) (includes Volatile)
 31. [ISR Type](#31-isr-type)
 32. [Literals](#32-literals)
-33. [Generic Types](#33-generic-types)
-34. [Expression Contexts](#34-expression-contexts)
+33. [Expression Contexts](#33-expression-contexts)
 
 ---
 
@@ -1553,23 +1552,9 @@ See `/docs/decisions/adr-108-volatile-keyword.md` for implementation details and
 
 ---
 
-## 33. Generic Types
+## 33. Expression Contexts
 
-| Feature                | Status | Test File |
-| ---------------------- | ------ | --------- |
-| Type<Arg> declaration  | [ ]    |           |
-| Type<Arg1, Arg2>       | [ ]    |           |
-| Generic function       | [ ]    |           |
-| Generic struct         | [ ]    |           |
-| Numeric type parameter | [ ]    |           |
-
-_Note: Generic types are defined in grammar but implementation status unclear._
-
----
-
-## 34. Expression Contexts
-
-### 34.1 Nested/Complex Expressions
+### 33.1 Nested/Complex Expressions
 
 | Context                            | Status | Test File                                          |
 | ---------------------------------- | ------ | -------------------------------------------------- |
@@ -1607,7 +1592,7 @@ _Note: Generic types are defined in grammar but implementation status unclear._
 
 **Note:** Tests created 2026-01-11. Grammar bug fixed (line 485-486 in CNext.g4). Code generator bug discovered and documented in `BUG-DISCOVERED-postfix-chains.md`.
 
-### 34.2 Statement Nesting
+### 33.2 Statement Nesting
 
 | Context              | Status | Test File                            |
 | -------------------- | ------ | ------------------------------------ |
@@ -1676,7 +1661,6 @@ _Last updated: 2026-01-11_
 | Strings              | ~90% (excellent coverage)                             |
 | Modifiers            | ~60% (atomic good, volatile missing)                  |
 | Register Bitfields   | ~10% (sparse)                                         |
-| Generic Types        | ~0% (not tested)                                      |
 | Statement Nesting    | ~30% (basic only)                                     |
 | Postfix Chains       | ~95% (comprehensive 11-file test suite, code gen bug) |
 

--- a/grammar/CNext.g4
+++ b/grammar/CNext.g4
@@ -505,7 +505,6 @@ type
     | qualifiedType                           // ADR-016: Scope.Type from outside scope
     | userType
     | arrayType
-    | genericType
     | 'void'
     ;
 
@@ -541,15 +540,6 @@ stringType
 arrayType
     : primitiveType '[' expression ']'
     | userType '[' expression ']'
-    ;
-
-genericType
-    : IDENTIFIER '<' typeArgument (',' typeArgument)* '>'
-    ;
-
-typeArgument
-    : type
-    | expression    // For numeric type parameters like buffer sizes
     ;
 
 // ----------------------------------------------------------------------------

--- a/src/codegen/CodeGenerator.ts
+++ b/src/codegen/CodeGenerator.ts
@@ -3927,11 +3927,6 @@ export default class CodeGenerator {
       return "{0}";
     }
 
-    // Check for generic types (like RingBuffer<u8, 256>)
-    if (typeCtx.genericType()) {
-      return "{0}";
-    }
-
     // Primitive types
     if (typeCtx.primitiveType()) {
       const primType = typeCtx.primitiveType()!.getText();
@@ -8057,9 +8052,6 @@ export default class CodeGenerator {
     if (ctx.primitiveType()) {
       return ctx.primitiveType()!.getText();
     }
-    if (ctx.genericType()) {
-      return ctx.genericType()!.IDENTIFIER().getText();
-    }
     return ctx.getText();
   }
 
@@ -8110,10 +8102,6 @@ export default class CodeGenerator {
         baseType = arrCtx.userType()!.getText();
       }
       return baseType;
-    }
-    if (ctx.genericType()) {
-      // Generics need special handling - for now, return the base name
-      return ctx.genericType()!.IDENTIFIER().getText();
     }
     if (ctx.getText() === "void") {
       return "void";


### PR DESCRIPTION
## Summary

- Closes #27 as false positive: C-Next explicitly rejected generics (ADR-019)
- Removes Section 33 (Generic Types) from coverage.md
- Removes `genericType` and `typeArgument` rules from CNext.g4
- Removes 3 genericType references from CodeGenerator.ts

## Context

Investigation revealed that issue #27 was a false positive:

1. **ADR-019 explicitly rejects generics**: "Generic type aliases? — Moot; feature rejected."
2. **Grammar had placeholder only** - The `genericType` rule existed but CodeGenerator only had stub code
3. **`string<N>` is separate** - Has its own `stringType` rule (ADR-045) and is properly implemented
4. **No documentation** - Neither README.md nor learn-cnext-in-y-minutes.md mention generics

The only remaining reference to generics is ADR-019 which documents the rejection decision.

## Test plan

- [x] All 458 tests pass
- [x] TypeScript type check passes
- [x] oxlint passes (0 warnings, 0 errors)
- [x] Parser regenerated successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)