### PR TITLE
Fix coverage.md Section 30a: Volatile modifier corrections

### DIFF
--- a/coverage.md
+++ b/coverage.md
@@ -1488,15 +1488,14 @@ This document tracks test coverage for every language construct in every valid c
 
 ## 30a. Volatile Modifier
 
-| Context                  | Status | Test File                                |
-| ------------------------ | ------ | ---------------------------------------- |
-| Global variable          | [x]    | `volatile/volatile-global.test.cnx`      |
-| Local variable           | [x]    | `volatile/volatile-local.test.cnx`       |
-| Struct member            | N/A    | Not supported in C-Next grammar          |
-| Register field (implied) | N/A    | Not implemented yet (ADR-108 future)     |
-| With const               | [x]    | `volatile/volatile-const.test.cnx`       |
-| With atomic **(ERROR)**  | [x]    | `atomic/atomic-volatile-error.test.cnx`  |
-| In for loop              | [x]    | `volatile/volatile-in-for-loop.test.cnx` |
+| Context                  | Status | Test File                                    |
+| ------------------------ | ------ | -------------------------------------------- |
+| Global variable          | [x]    | `volatile/volatile-global.test.cnx`          |
+| Local variable           | [x]    | `volatile/volatile-local.test.cnx`           |
+| Register field (implied) | [x]    | `register/register-basic.test.cnx` (ADR-004) |
+| With const               | [x]    | `volatile/volatile-const.test.cnx`           |
+| With atomic **(ERROR)**  | [x]    | `atomic/atomic-volatile-error.test.cnx`      |
+| In for loop              | [x]    | `volatile/volatile-in-for-loop.test.cnx`     |
 
 **Implementation Note (ADR-108):**
 
@@ -1507,11 +1506,12 @@ ADR-108 marked "Implemented" (2026-01-10) with hardware testing on Nucleo-F446RE
 - Volatile + const combination (hardware status register pattern)
 - Volatile in for loops (loop counter pattern)
 - Atomic + volatile combination (ERROR case)
+- Register field implied volatile (ADR-004: `rw` → `volatile`, `ro` → `volatile const`)
 
-**Not tested (not implemented):**
+**Design Note:** Struct member volatile is intentionally not supported. C-Next provides better alternatives:
 
-- Struct member volatile (not supported in C-Next grammar)
-- Register field implied volatile (future enhancement per ADR-108)
+- Register bindings for hardware access (implicit volatile)
+- `atomic` keyword for ISR-shared data (volatile + atomicity)
 
 See `/docs/decisions/adr-108-volatile-keyword.md` for implementation details and usage patterns.
 


### PR DESCRIPTION
## Summary

- Corrects Section 30a to show register field volatile IS implemented (ADR-004)
- Removes struct member volatile from coverage (intentional design choice, not a gap)
- Section 30a is now 6/6 complete (100%)

## Details

**Register field volatile** was incorrectly marked as N/A "not implemented yet":
- ADR-004 specifies `rw` → `volatile uint32_t`, `ro` → `volatile const uint32_t`
- CodeGenerator.ts already implements this (lines 2942-2945)
- Already tested by `register/register-basic.test.cnx`

**Struct member volatile** was listed as N/A but should not be tracked at all:
- C-Next intentionally does not support this
- Register bindings handle hardware access (implicit volatile)
- `atomic` keyword handles ISR-shared data (volatile + atomicity)
- This is a design choice, not a missing feature

## Test plan

- [x] No code changes, documentation only
- [x] Verified existing test `register/register-basic.expected.c` shows volatile is generated

🤖 Generated with [Claude Code](https://claude.com/claude-code)