### PR TITLE
Implement grammar rule coverage tracking (#35)

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -53,6 +53,11 @@ jobs:
           test -f examples/teensy4/blink.c || exit 1
         continue-on-error: true
 
+      - name: Check grammar coverage (Issue #35)
+        id: grammar_coverage
+        run: npm run coverage:grammar:check -- --threshold 80
+        continue-on-error: true
+
       - name: Report results
         if: always()
         run: |
@@ -94,6 +99,13 @@ jobs:
             FAILED=1
           else
             echo "✅ CLI smoke test passed"
+          fi
+
+          if [ "${{ steps.grammar_coverage.outcome }}" != "success" ]; then
+            echo "❌ Grammar coverage check failed (below 80%)"
+            FAILED=1
+          else
+            echo "✅ Grammar coverage check passed"
           fi
 
           echo ""

--- a/GRAMMAR-COVERAGE.md
+++ b/GRAMMAR-COVERAGE.md
@@ -1,0 +1,245 @@
+# Grammar Rule Coverage Report
+
+> Generated: 2026-01-15T03:48:48.957Z
+
+## Summary
+
+| Category     | Total | Covered | Percentage |
+| ------------ | ----- | ------- | ---------- |
+| Parser Rules | 91    | 88      | 96.7%      |
+| Lexer Rules  | 119   | 112     | 94.1%      |
+| **Combined** | 210   | 200     | **95.2%**  |
+
+## Parser Rules
+
+### Covered Parser Rules
+
+| Rule                     | Visit Count |
+| ------------------------ | ----------- |
+| unaryExpression          | 27,795      |
+| postfixExpression        | 26,889      |
+| primaryExpression        | 26,889      |
+| multiplicativeExpression | 26,648      |
+| additiveExpression       | 26,350      |
+| shiftExpression          | 26,242      |
+| bitwiseAndExpression     | 26,211      |
+| bitwiseXorExpression     | 26,200      |
+| bitwiseOrExpression      | 26,180      |
+| relationalExpression     | 25,551      |
+| equalityExpression       | 21,760      |
+| andExpression            | 21,544      |
+| orExpression             | 21,527      |
+| expression               | 21,372      |
+| ternaryExpression        | 21,372      |
+| literal                  | 17,978      |
+| statement                | 16,883      |
+| type                     | 5,591       |
+| postfixOp                | 4,954       |
+| primitiveType            | 4,396       |
+| returnStatement          | 4,155       |
+| assignmentTarget         | 4,140       |
+| assignmentOperator       | 4,140       |
+| assignmentStatement      | 3,915       |
+| ifStatement              | 3,760       |
+| variableDeclaration      | 3,225       |
+| block                    | 2,994       |
+| declaration              | 1,683       |
+| functionDeclaration      | 1,267       |
+| memberAccess             | 951         |
+| argumentList             | 758         |
+| expressionStatement      | 749         |
+| program                  | 573         |
+| scopeMember              | 507         |
+| arrayDimension           | 414         |
+| parameter                | 411         |
+| userType                 | 368         |
+| caseLabel                | 354         |
+| switchCase               | 319         |
+| parameterList            | 316         |
+| structMember             | 312         |
+| arrayAccess              | 259         |
+| visibilityModifier       | 258         |
+| forStatement             | 222         |
+| forInit                  | 219         |
+| forUpdate                | 219         |
+| bitmapMember             | 215         |
+| forVarDecl               | 213         |
+| stringType               | 209         |
+| constModifier            | 165         |
+| structDeclaration        | 141         |
+| thisAccess               | 134         |
+| arrayInitializerElement  | 115         |
+| overflowModifier         | 100         |
+| switchStatement          | 97          |
+| defaultCase              | 90          |
+| registerMember           | 78          |
+| accessModifier           | 78          |
+| enumMember               | 74          |
+| scopeDeclaration         | 73          |
+| fieldInitializer         | 71          |
+| whileStatement           | 69          |
+| sizeofExpression         | 62          |
+| includeDirective         | 53          |
+| qualifiedType            | 42          |
+| criticalStatement        | 41          |
+| atomicModifier           | 37          |
+| structInitializer        | 33          |
+| fieldInitializerList     | 33          |
+| registerDeclaration      | 33          |
+| doWhileStatement         | 31          |
+| arrayInitializer         | 29          |
+| preprocessorDirective    | 28          |
+| bitmapDeclaration        | 25          |
+| bitmapType               | 25          |
+| castExpression           | 24          |
+| enumDeclaration          | 22          |
+| volatileModifier         | 19          |
+| pragmaDirective          | 14          |
+| globalAccess             | 14          |
+| defineDirective          | 9           |
+| thisMemberAccess         | 7           |
+| forAssignment            | 6           |
+| thisArrayAccess          | 6           |
+| conditionalDirective     | 5           |
+| globalArrayAccess        | 4           |
+| scopedType               | 2           |
+| arrayType                | 1           |
+
+### Never Visited Parser Rules
+
+These parser rules were never executed during test runs. Consider adding tests for these language constructs.
+
+- [ ] `globalMemberAccess`
+- [ ] `genericType`
+- [ ] `typeArgument`
+
+## Lexer Rules (Token Types)
+
+### Covered Lexer Rules
+
+| Rule              | Match Count |
+| ----------------- | ----------- |
+| IDENTIFIER        | 22,220      |
+| INTEGER_LITERAL   | 16,145      |
+| SEMI              | 12,788      |
+| LPAREN            | 6,929       |
+| RPAREN            | 6,929       |
+| ASSIGN            | 5,772       |
+| RETURN            | 4,155       |
+| IF                | 3,760       |
+| LBRACKET          | 3,530       |
+| RBRACKET          | 3,529       |
+| LBRACE            | 3,416       |
+| RBRACE            | 3,413       |
+| NEQ               | 3,349       |
+| DOT               | 3,309       |
+| U32               | 1,649       |
+| COMMA             | 1,028       |
+| MINUS             | 984         |
+| HEX_LITERAL       | 903         |
+| PLUS_ASSIGN       | 791         |
+| LT                | 618         |
+| VOID              | 591         |
+| U8                | 559         |
+| FLOAT_LITERAL     | 451         |
+| EQ                | 442         |
+| I32               | 362         |
+| TRUE              | 360         |
+| THIS              | 336         |
+| GT                | 330         |
+| BOOL              | 322         |
+| CASE              | 319         |
+| STRING_LITERAL    | 294         |
+| U16               | 274         |
+| I8                | 269         |
+| PUBLIC            | 258         |
+| I16               | 248         |
+| MINUS_ASSIGN      | 247         |
+| COLON             | 227         |
+| FOR               | 222         |
+| PLUS              | 217         |
+| AND               | 216         |
+| I64               | 213         |
+| STRING            | 209         |
+| U64               | 206         |
+| FALSE             | 167         |
+| CONST             | 165         |
+| F32               | 165         |
+| STRUCT            | 141         |
+| STAR              | 116         |
+| F64               | 114         |
+| AT                | 110         |
+| WHILE             | 100         |
+| SWITCH            | 97          |
+| GLOBAL            | 94          |
+| CHAR_LITERAL      | 93          |
+| DEFAULT           | 90          |
+| BINARY_LITERAL    | 87          |
+| T\_\_0            | 78          |
+| SCOPE             | 73          |
+| SLASH             | 70          |
+| STAR_ASSIGN       | 65          |
+| RSHIFT            | 62          |
+| SIZEOF            | 62          |
+| CLAMP             | 53          |
+| INCLUDE_DIRECTIVE | 53          |
+| OR                | 52          |
+| SLASH_ASSIGN      | 50          |
+| PERCENT_ASSIGN    | 47          |
+| WRAP              | 47          |
+| LSHIFT_ASSIGN     | 46          |
+| RSHIFT_ASSIGN     | 46          |
+| LSHIFT            | 46          |
+| NOT               | 46          |
+| RW                | 43          |
+| GTE               | 43          |
+| CRITICAL          | 41          |
+| BITAND_ASSIGN     | 40          |
+| BITXOR_ASSIGN     | 38          |
+| PERCENT           | 37          |
+| ATOMIC            | 37          |
+| LTE               | 36          |
+| REGISTER          | 33          |
+| ELSE              | 33          |
+| BITOR_ASSIGN      | 32          |
+| BITAND            | 31          |
+| DO                | 31          |
+| SUFFIXED_DECIMAL  | 23          |
+| ENUM              | 22          |
+| BITOR             | 20          |
+| VOLATILE          | 19          |
+| BITNOT            | 18          |
+| WO                | 17          |
+| ISR_TYPE          | 15          |
+| PRAGMA_TARGET     | 14          |
+| BITMAP8           | 12          |
+| BITXOR            | 11          |
+| C_NULL            | 10          |
+| RO                | 10          |
+| SUFFIXED_FLOAT    | 10          |
+| SUFFIXED_HEX      | 7           |
+| SUFFIXED_BINARY   | 7           |
+| DEFINE_FLAG       | 7           |
+| BITMAP16          | 5           |
+| BITMAP32          | 5           |
+| W1C               | 4           |
+| BITMAP24          | 3           |
+| W1S               | 3           |
+| ENDIF_DIRECTIVE   | 2           |
+| IFDEF_DIRECTIVE   | 1           |
+| IFNDEF_DIRECTIVE  | 1           |
+| ELSE_DIRECTIVE    | 1           |
+| DEFINE_FUNCTION   | 1           |
+| DEFINE_WITH_VALUE | 1           |
+
+### Never Matched Lexer Rules
+
+These token types were never matched during test runs. Some may be expected (comments, whitespace) while others may indicate missing test coverage.
+
+- [ ] `PRIVATE`
+- [ ] `NULL`
+- [ ] `DOTDOT`
+- [ ] `DOC_COMMENT`
+- [ ] `LINE_COMMENT`
+- [ ] `BLOCK_COMMENT`
+- [ ] `WS`

--- a/README.md
+++ b/README.md
@@ -763,6 +763,11 @@ npm test -- tests/enum/my.test.cnx    # Run single test file
 # Code quality (auto-run by pre-commit hooks)
 npm run prettier:fix   # Format all code
 npm run eslint:check   # Check for lint errors
+
+# Coverage tracking
+npm run coverage:check           # Feature coverage report
+npm run coverage:grammar         # Grammar rule coverage (generates GRAMMAR-COVERAGE.md)
+npm run coverage:grammar:check   # Grammar coverage with threshold check (CI)
 ```
 
 **Note:** C-Next runs directly via `tsx` without a build step. The `typecheck` command validates types only and does not generate any output files.

--- a/docs/LANGUAGE-FEATURE-TESTING-RESEARCH.md
+++ b/docs/LANGUAGE-FEATURE-TESTING-RESEARCH.md
@@ -397,28 +397,42 @@ Untested features (HIGH priority):
   ❌ 7-switch-nested
 ```
 
-### Phase 2: Grammar Rule Coverage (Week 2)
+### Phase 2: Grammar Rule Coverage (Week 2) ✅ IMPLEMENTED
 
-**Create:** `scripts/grammar-coverage.ts`
+> **Implemented:** Issue #35 - See `scripts/grammar-coverage.ts`
+
+**Commands:**
+
+```bash
+npm run coverage:grammar         # Generate GRAMMAR-COVERAGE.md
+npm run coverage:grammar:check   # CI check with 80% threshold
+npm run coverage:grammar:console # Console output only
+```
+
+**Current Status (95.2% combined coverage):**
+
+- 91 parser rules, 88 covered (96.7%)
+- 119 lexer rules, 112 covered (94.1%)
 
 **Features:**
 
-1. Instrument transpiler with rule visitor
-2. Track which grammar rules execute
-3. Generate report of covered/uncovered rules
+1. ✅ Instrument transpiler with ANTLR ParseTreeListener
+2. ✅ Track which parser and lexer rules execute
+3. ✅ Generate markdown and console reports
+4. ✅ CI integration with configurable threshold
 
 **Output:**
 
 ```
 Grammar Rule Coverage:
-  Total rules: 156
-  Executed: 142 (91%)
-  Never executed: 14 (9%)
+  Total rules: 210
+  Executed: 200 (95.2%)
+  Never executed: 10 (4.8%)
 
-Untested grammar rules:
-  ❌ inline_assembly
-  ❌ bitfield_range
-  ❌ scope_operator (rare usage)
+Never Visited Parser Rules:
+  ❌ globalMemberAccess
+  ❌ genericType
+  ❌ typeArgument
 ```
 
 ### Phase 3: FileCheck Integration (Week 3)

--- a/package.json
+++ b/package.json
@@ -30,7 +30,10 @@
     "coverage:check": "tsx scripts/coverage-checker.ts check",
     "coverage:report": "tsx scripts/coverage-checker.ts report",
     "coverage:gaps": "tsx scripts/coverage-checker.ts gaps",
-    "coverage:ids": "tsx scripts/coverage-checker.ts ids"
+    "coverage:ids": "tsx scripts/coverage-checker.ts ids",
+    "coverage:grammar": "tsx scripts/grammar-coverage.ts report",
+    "coverage:grammar:check": "tsx scripts/grammar-coverage.ts check",
+    "coverage:grammar:console": "tsx scripts/grammar-coverage.ts console"
   },
   "keywords": [
     "c",

--- a/scripts/grammar-coverage.ts
+++ b/scripts/grammar-coverage.ts
@@ -1,0 +1,389 @@
+#!/usr/bin/env tsx
+/**
+ * C-Next Grammar Coverage Tracker (Issue #35)
+ *
+ * Tracks which ANTLR grammar rules are executed during test runs
+ * to identify dead grammar code and untested language constructs.
+ *
+ * Usage:
+ *   npm run coverage:grammar         - Generate coverage report
+ *   npm run coverage:grammar:check   - Check coverage (fail if below threshold)
+ */
+
+import { readFileSync, readdirSync, statSync, writeFileSync } from "fs";
+import { join, dirname, relative } from "path";
+import { fileURLToPath } from "url";
+
+import transpile from "../src/lib/transpiler";
+import IGrammarCoverageReport from "../src/analysis/types/IGrammarCoverageReport";
+import { CNextLexer } from "../src/parser/grammar/CNextLexer";
+import { CNextParser } from "../src/parser/grammar/CNextParser";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const rootDir = join(__dirname, "..");
+
+// ANSI colors
+const colors = {
+  reset: "\x1b[0m",
+  red: "\x1b[31m",
+  green: "\x1b[32m",
+  yellow: "\x1b[33m",
+  cyan: "\x1b[36m",
+  dim: "\x1b[2m",
+};
+
+// Default coverage threshold (percentage)
+const DEFAULT_THRESHOLD = 80;
+
+/**
+ * Recursively find all .test.cnx files
+ */
+function findTestFiles(dir: string): string[] {
+  const files: string[] = [];
+
+  function walk(currentDir: string): void {
+    const entries = readdirSync(currentDir);
+
+    for (const entry of entries) {
+      const fullPath = join(currentDir, entry);
+      const stat = statSync(fullPath);
+
+      if (stat.isDirectory()) {
+        walk(fullPath);
+      } else if (entry.endsWith(".test.cnx")) {
+        files.push(fullPath);
+      }
+    }
+  }
+
+  walk(dir);
+  return files;
+}
+
+/**
+ * Aggregate coverage from all test files
+ */
+function aggregateCoverage(testsDir: string): IGrammarCoverageReport {
+  const testFiles = findTestFiles(testsDir);
+  const parserVisits = new Map<string, number>();
+  const lexerVisits = new Map<string, number>();
+
+  for (const file of testFiles) {
+    try {
+      const source = readFileSync(file, "utf-8");
+      const result = transpile(source, { collectGrammarCoverage: true });
+
+      if (result.grammarCoverage) {
+        for (const [rule, count] of result.grammarCoverage.parserRuleVisits) {
+          const current = parserVisits.get(rule) || 0;
+          parserVisits.set(rule, current + count);
+        }
+        for (const [rule, count] of result.grammarCoverage.lexerRuleVisits) {
+          const current = lexerVisits.get(rule) || 0;
+          lexerVisits.set(rule, current + count);
+        }
+      }
+    } catch {
+      // Already logged above
+    }
+  }
+
+  const totalParserRules = CNextParser.ruleNames.length;
+  const totalLexerRules = CNextLexer.ruleNames.length;
+  const visitedParserRules = parserVisits.size;
+  const visitedLexerRules = lexerVisits.size;
+
+  const neverVisitedParserRules = CNextParser.ruleNames.filter(
+    (name) => !parserVisits.has(name),
+  );
+  const neverVisitedLexerRules = CNextLexer.ruleNames.filter(
+    (name) => !lexerVisits.has(name),
+  );
+
+  const parserCoveragePercentage =
+    totalParserRules > 0 ? (visitedParserRules / totalParserRules) * 100 : 0;
+  const lexerCoveragePercentage =
+    totalLexerRules > 0 ? (visitedLexerRules / totalLexerRules) * 100 : 0;
+  const combinedTotal = totalParserRules + totalLexerRules;
+  const combinedVisited = visitedParserRules + visitedLexerRules;
+  const combinedCoveragePercentage =
+    combinedTotal > 0 ? (combinedVisited / combinedTotal) * 100 : 0;
+
+  return {
+    totalParserRules,
+    totalLexerRules,
+    visitedParserRules,
+    visitedLexerRules,
+    neverVisitedParserRules,
+    neverVisitedLexerRules,
+    parserRuleVisits: parserVisits,
+    lexerRuleVisits: lexerVisits,
+    parserCoveragePercentage,
+    lexerCoveragePercentage,
+    combinedCoveragePercentage,
+  };
+}
+
+/**
+ * Generate console report
+ */
+function generateConsoleReport(report: IGrammarCoverageReport): void {
+  console.log("\n" + "=".repeat(50));
+  console.log("  Grammar Rule Coverage Report");
+  console.log("=".repeat(50) + "\n");
+
+  // Summary
+  console.log(`${colors.cyan}Parser Rules:${colors.reset}`);
+  console.log(`  Total:    ${report.totalParserRules}`);
+  console.log(
+    `  Covered:  ${report.visitedParserRules} (${report.parserCoveragePercentage.toFixed(1)}%)`,
+  );
+  console.log(`  Missing:  ${report.neverVisitedParserRules.length}`);
+
+  console.log(`\n${colors.cyan}Lexer Rules (Token Types):${colors.reset}`);
+  console.log(`  Total:    ${report.totalLexerRules}`);
+  console.log(
+    `  Covered:  ${report.visitedLexerRules} (${report.lexerCoveragePercentage.toFixed(1)}%)`,
+  );
+  console.log(`  Missing:  ${report.neverVisitedLexerRules.length}`);
+
+  console.log(`\n${colors.cyan}Combined Coverage:${colors.reset}`);
+  const combinedColor =
+    report.combinedCoveragePercentage >= 80
+      ? colors.green
+      : report.combinedCoveragePercentage >= 60
+        ? colors.yellow
+        : colors.red;
+  console.log(
+    `  ${combinedColor}${report.combinedCoveragePercentage.toFixed(1)}%${colors.reset}`,
+  );
+
+  // Top 10 most used parser rules
+  console.log(`\n${colors.cyan}Top 10 Most Used Parser Rules:${colors.reset}`);
+  const sortedParser = Array.from(report.parserRuleVisits.entries())
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, 10);
+
+  for (const [rule, count] of sortedParser) {
+    console.log(`  ${rule.padEnd(35)} ${count.toLocaleString()} times`);
+  }
+
+  // Never visited parser rules
+  if (report.neverVisitedParserRules.length > 0) {
+    console.log(`\n${colors.yellow}Never Visited Parser Rules:${colors.reset}`);
+    for (const rule of report.neverVisitedParserRules) {
+      console.log(`  ${colors.red}✗${colors.reset} ${rule}`);
+    }
+  } else {
+    console.log(`\n${colors.green}✓ All parser rules covered!${colors.reset}`);
+  }
+
+  // Never visited lexer rules (only show notable ones)
+  const notableMissing = report.neverVisitedLexerRules.filter(
+    (rule) =>
+      !rule.startsWith("T__") && // Skip anonymous tokens
+      rule !== "WS" && // Skip whitespace
+      !rule.includes("COMMENT"), // Skip comments
+  );
+
+  if (notableMissing.length > 0) {
+    console.log(
+      `\n${colors.yellow}Never Matched Lexer Rules (Notable):${colors.reset}`,
+    );
+    for (const rule of notableMissing.slice(0, 20)) {
+      console.log(`  ${colors.red}✗${colors.reset} ${rule}`);
+    }
+    if (notableMissing.length > 20) {
+      console.log(
+        `  ${colors.dim}... and ${notableMissing.length - 20} more${colors.reset}`,
+      );
+    }
+  }
+
+  console.log("");
+}
+
+/**
+ * Generate markdown report
+ */
+function generateMarkdownReport(report: IGrammarCoverageReport): string {
+  const lines: string[] = [];
+  const timestamp = new Date().toISOString();
+
+  lines.push("# Grammar Rule Coverage Report");
+  lines.push("");
+  lines.push(`> Generated: ${timestamp}`);
+  lines.push("");
+
+  // Summary
+  lines.push("## Summary");
+  lines.push("");
+  lines.push("| Category | Total | Covered | Percentage |");
+  lines.push("|----------|-------|---------|------------|");
+  lines.push(
+    `| Parser Rules | ${report.totalParserRules} | ${report.visitedParserRules} | ${report.parserCoveragePercentage.toFixed(1)}% |`,
+  );
+  lines.push(
+    `| Lexer Rules | ${report.totalLexerRules} | ${report.visitedLexerRules} | ${report.lexerCoveragePercentage.toFixed(1)}% |`,
+  );
+  lines.push(
+    `| **Combined** | ${report.totalParserRules + report.totalLexerRules} | ${report.visitedParserRules + report.visitedLexerRules} | **${report.combinedCoveragePercentage.toFixed(1)}%** |`,
+  );
+  lines.push("");
+
+  // Parser rules coverage
+  lines.push("## Parser Rules");
+  lines.push("");
+  lines.push("### Covered Parser Rules");
+  lines.push("");
+  lines.push("| Rule | Visit Count |");
+  lines.push("|------|-------------|");
+
+  const sortedParser = Array.from(report.parserRuleVisits.entries()).sort(
+    (a, b) => b[1] - a[1],
+  );
+
+  for (const [rule, count] of sortedParser) {
+    lines.push(`| ${rule} | ${count.toLocaleString()} |`);
+  }
+  lines.push("");
+
+  // Never visited parser rules
+  if (report.neverVisitedParserRules.length > 0) {
+    lines.push("### Never Visited Parser Rules");
+    lines.push("");
+    lines.push(
+      "These parser rules were never executed during test runs. Consider adding tests for these language constructs.",
+    );
+    lines.push("");
+    for (const rule of report.neverVisitedParserRules) {
+      lines.push(`- [ ] \`${rule}\``);
+    }
+    lines.push("");
+  } else {
+    lines.push("### ✅ All Parser Rules Covered");
+    lines.push("");
+  }
+
+  // Lexer rules coverage
+  lines.push("## Lexer Rules (Token Types)");
+  lines.push("");
+  lines.push("### Covered Lexer Rules");
+  lines.push("");
+  lines.push("| Rule | Match Count |");
+  lines.push("|------|-------------|");
+
+  const sortedLexer = Array.from(report.lexerRuleVisits.entries()).sort(
+    (a, b) => b[1] - a[1],
+  );
+
+  for (const [rule, count] of sortedLexer) {
+    lines.push(`| ${rule} | ${count.toLocaleString()} |`);
+  }
+  lines.push("");
+
+  // Never visited lexer rules
+  if (report.neverVisitedLexerRules.length > 0) {
+    lines.push("### Never Matched Lexer Rules");
+    lines.push("");
+    lines.push(
+      "These token types were never matched during test runs. Some may be expected (comments, whitespace) while others may indicate missing test coverage.",
+    );
+    lines.push("");
+    for (const rule of report.neverVisitedLexerRules) {
+      lines.push(`- [ ] \`${rule}\``);
+    }
+    lines.push("");
+  } else {
+    lines.push("### ✅ All Lexer Rules Matched");
+    lines.push("");
+  }
+
+  return lines.join("\n");
+}
+
+function printUsage(): void {
+  console.log(`
+Usage: tsx scripts/grammar-coverage.ts [mode] [options]
+
+Modes:
+  report    - Generate GRAMMAR-COVERAGE.md (default)
+  check     - Check coverage and exit with error if below threshold
+  console   - Print report to console only
+
+Options:
+  --threshold <N>  - Set minimum coverage percentage (default: ${DEFAULT_THRESHOLD})
+  --help           - Show this help message
+`);
+}
+
+async function main(): Promise<void> {
+  const args = process.argv.slice(2);
+
+  if (args.includes("--help") || args.includes("-h")) {
+    printUsage();
+    process.exit(0);
+  }
+
+  // Parse arguments
+  let mode = "report";
+  let threshold = DEFAULT_THRESHOLD;
+
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    if (arg === "--threshold" && args[i + 1]) {
+      threshold = parseFloat(args[i + 1]);
+      i++;
+    } else if (!arg.startsWith("--")) {
+      mode = arg;
+    }
+  }
+
+  const testsDir = join(rootDir, "tests");
+  const reportPath = join(rootDir, "GRAMMAR-COVERAGE.md");
+
+  console.log(
+    `${colors.yellow}Scanning test files for grammar coverage...${colors.reset}`,
+  );
+
+  const testFiles = findTestFiles(testsDir);
+  console.log(`  Found ${testFiles.length} test files`);
+
+  console.log(`${colors.yellow}Aggregating grammar coverage...${colors.reset}`);
+  const report = aggregateCoverage(testsDir);
+
+  switch (mode) {
+    case "console":
+      generateConsoleReport(report);
+      break;
+
+    case "check":
+      generateConsoleReport(report);
+      if (report.combinedCoveragePercentage < threshold) {
+        console.error(
+          `\n${colors.red}Error: Grammar coverage (${report.combinedCoveragePercentage.toFixed(1)}%) is below threshold (${threshold}%)${colors.reset}`,
+        );
+        process.exit(1);
+      }
+      console.log(
+        `\n${colors.green}✓ Grammar coverage meets threshold (${threshold}%)${colors.reset}`,
+      );
+      break;
+
+    case "report":
+    default:
+      generateConsoleReport(report);
+      const markdown = generateMarkdownReport(report);
+      writeFileSync(reportPath, markdown, "utf-8");
+      console.log(
+        `${colors.green}Report written to ${relative(rootDir, reportPath)}${colors.reset}`,
+      );
+      break;
+  }
+}
+
+main().catch((err) => {
+  console.error(`${colors.red}Error: ${err.message}${colors.reset}`);
+  process.exit(1);
+});

--- a/src/analysis/GrammarCoverageListener.ts
+++ b/src/analysis/GrammarCoverageListener.ts
@@ -1,0 +1,150 @@
+/**
+ * Grammar Coverage Listener
+ * Tracks which ANTLR grammar rules are executed during parsing
+ *
+ * This listener attaches to the parser and records:
+ * - Parser rules visited (e.g., program, expression, statement)
+ * - Lexer rules matched (e.g., IDENTIFIER, INTEGER_LITERAL)
+ *
+ * Used to identify dead grammar code and untested language constructs.
+ */
+
+import {
+  ErrorNode,
+  ParserRuleContext,
+  ParseTreeListener,
+  TerminalNode,
+} from "antlr4ng";
+import IGrammarCoverageReport from "./types/IGrammarCoverageReport";
+
+class GrammarCoverageListener implements ParseTreeListener {
+  private parserRuleVisits: Map<string, number> = new Map();
+  private lexerRuleVisits: Map<string, number> = new Map();
+  private readonly parserRuleNames: string[];
+  private readonly lexerRuleNames: string[];
+
+  constructor(parserRuleNames: string[], lexerRuleNames: string[]) {
+    this.parserRuleNames = parserRuleNames;
+    this.lexerRuleNames = lexerRuleNames;
+  }
+
+  /**
+   * Called when entering every parser rule
+   */
+  enterEveryRule(ctx: ParserRuleContext): void {
+    const ruleName = this.parserRuleNames[ctx.ruleIndex];
+    if (ruleName) {
+      const count = this.parserRuleVisits.get(ruleName) || 0;
+      this.parserRuleVisits.set(ruleName, count + 1);
+    }
+  }
+
+  /**
+   * Called when exiting every parser rule
+   */
+  exitEveryRule(_ctx: ParserRuleContext): void {
+    // Not needed for coverage tracking
+  }
+
+  /**
+   * Called when visiting a terminal node (token)
+   */
+  visitTerminal(node: TerminalNode): void {
+    const tokenType = node.symbol.type;
+    // Token type -1 is EOF, skip it
+    if (tokenType < 0) return;
+
+    // Token types are 1-indexed in ANTLR, but the array is 0-indexed
+    // The first element (index 0) corresponds to token type 1
+    const ruleName = this.lexerRuleNames[tokenType - 1];
+    if (ruleName) {
+      const count = this.lexerRuleVisits.get(ruleName) || 0;
+      this.lexerRuleVisits.set(ruleName, count + 1);
+    }
+  }
+
+  /**
+   * Called when visiting an error node
+   */
+  visitErrorNode(_node: ErrorNode): void {
+    // Track error nodes if needed in the future
+  }
+
+  /**
+   * Merge coverage from another listener (for aggregating across files)
+   */
+  merge(other: GrammarCoverageListener): void {
+    for (const [rule, count] of other.parserRuleVisits) {
+      const current = this.parserRuleVisits.get(rule) || 0;
+      this.parserRuleVisits.set(rule, current + count);
+    }
+    for (const [rule, count] of other.lexerRuleVisits) {
+      const current = this.lexerRuleVisits.get(rule) || 0;
+      this.lexerRuleVisits.set(rule, current + count);
+    }
+  }
+
+  /**
+   * Reset all coverage counters
+   */
+  reset(): void {
+    this.parserRuleVisits.clear();
+    this.lexerRuleVisits.clear();
+  }
+
+  /**
+   * Get the current parser rule visit counts
+   */
+  getParserRuleVisits(): Map<string, number> {
+    return new Map(this.parserRuleVisits);
+  }
+
+  /**
+   * Get the current lexer rule visit counts
+   */
+  getLexerRuleVisits(): Map<string, number> {
+    return new Map(this.lexerRuleVisits);
+  }
+
+  /**
+   * Generate a coverage report
+   */
+  getReport(): IGrammarCoverageReport {
+    const totalParserRules = this.parserRuleNames.length;
+    const totalLexerRules = this.lexerRuleNames.length;
+    const visitedParserRules = this.parserRuleVisits.size;
+    const visitedLexerRules = this.lexerRuleVisits.size;
+
+    const neverVisitedParserRules = this.parserRuleNames.filter(
+      (name) => !this.parserRuleVisits.has(name),
+    );
+    const neverVisitedLexerRules = this.lexerRuleNames.filter(
+      (name) => !this.lexerRuleVisits.has(name),
+    );
+
+    const parserCoveragePercentage =
+      totalParserRules > 0 ? (visitedParserRules / totalParserRules) * 100 : 0;
+    const lexerCoveragePercentage =
+      totalLexerRules > 0 ? (visitedLexerRules / totalLexerRules) * 100 : 0;
+    const combinedTotal = totalParserRules + totalLexerRules;
+    const combinedVisited = visitedParserRules + visitedLexerRules;
+    const combinedCoveragePercentage =
+      combinedTotal > 0 ? (combinedVisited / combinedTotal) * 100 : 0;
+
+    return {
+      totalParserRules,
+      totalLexerRules,
+      visitedParserRules,
+      visitedLexerRules,
+      neverVisitedParserRules,
+      neverVisitedLexerRules,
+      parserRuleVisits: new Map(this.parserRuleVisits),
+      lexerRuleVisits: new Map(this.lexerRuleVisits),
+      parserCoveragePercentage,
+      lexerCoveragePercentage,
+      combinedCoveragePercentage,
+    };
+  }
+}
+
+export default GrammarCoverageListener;

--- a/src/analysis/types/IGrammarCoverageReport.ts
+++ b/src/analysis/types/IGrammarCoverageReport.ts
@@ -1,0 +1,29 @@
+/**
+ * Grammar rule coverage report aggregating statistics across parsed files
+ */
+interface IGrammarCoverageReport {
+  /** Total number of parser rules in the grammar */
+  totalParserRules: number;
+  /** Total number of lexer rules in the grammar */
+  totalLexerRules: number;
+  /** Number of parser rules that were visited at least once */
+  visitedParserRules: number;
+  /** Number of lexer rules (token types) that were matched at least once */
+  visitedLexerRules: number;
+  /** Parser rules that were never visited */
+  neverVisitedParserRules: string[];
+  /** Lexer rules that were never matched */
+  neverVisitedLexerRules: string[];
+  /** Visit counts for each parser rule */
+  parserRuleVisits: Map<string, number>;
+  /** Match counts for each lexer rule (token type) */
+  lexerRuleVisits: Map<string, number>;
+  /** Coverage percentage for parser rules (0-100) */
+  parserCoveragePercentage: number;
+  /** Coverage percentage for lexer rules (0-100) */
+  lexerCoveragePercentage: number;
+  /** Combined coverage percentage (0-100) */
+  combinedCoveragePercentage: number;
+}
+
+export default IGrammarCoverageReport;

--- a/src/lib/types/ITranspileOptions.ts
+++ b/src/lib/types/ITranspileOptions.ts
@@ -8,6 +8,8 @@ interface ITranspileOptions {
   debugMode?: boolean;
   /** ADR-049: Target platform for atomic code generation (e.g., "teensy41", "cortex-m0") */
   target?: string;
+  /** Issue #35: Collect grammar rule coverage during parsing */
+  collectGrammarCoverage?: boolean;
 }
 
 export default ITranspileOptions;

--- a/src/lib/types/ITranspileResult.ts
+++ b/src/lib/types/ITranspileResult.ts
@@ -1,4 +1,5 @@
 import ITranspileError from "./ITranspileError";
+import IGrammarCoverageReport from "../../analysis/types/IGrammarCoverageReport";
 
 /**
  * Result of transpiling C-Next source to C
@@ -12,6 +13,8 @@ interface ITranspileResult {
   errors: ITranspileError[];
   /** Number of top-level declarations found */
   declarationCount: number;
+  /** Issue #35: Grammar coverage report (if collectGrammarCoverage was enabled) */
+  grammarCoverage?: IGrammarCoverageReport;
 }
 
 export default ITranspileResult;


### PR DESCRIPTION
## Summary

- Implements automated tracking of which ANTLR grammar rules are executed during test runs
- Identifies dead grammar code and untested language constructs
- Adds CI integration with configurable coverage threshold (default 80%)

## Features

- **GrammarCoverageListener** - ANTLR ParseTreeListener that tracks parser and lexer rule visits
- **Transpiler integration** - New `collectGrammarCoverage` option in transpiler
- **Coverage script** - `scripts/grammar-coverage.ts` generates markdown and console reports
- **CI check** - Fails if grammar coverage drops below 80%

## Current Coverage: 95.2%

| Category | Total | Covered | Percentage |
|----------|-------|---------|------------|
| Parser Rules | 91 | 88 | 96.7% |
| Lexer Rules | 119 | 112 | 94.1% |
| **Combined** | 210 | 200 | **95.2%** |

## Commands Added

```bash
npm run coverage:grammar         # Generate GRAMMAR-COVERAGE.md
npm run coverage:grammar:check   # CI check with threshold
npm run coverage:grammar:console # Console output only
```

## Files Changed

- **New:** `src/analysis/GrammarCoverageListener.ts` - ANTLR listener
- **New:** `src/analysis/types/IGrammarCoverageReport.ts` - Type definitions
- **New:** `scripts/grammar-coverage.ts` - Coverage script
- **New:** `GRAMMAR-COVERAGE.md` - Generated report
- **Modified:** `src/lib/transpiler.ts` - Integrated coverage collection
- **Modified:** `.github/workflows/pr-checks.yml` - Added CI step
- **Modified:** `package.json` - Added npm scripts
- **Modified:** `README.md` - Documented commands

## Test plan

- [x] Run `npm run coverage:grammar` - Generates report successfully
- [x] Run `npm run coverage:grammar:check` - Passes with 95.2% coverage
- [x] Run existing tests - All pass
- [x] TypeScript compiles without errors
- [x] Linting passes

Closes #35

🤖 Generated with [Claude Code](https://claude.com/claude-code)