### PR TITLE
Refactor TypeResolver to be independent from CodeGenerator (#61)

### DIFF
--- a/src/codegen/CodeGenerator.ts
+++ b/src/codegen/CodeGenerator.ts
@@ -422,9 +422,6 @@ export default class CodeGenerator {
       this.commentExtractor = null;
     }
 
-    // Initialize type resolver for type classification and validation
-    this.typeResolver = new TypeResolver(this);
-
     // ADR-049: Determine target capabilities with priority: CLI > pragma > default
     const targetCapabilities = this.resolveTargetCapabilities(
       tree,
@@ -474,6 +471,14 @@ export default class CodeGenerator {
     for (const [scopeName, members] of this.symbols.scopeMembers) {
       this.context.scopeMembers.set(scopeName, members);
     }
+
+    // Issue #61: Initialize type resolver with clean dependencies
+    this.typeResolver = new TypeResolver({
+      symbols: this.symbols,
+      symbolTable: this.symbolTable,
+      typeRegistry: this.context.typeRegistry,
+      resolveIdentifier: (name: string) => this.resolveIdentifier(name),
+    });
 
     // Collect function/callback information (not yet extracted to SymbolCollector)
     this.collectFunctionsAndCallbacks(tree);

--- a/src/codegen/types/ITypeResolverDeps.ts
+++ b/src/codegen/types/ITypeResolverDeps.ts
@@ -1,0 +1,23 @@
+/**
+ * Dependencies for TypeResolver - allows TypeResolver to be independent of CodeGenerator
+ * Issue #61: Extracted dependencies for better separation of concerns
+ */
+import SymbolCollector from "../SymbolCollector";
+import SymbolTable from "../../symbols/SymbolTable";
+import TTypeInfo from "./TTypeInfo";
+
+interface ITypeResolverDeps {
+  /** Symbol information from C-Next source (Issue #60) */
+  symbols: SymbolCollector | null;
+
+  /** Symbol table for C header struct lookups */
+  symbolTable: SymbolTable | null;
+
+  /** Type registry for variable type information */
+  typeRegistry: Map<string, TTypeInfo>;
+
+  /** Callback to resolve identifiers to scoped names */
+  resolveIdentifier: (name: string) => string;
+}
+
+export default ITypeResolverDeps;


### PR DESCRIPTION
## Summary

- Create `ITypeResolverDeps` interface for clean dependency injection
- Replace `CodeGenerator` reference with explicit dependencies
- Move `getPostfixExpression()` method into TypeResolver
- Remove all bracket-notation private member access (`["..."]` pattern)

## Changes

| File | Change |
|------|--------|
| `src/codegen/types/ITypeResolverDeps.ts` | New interface defining TypeResolver dependencies |
| `src/codegen/TypeResolver.ts` | Refactored to use injected deps instead of CodeGenerator |
| `src/codegen/CodeGenerator.ts` | Updated instantiation to pass clean dependencies |

## Benefits

- TypeResolver is now independently testable
- Dependencies are explicit and visible
- Removes unsafe private member access via bracket notation
- Better separation of concerns

## Test plan

- [x] TypeScript type-checks clean (`npm run typecheck`)
- [x] OxLint passes (`npm run oxlint:check`)
- [x] Prettier passes (`npm run prettier:check`)
- [x] All 579 tests pass (`npm test`)

Closes #61

🤖 Generated with [Claude Code](https://claude.com/claude-code)