### PR TITLE
Fix default visibility from public to private (ADR-016 compliance)

### DIFF
--- a/src/codegen/CodeGenerator.ts
+++ b/src/codegen/CodeGenerator.ts
@@ -2424,7 +2424,7 @@ export default class CodeGenerator {
     lines.push(`/* Scope: ${name} */`);
 
     for (const member of ctx.scopeMember()) {
-      const visibility = member.visibilityModifier()?.getText() || "public";
+      const visibility = member.visibilityModifier()?.getText() || "private";
       const isPrivate = visibility === "private";
 
       if (member.variableDeclaration()) {

--- a/tests/atomic/atomic-in-scope.expected.c
+++ b/tests/atomic/atomic-in-scope.expected.c
@@ -23,8 +23,8 @@ static inline uint32_t cnx_clamp_add_u32(uint32_t a, uint64_t b) {
 }
 
 /* Scope: Counter */
-uint32_t Counter_value = 0;
-uint8_t Counter_overflowCount = 0;
+static uint32_t Counter_value = 0;
+static uint8_t Counter_overflowCount = 0;
 
 void Counter_increment(void) {
     Counter_value = cnx_clamp_add_u32(Counter_value, 1);
@@ -43,8 +43,8 @@ uint32_t Counter_get(void) {
 }
 
 /* Scope: Timer */
-uint32_t Timer_ticks = 0;
-uint16_t Timer_period = 1000;
+static uint32_t Timer_ticks = 0;
+static uint16_t Timer_period = 1000;
 
 void Timer_tick(void) {
     Timer_ticks += 1;

--- a/tests/atomic/atomic-in-scope.test.cnx
+++ b/tests/atomic/atomic-in-scope.test.cnx
@@ -9,19 +9,19 @@ scope Counter {
     atomic u32 value <- 0;
     atomic u8 overflowCount <- 0;
 
-    void increment() {
+    public void increment() {
         this.value +<- 1;
     }
 
-    void incrementBy(u32 delta) {
+    public void incrementBy(u32 delta) {
         this.value +<- delta;
     }
 
-    void reset() {
+    public void reset() {
         this.value <- 0;
     }
 
-    u32 get() {
+    public u32 get() {
         return this.value;
     }
 }
@@ -30,15 +30,15 @@ scope Timer {
     atomic wrap u32 ticks <- 0;
     atomic clamp u16 period <- 1000;
 
-    void tick() {
+    public void tick() {
         this.ticks +<- 1;
     }
 
-    void setPeriod(u16 p) {
+    public void setPeriod(u16 p) {
         this.period <- p;
     }
 
-    void adjustPeriod(u16 delta) {
+    public void adjustPeriod(u16 delta) {
         this.period +<- delta;
     }
 }

--- a/tests/compound-assign/global-member-compound.test.cnx
+++ b/tests/compound-assign/global-member-compound.test.cnx
@@ -10,7 +10,7 @@ u32 gBits <- 0;
 
 scope Worker {
     // ===== SUBTRACTION (-<-) =====
-    i32 testSubtraction() {
+    public i32 testSubtraction() {
         global.gValue <- 100;
         global.gValue -<- 30;
         if (global.gValue != 70) return 1;
@@ -23,7 +23,7 @@ scope Worker {
     }
 
     // ===== MULTIPLICATION (*<-) =====
-    i32 testMultiplication() {
+    public i32 testMultiplication() {
         global.gValue <- 7;
         global.gValue *<- 6;
         if (global.gValue != 42) return 10;
@@ -40,7 +40,7 @@ scope Worker {
     }
 
     // ===== DIVISION (/<-) =====
-    i32 testDivision() {
+    public i32 testDivision() {
         global.gValue <- 100;
         global.gValue /<- 5;
         if (global.gValue != 20) return 20;
@@ -57,7 +57,7 @@ scope Worker {
     }
 
     // ===== MODULO (%<-) =====
-    i32 testModulo() {
+    public i32 testModulo() {
         global.gValue <- 17;
         global.gValue %<- 5;
         if (global.gValue != 2) return 30;
@@ -74,7 +74,7 @@ scope Worker {
     }
 
     // ===== BITWISE AND (&<-) =====
-    i32 testBitwiseAnd() {
+    public i32 testBitwiseAnd() {
         global.gBits <- 0xFF;
         global.gBits &<- 0x0F;
         if (global.gBits != 0x0F) return 40;
@@ -91,7 +91,7 @@ scope Worker {
     }
 
     // ===== BITWISE OR (|<-) =====
-    i32 testBitwiseOr() {
+    public i32 testBitwiseOr() {
         global.gBits <- 0xF0;
         global.gBits |<- 0x0F;
         if (global.gBits != 0xFF) return 50;
@@ -108,7 +108,7 @@ scope Worker {
     }
 
     // ===== BITWISE XOR (^<-) =====
-    i32 testBitwiseXor() {
+    public i32 testBitwiseXor() {
         global.gBits <- 0xFF;
         global.gBits ^<- 0xFF;
         if (global.gBits != 0) return 60;
@@ -125,7 +125,7 @@ scope Worker {
     }
 
     // ===== LEFT SHIFT (<<<-) =====
-    i32 testLeftShift() {
+    public i32 testLeftShift() {
         global.gBits <- 1;
         global.gBits <<<- 4;
         if (global.gBits != 16) return 70;
@@ -142,7 +142,7 @@ scope Worker {
     }
 
     // ===== RIGHT SHIFT (>><-) =====
-    i32 testRightShift() {
+    public i32 testRightShift() {
         global.gBits <- 256;
         global.gBits >><- 4;
         if (global.gBits != 16) return 80;

--- a/tests/compound-assign/this-member-compound.expected.c
+++ b/tests/compound-assign/this-member-compound.expected.c
@@ -28,10 +28,10 @@ static inline int32_t cnx_clamp_sub_i32(int32_t a, int64_t b) {
 // Validates: Compound operators -<-, *<-, /<-, %<-, &<-, |<-, ^<-, <<<-, >><- on scope-local members
 // Note: +<- is already tested in scope/scope-compound-assign.test.cnx
 /* Scope: Calculator */
-int32_t Calculator_value = 0;
-uint32_t Calculator_bits = 0;
+static int32_t Calculator_value = 0;
+static uint32_t Calculator_bits = 0;
 
-int32_t Calculator_testSubtraction(void) {
+static int32_t Calculator_testSubtraction(void) {
     Calculator_value = 100;
     Calculator_value = cnx_clamp_sub_i32(Calculator_value, 30);
     if (Calculator_value != 70) return 1;
@@ -41,7 +41,7 @@ int32_t Calculator_testSubtraction(void) {
     return 0;
 }
 
-int32_t Calculator_testMultiplication(void) {
+static int32_t Calculator_testMultiplication(void) {
     Calculator_value = 7;
     Calculator_value = cnx_clamp_mul_i32(Calculator_value, 6);
     if (Calculator_value != 42) return 10;
@@ -54,7 +54,7 @@ int32_t Calculator_testMultiplication(void) {
     return 0;
 }
 
-int32_t Calculator_testDivision(void) {
+static int32_t Calculator_testDivision(void) {
     Calculator_value = 100;
     Calculator_value /= 5;
     if (Calculator_value != 20) return 20;
@@ -67,7 +67,7 @@ int32_t Calculator_testDivision(void) {
     return 0;
 }
 
-int32_t Calculator_testModulo(void) {
+static int32_t Calculator_testModulo(void) {
     Calculator_value = 17;
     Calculator_value %= 5;
     if (Calculator_value != 2) return 30;
@@ -80,7 +80,7 @@ int32_t Calculator_testModulo(void) {
     return 0;
 }
 
-int32_t Calculator_testBitwiseAnd(void) {
+static int32_t Calculator_testBitwiseAnd(void) {
     Calculator_bits = 0xFF;
     Calculator_bits &= 0x0F;
     if (Calculator_bits != 0x0F) return 40;
@@ -93,7 +93,7 @@ int32_t Calculator_testBitwiseAnd(void) {
     return 0;
 }
 
-int32_t Calculator_testBitwiseOr(void) {
+static int32_t Calculator_testBitwiseOr(void) {
     Calculator_bits = 0xF0;
     Calculator_bits |= 0x0F;
     if (Calculator_bits != 0xFF) return 50;
@@ -106,7 +106,7 @@ int32_t Calculator_testBitwiseOr(void) {
     return 0;
 }
 
-int32_t Calculator_testBitwiseXor(void) {
+static int32_t Calculator_testBitwiseXor(void) {
     Calculator_bits = 0xFF;
     Calculator_bits ^= 0xFF;
     if (Calculator_bits != 0) return 60;
@@ -119,7 +119,7 @@ int32_t Calculator_testBitwiseXor(void) {
     return 0;
 }
 
-int32_t Calculator_testLeftShift(void) {
+static int32_t Calculator_testLeftShift(void) {
     Calculator_bits = 1;
     Calculator_bits <<= 4;
     if (Calculator_bits != 16) return 70;
@@ -132,7 +132,7 @@ int32_t Calculator_testLeftShift(void) {
     return 0;
 }
 
-int32_t Calculator_testRightShift(void) {
+static int32_t Calculator_testRightShift(void) {
     Calculator_bits = 256;
     Calculator_bits >>= 4;
     if (Calculator_bits != 16) return 80;

--- a/tests/compound-assign/this-member-compound.test.cnx
+++ b/tests/compound-assign/this-member-compound.test.cnx
@@ -158,7 +158,7 @@ scope Calculator {
     }
 
     // Run all tests
-    i32 runAllTests() {
+    public i32 runAllTests() {
         i32 result <- 0;
 
         result <- this.testSubtraction();

--- a/tests/control-flow/while-inside-scope.expected.c
+++ b/tests/control-flow/while-inside-scope.expected.c
@@ -19,7 +19,7 @@ static inline uint32_t cnx_clamp_add_u32(uint32_t a, uint64_t b) {
 uint32_t globalResult = 0;
 
 /* Scope: Counter */
-uint32_t Counter_value = 0;
+static uint32_t Counter_value = 0;
 
 void Counter_countToFive(void) {
     uint32_t i = 0;
@@ -46,7 +46,7 @@ void Counter_reset(void) {
 }
 
 /* Scope: Accumulator */
-uint32_t Accumulator_sum = 0;
+static uint32_t Accumulator_sum = 0;
 
 void Accumulator_sumRange(uint32_t* limit) {
     uint32_t i = 1;

--- a/tests/control-flow/while-inside-scope.test.cnx
+++ b/tests/control-flow/while-inside-scope.test.cnx
@@ -6,7 +6,7 @@ u32 globalResult <- 0;
 scope Counter {
     u32 value <- 0;
 
-    void countToFive() {
+    public void countToFive() {
         u32 i <- 0;
         while (i < 5) {
             this.value +<- 1;
@@ -14,7 +14,7 @@ scope Counter {
         }
     }
 
-    void countWhileCondition(bool shouldCount) {
+    public void countWhileCondition(bool shouldCount) {
         u32 i <- 0;
         while (i < 3 && shouldCount = true) {
             this.value +<- 10;
@@ -22,11 +22,11 @@ scope Counter {
         }
     }
 
-    u32 getValue() {
+    public u32 getValue() {
         return this.value;
     }
 
-    void reset() {
+    public void reset() {
         this.value <- 0;
     }
 }
@@ -34,7 +34,7 @@ scope Counter {
 scope Accumulator {
     u32 sum <- 0;
 
-    void sumRange(u32 limit) {
+    public void sumRange(u32 limit) {
         u32 i <- 1;
         while (i <= limit) {
             this.sum +<- i;
@@ -42,7 +42,7 @@ scope Accumulator {
         }
     }
 
-    u32 getSum() {
+    public u32 getSum() {
         return this.sum;
     }
 }

--- a/tests/enum/scoped-enum.expected.c
+++ b/tests/enum/scoped-enum.expected.c
@@ -18,7 +18,7 @@ typedef enum {
     Motor_State_STALLED = 2
 } Motor_State;
 
-uint8_t Motor_defaultValue = 1;
+static uint8_t Motor_defaultValue = 1;
 Motor_State Motor_current = Motor_State_IDLE;
 
 uint8_t Motor_start(void) {

--- a/tests/enum/scoped-enum.test.cnx
+++ b/tests/enum/scoped-enum.test.cnx
@@ -12,21 +12,21 @@ scope Motor {
 
     const u8 defaultValue <- 1;
 
-    this.State current <- this.State.IDLE; // This is a default value
+    public this.State current <- this.State.IDLE; // This is a default value
 
-    u8 start() {
+    public u8 start() {
         this.current <- this.State.RUNNING;
 
         return this.defaultValue;
     }
 
-    u8 stop() {
+    public u8 stop() {
         this.current <- this.State.IDLE;
 
         return global.defaultValue;
     }
 
-    bool isRunning() {
+    public bool isRunning() {
         const this.State currentState <- this.current;
         if (currentState = this.State.RUNNING) {
             return true;

--- a/tests/for-loops/for-inside-scope.expected.c
+++ b/tests/for-loops/for-inside-scope.expected.c
@@ -23,7 +23,7 @@ static inline uint32_t cnx_clamp_mul_u32(uint32_t a, uint64_t b) {
 uint32_t globalSum = 0;
 
 /* Scope: Calculator */
-uint32_t Calculator_result = 0;
+static uint32_t Calculator_result = 0;
 
 void Calculator_sumToN(uint32_t* n) {
     Calculator_result = 0;
@@ -44,8 +44,8 @@ uint32_t Calculator_getResult(void) {
 }
 
 /* Scope: ArrayOps */
-uint32_t ArrayOps_data[10] = {0};
-uint32_t ArrayOps_sum = 0;
+static uint32_t ArrayOps_data[10] = {0};
+static uint32_t ArrayOps_sum = 0;
 
 void ArrayOps_initialize(void) {
     for (uint32_t i = 0; i < 10; i = i + 1) {

--- a/tests/for-loops/for-inside-scope.test.cnx
+++ b/tests/for-loops/for-inside-scope.test.cnx
@@ -6,21 +6,21 @@ u32 globalSum <- 0;
 scope Calculator {
     u32 result <- 0;
 
-    void sumToN(u32 n) {
+    public void sumToN(u32 n) {
         this.result <- 0;
         for (u32 i <- 1; i <= n; i <- i + 1) {
             this.result +<- i;
         }
     }
 
-    void factorial(u32 n) {
+    public void factorial(u32 n) {
         this.result <- 1;
         for (u32 i <- 2; i <= n; i <- i + 1) {
             this.result *<- i;
         }
     }
 
-    u32 getResult() {
+    public u32 getResult() {
         return this.result;
     }
 }
@@ -29,20 +29,20 @@ scope ArrayOps {
     u32 data[10];
     u32 sum <- 0;
 
-    void initialize() {
+    public void initialize() {
         for (u32 i <- 0; i < 10; i <- i + 1) {
             this.data[i] <- i * 2;
         }
     }
 
-    void computeSum() {
+    public void computeSum() {
         this.sum <- 0;
         for (u32 i <- 0; i < 10; i <- i + 1) {
             this.sum +<- this.data[i];
         }
     }
 
-    u32 getSum() {
+    public u32 getSum() {
         return this.sum;
     }
 }

--- a/tests/initialization/namespace-init.test.cnx
+++ b/tests/initialization/namespace-init.test.cnx
@@ -5,11 +5,11 @@ u8 globalCount;  // Global - uninitialized
 scope Counter {
     u8 count;    // Scope member - uninitialized
 
-    void init() {
+    public void init() {
         count <- 0;  // Initialize scope member
     }
 
-    void increment() {
+    public void increment() {
         // Should reference Counter.count (initialized by init())
         count <- count + 1;
     }

--- a/tests/length/arrays/bool-array-length.expected.c
+++ b/tests/length/arrays/bool-array-length.expected.c
@@ -20,7 +20,7 @@ uint32_t TestScope_getGlobalArrayLength(void) {
 uint32_t TestScope_getGlobalElementLength(void) {
     return 8;
 }
-bool TestScope_scopeArr[16] = {0};
+static bool TestScope_scopeArr[16] = {0};
 
 uint32_t TestScope_getScopeArrayLength(void) {
     return 16;

--- a/tests/length/arrays/f32-array-length.expected.c
+++ b/tests/length/arrays/f32-array-length.expected.c
@@ -19,7 +19,7 @@ uint32_t TestScope_getGlobalArrayLength(void) {
 uint32_t TestScope_getGlobalElementLength(void) {
     return 32;
 }
-float TestScope_scopeArr[16] = {0};
+static float TestScope_scopeArr[16] = {0};
 
 uint32_t TestScope_getScopeArrayLength(void) {
     return 16;

--- a/tests/length/arrays/f64-array-length.expected.c
+++ b/tests/length/arrays/f64-array-length.expected.c
@@ -19,7 +19,7 @@ uint32_t TestScope_getGlobalArrayLength(void) {
 uint32_t TestScope_getGlobalElementLength(void) {
     return 64;
 }
-double TestScope_scopeArr[16] = {0};
+static double TestScope_scopeArr[16] = {0};
 
 uint32_t TestScope_getScopeArrayLength(void) {
     return 16;

--- a/tests/length/arrays/i16-array-length.expected.c
+++ b/tests/length/arrays/i16-array-length.expected.c
@@ -19,7 +19,7 @@ uint32_t TestScope_getGlobalArrayLength(void) {
 uint32_t TestScope_getGlobalElementLength(void) {
     return 16;
 }
-int16_t TestScope_scopeArr[16] = {0};
+static int16_t TestScope_scopeArr[16] = {0};
 
 uint32_t TestScope_getScopeArrayLength(void) {
     return 16;

--- a/tests/length/arrays/i32-array-length.expected.c
+++ b/tests/length/arrays/i32-array-length.expected.c
@@ -19,7 +19,7 @@ uint32_t TestScope_getGlobalArrayLength(void) {
 uint32_t TestScope_getGlobalElementLength(void) {
     return 32;
 }
-int32_t TestScope_scopeArr[16] = {0};
+static int32_t TestScope_scopeArr[16] = {0};
 
 uint32_t TestScope_getScopeArrayLength(void) {
     return 16;

--- a/tests/length/arrays/i64-array-length.expected.c
+++ b/tests/length/arrays/i64-array-length.expected.c
@@ -19,7 +19,7 @@ uint32_t TestScope_getGlobalArrayLength(void) {
 uint32_t TestScope_getGlobalElementLength(void) {
     return 64;
 }
-int64_t TestScope_scopeArr[16] = {0};
+static int64_t TestScope_scopeArr[16] = {0};
 
 uint32_t TestScope_getScopeArrayLength(void) {
     return 16;

--- a/tests/length/arrays/i8-array-length.expected.c
+++ b/tests/length/arrays/i8-array-length.expected.c
@@ -19,7 +19,7 @@ uint32_t TestScope_getGlobalArrayLength(void) {
 uint32_t TestScope_getGlobalElementLength(void) {
     return 8;
 }
-int8_t TestScope_scopeArr[16] = {0};
+static int8_t TestScope_scopeArr[16] = {0};
 
 uint32_t TestScope_getScopeArrayLength(void) {
     return 16;

--- a/tests/length/arrays/string-array-length.expected.c
+++ b/tests/length/arrays/string-array-length.expected.c
@@ -16,7 +16,7 @@ char globalArr[4][65] = {0};
 uint32_t TestScope_getGlobalArrayLength(void) {
     return 4;
 }
-char TestScope_scopeArr[4][65] = {0};
+static char TestScope_scopeArr[4][65] = {0};
 
 uint32_t TestScope_getScopeArrayLength(void) {
     return 4;

--- a/tests/length/arrays/u16-array-length.expected.c
+++ b/tests/length/arrays/u16-array-length.expected.c
@@ -19,7 +19,7 @@ uint32_t TestScope_getGlobalArrayLength(void) {
 uint32_t TestScope_getGlobalElementLength(void) {
     return 16;
 }
-uint16_t TestScope_scopeArr[16] = {0};
+static uint16_t TestScope_scopeArr[16] = {0};
 
 uint32_t TestScope_getScopeArrayLength(void) {
     return 16;

--- a/tests/length/arrays/u32-array-length.expected.c
+++ b/tests/length/arrays/u32-array-length.expected.c
@@ -19,7 +19,7 @@ uint32_t TestScope_getGlobalArrayLength(void) {
 uint32_t TestScope_getGlobalElementLength(void) {
     return 32;
 }
-uint32_t TestScope_scopeArr[16] = {0};
+static uint32_t TestScope_scopeArr[16] = {0};
 
 uint32_t TestScope_getScopeArrayLength(void) {
     return 16;

--- a/tests/length/arrays/u64-array-length.expected.c
+++ b/tests/length/arrays/u64-array-length.expected.c
@@ -19,7 +19,7 @@ uint32_t TestScope_getGlobalArrayLength(void) {
 uint32_t TestScope_getGlobalElementLength(void) {
     return 64;
 }
-uint64_t TestScope_scopeArr[16] = {0};
+static uint64_t TestScope_scopeArr[16] = {0};
 
 uint32_t TestScope_getScopeArrayLength(void) {
     return 16;

--- a/tests/length/arrays/u8-array-length.expected.c
+++ b/tests/length/arrays/u8-array-length.expected.c
@@ -19,7 +19,7 @@ uint32_t TestScope_getGlobalArrayLength(void) {
 uint32_t TestScope_getGlobalElementLength(void) {
     return 8;
 }
-uint8_t TestScope_scopeArr[16] = {0};
+static uint8_t TestScope_scopeArr[16] = {0};
 
 uint32_t TestScope_getScopeArrayLength(void) {
     return 16;

--- a/tests/length/multi-dim/multi-dim-array-all-types-length.expected.c
+++ b/tests/length/multi-dim/multi-dim-array-all-types-length.expected.c
@@ -17,7 +17,7 @@ float globalF32Matrix[2][10] = {0};
 
 // Scope with multi-dim arrays
 /* Scope: TestScope */
-uint8_t TestScope_scopeMatrix[4][8] = {0};
+static uint8_t TestScope_scopeMatrix[4][8] = {0};
 
 uint32_t TestScope_getScopeMatrixLength(void) {
     return 4;

--- a/tests/length/primitives/bool-length.expected.c
+++ b/tests/length/primitives/bool-length.expected.c
@@ -17,7 +17,7 @@ bool globalVar = true;
 uint32_t TestScope_getGlobalLength(void) {
     return 8;
 }
-bool TestScope_scopeMember = true;
+static bool TestScope_scopeMember = true;
 
 uint32_t TestScope_getMemberLength(void) {
     return 8;

--- a/tests/length/primitives/f32-length.expected.c
+++ b/tests/length/primitives/f32-length.expected.c
@@ -15,7 +15,7 @@ float globalVar = 3.14;
 uint32_t TestScope_getGlobalLength(void) {
     return 32;
 }
-float TestScope_scopeMember = 3.14;
+static float TestScope_scopeMember = 3.14;
 
 uint32_t TestScope_getMemberLength(void) {
     return 32;

--- a/tests/length/primitives/f64-length.expected.c
+++ b/tests/length/primitives/f64-length.expected.c
@@ -15,7 +15,7 @@ double globalVar = 3.14159;
 uint32_t TestScope_getGlobalLength(void) {
     return 64;
 }
-double TestScope_scopeMember = 3.14159;
+static double TestScope_scopeMember = 3.14159;
 
 uint32_t TestScope_getMemberLength(void) {
     return 64;

--- a/tests/length/primitives/i16-length.expected.c
+++ b/tests/length/primitives/i16-length.expected.c
@@ -15,7 +15,7 @@ int16_t globalVar = -1000;
 uint32_t TestScope_getGlobalLength(void) {
     return 16;
 }
-int16_t TestScope_scopeMember = -1000;
+static int16_t TestScope_scopeMember = -1000;
 
 uint32_t TestScope_getMemberLength(void) {
     return 16;

--- a/tests/length/primitives/i32-length.expected.c
+++ b/tests/length/primitives/i32-length.expected.c
@@ -15,7 +15,7 @@ int32_t globalVar = -100000;
 uint32_t TestScope_getGlobalLength(void) {
     return 32;
 }
-int32_t TestScope_scopeMember = -100000;
+static int32_t TestScope_scopeMember = -100000;
 
 uint32_t TestScope_getMemberLength(void) {
     return 32;

--- a/tests/length/primitives/i64-length.expected.c
+++ b/tests/length/primitives/i64-length.expected.c
@@ -15,7 +15,7 @@ int64_t globalVar = -1000000;
 uint32_t TestScope_getGlobalLength(void) {
     return 64;
 }
-int64_t TestScope_scopeMember = -1000000;
+static int64_t TestScope_scopeMember = -1000000;
 
 uint32_t TestScope_getMemberLength(void) {
     return 64;

--- a/tests/length/primitives/i8-length.expected.c
+++ b/tests/length/primitives/i8-length.expected.c
@@ -15,7 +15,7 @@ int8_t globalVar = -42;
 uint32_t TestScope_getGlobalLength(void) {
     return 8;
 }
-int8_t TestScope_scopeMember = -42;
+static int8_t TestScope_scopeMember = -42;
 
 uint32_t TestScope_getMemberLength(void) {
     return 8;

--- a/tests/length/primitives/u16-length.expected.c
+++ b/tests/length/primitives/u16-length.expected.c
@@ -15,7 +15,7 @@ uint16_t globalVar = 1000;
 uint32_t TestScope_getGlobalLength(void) {
     return 16;
 }
-uint16_t TestScope_scopeMember = 1000;
+static uint16_t TestScope_scopeMember = 1000;
 
 uint32_t TestScope_getMemberLength(void) {
     return 16;

--- a/tests/length/primitives/u32-length.expected.c
+++ b/tests/length/primitives/u32-length.expected.c
@@ -15,7 +15,7 @@ uint32_t globalVar = 100000;
 uint32_t TestScope_getGlobalLength(void) {
     return 32;
 }
-uint32_t TestScope_scopeMember = 100000;
+static uint32_t TestScope_scopeMember = 100000;
 
 uint32_t TestScope_getMemberLength(void) {
     return 32;

--- a/tests/length/primitives/u64-length.expected.c
+++ b/tests/length/primitives/u64-length.expected.c
@@ -15,7 +15,7 @@ uint64_t globalVar = 1000000;
 uint32_t TestScope_getGlobalLength(void) {
     return 64;
 }
-uint64_t TestScope_scopeMember = 1000000;
+static uint64_t TestScope_scopeMember = 1000000;
 
 uint32_t TestScope_getMemberLength(void) {
     return 64;

--- a/tests/length/primitives/u8-length.expected.c
+++ b/tests/length/primitives/u8-length.expected.c
@@ -17,7 +17,7 @@ uint8_t globalVar = 42;
 uint32_t TestScope_getGlobalLength(void) {
     return 8;
 }
-uint8_t TestScope_scopeMember = 42;
+static uint8_t TestScope_scopeMember = 42;
 
 uint32_t TestScope_getMemberLength(void) {
     return 8;

--- a/tests/length/structs/struct-member-all-types-length.expected.c
+++ b/tests/length/structs/struct-member-all-types-length.expected.c
@@ -28,7 +28,7 @@ AllTypes globalStruct = {0};
 
 // Test in scope context
 /* Scope: TestScope */
-AllTypes TestScope_scopeStruct = {0};
+static AllTypes TestScope_scopeStruct = {0};
 
 uint32_t TestScope_checkScopeStructMember(void) {
     if (32 != 32) {

--- a/tests/overflow-modifiers/clamp-scope.expected.c
+++ b/tests/overflow-modifiers/clamp-scope.expected.c
@@ -23,7 +23,7 @@ static inline uint8_t cnx_clamp_sub_u8(uint8_t a, uint32_t b) {
 // ADR-044 + ADR-016: Verifies clamp works with scope variables via this. accessor
 // This test exposes a BUG if clamp is ignored in scope contexts
 /* Scope: ClampScope */
-uint8_t ClampScope_brightness = 200;
+static uint8_t ClampScope_brightness = 200;
 
 void ClampScope_triggerOverflow(void) {
     ClampScope_brightness = cnx_clamp_add_u8(ClampScope_brightness, 100);

--- a/tests/overflow-modifiers/clamp-scope.test.cnx
+++ b/tests/overflow-modifiers/clamp-scope.test.cnx
@@ -8,22 +8,22 @@ scope ClampScope {
     clamp u8 brightness <- 200;
 
     // Method that triggers overflow - should clamp to 255
-    void triggerOverflow() {
+    public void triggerOverflow() {
         this.brightness +<- 100;  // 200 + 100 = 300, should clamp to 255
     }
 
     // Method that triggers underflow - should clamp to 0
-    void triggerUnderflow() {
+    public void triggerUnderflow() {
         this.brightness -<- 255;  // From any value, subtract 255
     }
 
     // Getter for validation
-    u8 getBrightness() {
+    public u8 getBrightness() {
         return this.brightness;
     }
 
     // Reset for next test
-    void reset(u8 value) {
+    public void reset(u8 value) {
         this.brightness <- value;
     }
 }

--- a/tests/postfix-chains/scoped-register-global-access.expected.c
+++ b/tests/postfix-chains/scoped-register-global-access.expected.c
@@ -21,7 +21,7 @@
 typedef uint8_t MotorFlags;
 
 /* Scope: MotorController */
-uint32_t MotorController_DEFAULT_SPEED = 100;
+static uint32_t MotorController_DEFAULT_SPEED = 100;
 
 /* Register: MotorController_MOTOR_REG @ 0x40002000 */
 #define MotorController_MOTOR_REG_CTRL (*(volatile MotorFlags*)(0x40002000 + 0x00))
@@ -49,7 +49,7 @@ uint8_t MotorController_getMode(void) {
 #define Board_GPIO_DR (*(volatile uint32_t*)(0x40000000 + 0x00))
 #define Board_GPIO_DR_SET (*(volatile uint32_t*)(0x40000000 + 0x84))
 
-uint32_t Board_LED_BIT = 3;
+static uint32_t Board_LED_BIT = 3;
 
 void Board_toggleLed(void) {
     Board_GPIO_DR_SET = (1 << Board_LED_BIT);

--- a/tests/postfix-chains/scoped-register-global-access.test.cnx
+++ b/tests/postfix-chains/scoped-register-global-access.test.cnx
@@ -20,19 +20,19 @@ scope MotorController {
         STATUS: u32 ro @ 0x08,
     }
 
-    void start() {
+    public void start() {
         // Inside scope: must use 'this.' to access own members
         this.MOTOR_REG.CTRL.Running <- true;
         this.MOTOR_REG.CTRL.Mode <- 3;
         this.MOTOR_REG.SPEED <- this.DEFAULT_SPEED;
     }
 
-    bool isRunning() {
+    public bool isRunning() {
         // Read through scoped register bitmap chain using this.
         return this.MOTOR_REG.CTRL.Running;
     }
 
-    u8 getMode() {
+    public u8 getMode() {
         // Read multi-bit field through scoped register
         return this.MOTOR_REG.CTRL.Mode;
     }
@@ -46,7 +46,7 @@ scope Board {
 
     const u32 LED_BIT <- 3;
 
-    void toggleLed() {
+    public void toggleLed() {
         // Scoped register with bit indexing using this.
         this.GPIO.DR_SET[this.LED_BIT] <- true;
     }

--- a/tests/preprocessor/conditional-compilation.test.cnx
+++ b/tests/preprocessor/conditional-compilation.test.cnx
@@ -26,11 +26,11 @@ register GPIO7 @ 0x42004000 {
 }
 
 scope LED {
-    void on() {
+    public void on() {
         GPIO7.DR_SET[LED_BIT] <- true;
     }
 
-    void off() {
+    public void off() {
         GPIO7.DR_CLEAR[LED_BIT] <- true;
     }
 }

--- a/tests/scope/cross-scope-compound.test.cnx
+++ b/tests/scope/cross-scope-compound.test.cnx
@@ -3,17 +3,17 @@
 // Tests OtherScope.var +<- value pattern
 
 scope Counter {
-    i32 value <- 100;
-    i32 data[3];
+    public i32 value <- 100;
+    public i32 data[3];
 }
 
 scope Manager {
-    void incrementCounter() {
+    public void incrementCounter() {
         // Cross-scope compound assignment
         Counter.value +<- 50;  // Should be: Counter_value += 50
     }
 
-    void incrementCounterArray() {
+    public void incrementCounterArray() {
         Counter.data[0] <- 10;
         Counter.data[0] +<- 5;  // Should be: Counter_data[0] += 5
     }

--- a/tests/scope/global-compound-assign.test.cnx
+++ b/tests/scope/global-compound-assign.test.cnx
@@ -6,12 +6,12 @@ i32 counter <- 100;
 i32 values[4];
 
 scope Worker {
-    void updateGlobal() {
+    public void updateGlobal() {
         // global.var compound assignment
         global.counter +<- 50;  // Should be: counter += 50
     }
 
-    void updateGlobalArray() {
+    public void updateGlobalArray() {
         // global.arr[i] compound assignment
         global.values[0] <- 200;
         global.values[0] +<- 100;  // Should be: values[0] += 100

--- a/tests/scope/scope-atomic-modifier.expected.c
+++ b/tests/scope/scope-atomic-modifier.expected.c
@@ -38,12 +38,12 @@ static inline uint8_t cnx_clamp_sub_u8(uint8_t a, uint32_t b) {
 }
 
 /* Scope: AtomicTest */
-uint8_t AtomicTest_counterU8 = 0;
-uint16_t AtomicTest_counterU16 = 0;
-uint32_t AtomicTest_counterU32 = 0;
-uint8_t AtomicTest_brightness = 100;
-uint16_t AtomicTest_position = 500;
-uint32_t AtomicTest_ticks = 0;
+static uint8_t AtomicTest_counterU8 = 0;
+static uint16_t AtomicTest_counterU16 = 0;
+static uint32_t AtomicTest_counterU32 = 0;
+static uint8_t AtomicTest_brightness = 100;
+static uint16_t AtomicTest_position = 500;
+static uint32_t AtomicTest_ticks = 0;
 
 uint8_t AtomicTest_getCounterU8(void) {
     return AtomicTest_counterU8;

--- a/tests/scope/scope-atomic-modifier.test.cnx
+++ b/tests/scope/scope-atomic-modifier.test.cnx
@@ -16,63 +16,63 @@ scope AtomicTest {
     atomic u32 ticks <- 0;
 
     // Public getter methods using this. accessor for atomic variables
-    u8 getCounterU8() {
+    public u8 getCounterU8() {
         return this.counterU8;
     }
 
-    u16 getCounterU16() {
+    public u16 getCounterU16() {
         return this.counterU16;
     }
 
-    u32 getCounterU32() {
+    public u32 getCounterU32() {
         return this.counterU32;
     }
 
-    u8 getBrightness() {
+    public u8 getBrightness() {
         return this.brightness;
     }
 
-    u16 getPosition() {
+    public u16 getPosition() {
         return this.position;
     }
 
-    u32 getTicks() {
+    public u32 getTicks() {
         return this.ticks;
     }
 
     // Increment methods using atomic compound add (+<-)
-    void incrementU8() {
+    public void incrementU8() {
         this.counterU8 +<- 1;
     }
 
-    void incrementU16() {
+    public void incrementU16() {
         this.counterU16 +<- 1;
     }
 
-    void incrementU32() {
+    public void incrementU32() {
         this.counterU32 +<- 1;
     }
 
     // Decrement methods using atomic compound subtract (-<-)
-    void decrementBrightness() {
+    public void decrementBrightness() {
         this.brightness -<- 10;
     }
 
-    void decrementPosition() {
+    public void decrementPosition() {
         this.position -<- 50;
     }
 
     // Bitwise operations using atomic compound operators
-    void maskTicks() {
+    public void maskTicks() {
         this.ticks &<- 0xFFFF;
     }
 
-    void setTickFlag() {
+    public void setTickFlag() {
         this.ticks |<- 0x80000000;
     }
 
     // Combined increment of all counters
-    void incrementAll() {
+    public void incrementAll() {
         this.counterU8 +<- 1;
         this.counterU16 +<- 1;
         this.counterU32 +<- 1;

--- a/tests/scope/scope-clamp-modifier.expected.c
+++ b/tests/scope/scope-clamp-modifier.expected.c
@@ -59,12 +59,12 @@ static inline uint8_t cnx_clamp_sub_u8(uint8_t a, uint32_t b) {
 // Verifies that clamp modifier works correctly with integer types inside scope methods
 // Tests: clamp variables accessed via this. accessor with compound assignment operators
 /* Scope: ClampTest */
-uint8_t ClampTest_brightness = 200;
-uint16_t ClampTest_sensorValue = 60000;
-uint32_t ClampTest_counter = 4000000000;
-int8_t ClampTest_temperature = -100;
-int16_t ClampTest_altitude = 30000;
-int32_t ClampTest_position = 2000000000;
+static uint8_t ClampTest_brightness = 200;
+static uint16_t ClampTest_sensorValue = 60000;
+static uint32_t ClampTest_counter = 4000000000;
+static int8_t ClampTest_temperature = -100;
+static int16_t ClampTest_altitude = 30000;
+static int32_t ClampTest_position = 2000000000;
 
 uint8_t ClampTest_getBrightness(void) {
     return ClampTest_brightness;

--- a/tests/scope/scope-compound-assign.expected.c
+++ b/tests/scope/scope-compound-assign.expected.c
@@ -19,14 +19,14 @@ static inline int32_t cnx_clamp_add_i32(int32_t a, int64_t b) {
 // Test: Compound assignment with scope-local (this.) patterns
 // Tests lines 4336 and 4338 in CodeGenerator.ts
 /* Scope: Counter */
-int32_t Counter_value = 100;
-int32_t Counter_values[4] = {0};
+static int32_t Counter_value = 100;
+static int32_t Counter_values[4] = {0};
 
-void Counter_increment(void) {
+static void Counter_increment(void) {
     Counter_value = cnx_clamp_add_i32(Counter_value, 10);
 }
 
-void Counter_incrementArray(void) {
+static void Counter_incrementArray(void) {
     Counter_values[0] = 50;
     Counter_values[0] += 25;
 }

--- a/tests/scope/scope-compound-assign.test.cnx
+++ b/tests/scope/scope-compound-assign.test.cnx
@@ -17,7 +17,7 @@ scope Counter {
         this.values[0] +<- 25;  // Should be: Counter_values[0] += 25
     }
 
-    i32 test() {
+    public i32 test() {
         this.increment();
         this.incrementArray();
 

--- a/tests/scope/scope-critical-section.expected.c
+++ b/tests/scope/scope-critical-section.expected.c
@@ -38,13 +38,13 @@ uint32_t globalReadIndex = 0;
 bool globalBufferLock = false;
 
 /* Scope: CriticalTest */
-uint8_t CriticalTest_buffer[32] = {0};
-uint32_t CriticalTest_writeIndex = 0;
-uint32_t CriticalTest_readIndex = 0;
-uint8_t CriticalTest_count = 0;
-bool CriticalTest_locked = false;
+static uint8_t CriticalTest_buffer[32] = {0};
+static uint32_t CriticalTest_writeIndex = 0;
+static uint32_t CriticalTest_readIndex = 0;
+static uint8_t CriticalTest_count = 0;
+static bool CriticalTest_locked = false;
 
-void CriticalTest_internalEnqueue(uint8_t* data) {
+static void CriticalTest_internalEnqueue(uint8_t* data) {
     {
         uint32_t __primask = __get_PRIMASK();
         __disable_irq();
@@ -55,7 +55,7 @@ void CriticalTest_internalEnqueue(uint8_t* data) {
     }
 }
 
-uint8_t CriticalTest_internalDequeue(void) {
+static uint8_t CriticalTest_internalDequeue(void) {
     uint8_t result = 0;
     {
         uint32_t __primask = __get_PRIMASK();
@@ -70,7 +70,7 @@ uint8_t CriticalTest_internalDequeue(void) {
     return result;
 }
 
-void CriticalTest_internalUpdateGlobal(void) {
+static void CriticalTest_internalUpdateGlobal(void) {
     {
         uint32_t __primask = __get_PRIMASK();
         __disable_irq();
@@ -80,7 +80,7 @@ void CriticalTest_internalUpdateGlobal(void) {
     }
 }
 
-void CriticalTest_internalTransfer(void) {
+static void CriticalTest_internalTransfer(void) {
     {
         uint32_t __primask = __get_PRIMASK();
         __disable_irq();
@@ -92,7 +92,7 @@ void CriticalTest_internalTransfer(void) {
     }
 }
 
-bool CriticalTest_internalTryLock(void) {
+static bool CriticalTest_internalTryLock(void) {
     bool acquired = false;
     {
         uint32_t __primask = __get_PRIMASK();
@@ -106,7 +106,7 @@ bool CriticalTest_internalTryLock(void) {
     return acquired;
 }
 
-void CriticalTest_internalUnlock(void) {
+static void CriticalTest_internalUnlock(void) {
     {
         uint32_t __primask = __get_PRIMASK();
         __disable_irq();

--- a/tests/scope/scope-method-contexts.expected.c
+++ b/tests/scope/scope-method-contexts.expected.c
@@ -36,78 +36,78 @@ int16_t globalOffset = -25;
 float globalScale = 2.5;
 
 /* Scope: MethodContexts */
-uint8_t MethodContexts_privateValue = 10;
-uint8_t MethodContexts_privateClampValue = 200;
-uint8_t MethodContexts_privateWrapValue = 250;
-bool MethodContexts_privateFlag = false;
-int16_t MethodContexts_privateOffset = -50;
+static uint8_t MethodContexts_privateValue = 10;
+static uint8_t MethodContexts_privateClampValue = 200;
+static uint8_t MethodContexts_privateWrapValue = 250;
+static bool MethodContexts_privateFlag = false;
+static int16_t MethodContexts_privateOffset = -50;
 uint8_t MethodContexts_publicValue = 20;
 uint16_t MethodContexts_publicClampValue = 60000;
 uint16_t MethodContexts_publicWrapValue = 65530;
 bool MethodContexts_publicFlag = true;
 int32_t MethodContexts_publicOffset = -1000;
 
-uint8_t MethodContexts_getPrivateValue(void) {
+static uint8_t MethodContexts_getPrivateValue(void) {
     return MethodContexts_privateValue;
 }
 
-uint8_t MethodContexts_getPublicValueInternal(void) {
+static uint8_t MethodContexts_getPublicValueInternal(void) {
     return MethodContexts_publicValue;
 }
 
-uint8_t MethodContexts_getPrivateClampValue(void) {
+static uint8_t MethodContexts_getPrivateClampValue(void) {
     return MethodContexts_privateClampValue;
 }
 
-uint8_t MethodContexts_getPrivateWrapValue(void) {
+static uint8_t MethodContexts_getPrivateWrapValue(void) {
     return MethodContexts_privateWrapValue;
 }
 
-void MethodContexts_incrementPrivateClamp(void) {
+static void MethodContexts_incrementPrivateClamp(void) {
     MethodContexts_privateClampValue = cnx_clamp_add_u8(MethodContexts_privateClampValue, 100);
 }
 
-void MethodContexts_incrementPrivateWrap(void) {
+static void MethodContexts_incrementPrivateWrap(void) {
     MethodContexts_privateWrapValue += 10;
 }
 
-bool MethodContexts_getPrivateFlag(void) {
+static bool MethodContexts_getPrivateFlag(void) {
     return MethodContexts_privateFlag;
 }
 
-int16_t MethodContexts_getPrivateOffset(void) {
+static int16_t MethodContexts_getPrivateOffset(void) {
     return MethodContexts_privateOffset;
 }
 
-uint8_t MethodContexts_getGlobalMaxInternal(void) {
+static uint8_t MethodContexts_getGlobalMaxInternal(void) {
     return GLOBAL_MAX;
 }
 
-uint8_t MethodContexts_getGlobalCounterInternal(void) {
+static uint8_t MethodContexts_getGlobalCounterInternal(void) {
     return globalCounter;
 }
 
-bool MethodContexts_getGlobalEnabledInternal(void) {
+static bool MethodContexts_getGlobalEnabledInternal(void) {
     return globalEnabled;
 }
 
-int16_t MethodContexts_getGlobalOffsetInternal(void) {
+static int16_t MethodContexts_getGlobalOffsetInternal(void) {
     return globalOffset;
 }
 
-float MethodContexts_getGlobalScaleInternal(void) {
+static float MethodContexts_getGlobalScaleInternal(void) {
     return globalScale;
 }
 
-uint8_t MethodContexts_computePrivateSum(void) {
+static uint8_t MethodContexts_computePrivateSum(void) {
     return MethodContexts_privateValue + globalCounter;
 }
 
-bool MethodContexts_privateValueBelowMax(void) {
+static bool MethodContexts_privateValueBelowMax(void) {
     return MethodContexts_privateValue < GLOBAL_MAX;
 }
 
-int16_t MethodContexts_computePrivateWithOffset(void) {
+static int16_t MethodContexts_computePrivateWithOffset(void) {
     return MethodContexts_privateOffset + globalOffset;
 }
 

--- a/tests/scope/scope-modifier-combos.expected.c
+++ b/tests/scope/scope-modifier-combos.expected.c
@@ -30,25 +30,25 @@ static inline uint16_t cnx_clamp_sub_u16(uint16_t a, uint32_t b) {
 // Verifies that combined modifiers (const clamp, const wrap, public clamp, etc.)
 // work correctly with scope variables accessed via this. accessor
 /* Scope: ModifierCombos */
-uint8_t ModifierCombos_MAX_BRIGHTNESS = 255;
-uint16_t ModifierCombos_MAX_SENSOR = 65535;
-int8_t ModifierCombos_MIN_TEMP = -128;
-uint8_t ModifierCombos_COUNTER_START = 0;
-uint16_t ModifierCombos_TICK_START = 1000;
+static uint8_t ModifierCombos_MAX_BRIGHTNESS = 255;
+static uint16_t ModifierCombos_MAX_SENSOR = 65535;
+static int8_t ModifierCombos_MIN_TEMP = -128;
+static uint8_t ModifierCombos_COUNTER_START = 0;
+static uint16_t ModifierCombos_TICK_START = 1000;
 uint8_t ModifierCombos_publicClampByte = 200;
 uint16_t ModifierCombos_publicClampWord = 60000;
 int8_t ModifierCombos_publicClampSigned = 100;
-uint8_t ModifierCombos_privateClampByte = 50;
-uint16_t ModifierCombos_privateClampWord = 10000;
-int8_t ModifierCombos_privateClampSigned = -50;
+static uint8_t ModifierCombos_privateClampByte = 50;
+static uint16_t ModifierCombos_privateClampWord = 10000;
+static int8_t ModifierCombos_privateClampSigned = -50;
 uint8_t ModifierCombos_publicWrapByte = 250;
 uint16_t ModifierCombos_publicWrapWord = 65530;
-uint8_t ModifierCombos_privateWrapByte = 5;
-uint16_t ModifierCombos_privateWrapWord = 100;
+static uint8_t ModifierCombos_privateWrapByte = 5;
+static uint16_t ModifierCombos_privateWrapWord = 100;
 uint8_t ModifierCombos_PUBLIC_CONST = 42;
 bool ModifierCombos_PUBLIC_FLAG = true;
-uint8_t ModifierCombos_PRIVATE_CONST = 99;
-bool ModifierCombos_PRIVATE_FLAG = false;
+static uint8_t ModifierCombos_PRIVATE_CONST = 99;
+static bool ModifierCombos_PRIVATE_FLAG = false;
 
 uint8_t ModifierCombos_getMaxBrightness(void) {
     return ModifierCombos_MAX_BRIGHTNESS;
@@ -134,11 +134,11 @@ void ModifierCombos_decreasePublicClampSigned(void) {
     ModifierCombos_publicClampSigned = cnx_clamp_sub_i8(ModifierCombos_publicClampSigned, 50);
 }
 
-void ModifierCombos_increasePrivateClampByte(void) {
+static void ModifierCombos_increasePrivateClampByte(void) {
     ModifierCombos_privateClampByte = cnx_clamp_add_u8(ModifierCombos_privateClampByte, 220);
 }
 
-void ModifierCombos_decreasePrivateClampWord(void) {
+static void ModifierCombos_decreasePrivateClampWord(void) {
     ModifierCombos_privateClampWord = cnx_clamp_sub_u16(ModifierCombos_privateClampWord, 15000);
 }
 
@@ -150,11 +150,11 @@ void ModifierCombos_incrementPublicWrapWord(void) {
     ModifierCombos_publicWrapWord += 10;
 }
 
-void ModifierCombos_decrementPrivateWrapByte(void) {
+static void ModifierCombos_decrementPrivateWrapByte(void) {
     ModifierCombos_privateWrapByte -= 10;
 }
 
-void ModifierCombos_decrementPrivateWrapWord(void) {
+static void ModifierCombos_decrementPrivateWrapWord(void) {
     ModifierCombos_privateWrapWord -= 150;
 }
 

--- a/tests/scope/scope-modifier-combos.test.cnx
+++ b/tests/scope/scope-modifier-combos.test.cnx
@@ -39,24 +39,24 @@ scope ModifierCombos {
     const bool PRIVATE_FLAG <- false;
 
     // Getter methods for const clamp variables
-    u8 getMaxBrightness() {
+    public u8 getMaxBrightness() {
         return this.MAX_BRIGHTNESS;
     }
 
-    u16 getMaxSensor() {
+    public u16 getMaxSensor() {
         return this.MAX_SENSOR;
     }
 
-    i8 getMinTemp() {
+    public i8 getMinTemp() {
         return this.MIN_TEMP;
     }
 
     // Getter methods for const wrap variables
-    u8 getCounterStart() {
+    public u8 getCounterStart() {
         return this.COUNTER_START;
     }
 
-    u16 getTickStart() {
+    public u16 getTickStart() {
         return this.TICK_START;
     }
 
@@ -74,15 +74,15 @@ scope ModifierCombos {
     }
 
     // Getter methods for private clamp variables
-    u8 getPrivateClampByte() {
+    public u8 getPrivateClampByte() {
         return this.privateClampByte;
     }
 
-    u16 getPrivateClampWord() {
+    public u16 getPrivateClampWord() {
         return this.privateClampWord;
     }
 
-    i8 getPrivateClampSigned() {
+    public i8 getPrivateClampSigned() {
         return this.privateClampSigned;
     }
 
@@ -96,11 +96,11 @@ scope ModifierCombos {
     }
 
     // Getter methods for private wrap variables
-    u8 getPrivateWrapByte() {
+    public u8 getPrivateWrapByte() {
         return this.privateWrapByte;
     }
 
-    u16 getPrivateWrapWord() {
+    public u16 getPrivateWrapWord() {
         return this.privateWrapWord;
     }
 
@@ -114,11 +114,11 @@ scope ModifierCombos {
     }
 
     // Getter methods for private const variables
-    u8 getPrivateConst() {
+    public u8 getPrivateConst() {
         return this.PRIVATE_CONST;
     }
 
-    bool getPrivateFlag() {
+    public bool getPrivateFlag() {
         return this.PRIVATE_FLAG;
     }
 

--- a/tests/scope/scope-public-private.expected.c
+++ b/tests/scope/scope-public-private.expected.c
@@ -10,20 +10,20 @@
 // Test: ADR-016 public and private visibility modifiers on scope members and methods
 // Verifies public members are accessible from outside scope and private are only internal
 /* Scope: Visibility */
-uint8_t Visibility_privateCounter = 0;
-bool Visibility_privateFlag = false;
+static uint8_t Visibility_privateCounter = 0;
+static bool Visibility_privateFlag = false;
 uint8_t Visibility_publicCounter = 10;
 bool Visibility_publicFlag = true;
 
-uint8_t Visibility_getPrivateCounterInternal(void) {
+static uint8_t Visibility_getPrivateCounterInternal(void) {
     return Visibility_privateCounter;
 }
 
-void Visibility_incrementPrivateCounter(void) {
+static void Visibility_incrementPrivateCounter(void) {
     Visibility_privateCounter = Visibility_privateCounter + 1;
 }
 
-bool Visibility_checkPrivateFlag(void) {
+static bool Visibility_checkPrivateFlag(void) {
     return Visibility_privateFlag;
 }
 

--- a/tests/scope/scope-wrap-modifier.expected.c
+++ b/tests/scope/scope-wrap-modifier.expected.c
@@ -10,12 +10,12 @@
 // Verifies that wrap modifier works correctly with integer types inside scope methods
 // Tests: wrap variables accessed via this. accessor with compound assignment operators
 /* Scope: WrapTest */
-uint8_t WrapTest_byteCounter = 250;
-uint16_t WrapTest_tickCount = 65530;
-uint32_t WrapTest_cycleCounter = 4294967290;
-uint8_t WrapTest_brightness = 10;
-uint16_t WrapTest_sensorValue = 100;
-uint32_t WrapTest_position = 50;
+static uint8_t WrapTest_byteCounter = 250;
+static uint16_t WrapTest_tickCount = 65530;
+static uint32_t WrapTest_cycleCounter = 4294967290;
+static uint8_t WrapTest_brightness = 10;
+static uint16_t WrapTest_sensorValue = 100;
+static uint32_t WrapTest_position = 50;
 
 uint8_t WrapTest_getByteCounter(void) {
     return WrapTest_byteCounter;

--- a/tests/scope/scoped-register-bit-access.expected.c
+++ b/tests/scope/scoped-register-bit-access.expected.c
@@ -8,7 +8,7 @@
 
 // Test: Bit indexing on scoped registers
 /* Scope: Board */
-uint32_t Board_LED_BIT = 3;
+static uint32_t Board_LED_BIT = 3;
 
 /* Register: Board_GPIO @ 0x40000000 */
 #define Board_GPIO_DR (*(volatile uint32_t*)(0x40000000 + 0x00))

--- a/tests/scope/scoped-register-bit-access.test.cnx
+++ b/tests/scope/scoped-register-bit-access.test.cnx
@@ -8,7 +8,7 @@ scope Board {
         DR_SET: u32 wo @ 0x84,
     }
 
-    void toggleLed() {
+    public void toggleLed() {
         // Simpler test: direct access
         Board.GPIO.DR_SET[3] <- true;
     }

--- a/tests/scope/this-all-types.expected.c
+++ b/tests/scope/this-all-types.expected.c
@@ -10,17 +10,17 @@
 // Test: ADR-016 this. accessor with all primitive types
 // Verifies that this. works correctly with every C-Next primitive type inside scope methods
 /* Scope: AllTypesTest */
-uint8_t AllTypesTest_valU8 = 255;
-uint16_t AllTypesTest_valU16 = 65535;
-uint32_t AllTypesTest_valU32 = 4294967295;
-uint64_t AllTypesTest_valU64 = 18446744073709551615;
-int8_t AllTypesTest_valI8 = -128;
-int16_t AllTypesTest_valI16 = -32768;
-int32_t AllTypesTest_valI32 = -2147483648;
-int64_t AllTypesTest_valI64 = -9223372036854775808;
-float AllTypesTest_valF32 = 3.14;
-double AllTypesTest_valF64 = 3.141592653589793;
-bool AllTypesTest_valBool = true;
+static uint8_t AllTypesTest_valU8 = 255;
+static uint16_t AllTypesTest_valU16 = 65535;
+static uint32_t AllTypesTest_valU32 = 4294967295;
+static uint64_t AllTypesTest_valU64 = 18446744073709551615;
+static int8_t AllTypesTest_valI8 = -128;
+static int16_t AllTypesTest_valI16 = -32768;
+static int32_t AllTypesTest_valI32 = -2147483648;
+static int64_t AllTypesTest_valI64 = -9223372036854775808;
+static float AllTypesTest_valF32 = 3.14;
+static double AllTypesTest_valF64 = 3.141592653589793;
+static bool AllTypesTest_valBool = true;
 
 uint8_t AllTypesTest_getU8(void) {
     return AllTypesTest_valU8;

--- a/tests/scope/this-global-test.expected.c
+++ b/tests/scope/this-global-test.expected.c
@@ -9,8 +9,8 @@
 const uint8_t globalValue = 10;
 
 /* Scope: Motor */
-uint8_t Motor_localValue = 5;
-uint8_t Motor_state = 0;
+static uint8_t Motor_localValue = 5;
+static uint8_t Motor_state = 0;
 
 uint8_t Motor_getLocalValue(void) {
     return Motor_localValue;

--- a/tests/scope/this-global-test.test.cnx
+++ b/tests/scope/this-global-test.test.cnx
@@ -7,22 +7,22 @@ scope Motor {
     u8 state <- 0;
 
     // Test this. for scope member access
-    u8 getLocalValue() {
+    public u8 getLocalValue() {
         return this.localValue;
     }
 
     // Test global. for global access
-    u8 getGlobalValue() {
+    public u8 getGlobalValue() {
         return global.globalValue;
     }
 
     // Test both in same function
-    u8 getSum() {
+    public u8 getSum() {
         return this.localValue + global.globalValue;
     }
 
     // Test this. in assignment
-    void setState(u8 val) {
+    public void setState(u8 val) {
         this.state <- val;
     }
 }

--- a/tests/string-assignment/string-assign-scope-global.test.cnx
+++ b/tests/string-assignment/string-assign-scope-global.test.cnx
@@ -4,15 +4,15 @@
 string<64> globalBuffer <- "";
 
 scope Handler {
-    void updateGlobal() {
+    public void updateGlobal() {
         global.globalBuffer <- "FromScope";
     }
 
-    void clearGlobal() {
+    public void clearGlobal() {
         global.globalBuffer <- "";
     }
 
-    void setLongMessage() {
+    public void setLongMessage() {
         global.globalBuffer <- "This is a longer message from scope";
     }
 }

--- a/tests/string-assignment/string-assign-scope-this.test.cnx
+++ b/tests/string-assignment/string-assign-scope-this.test.cnx
@@ -2,17 +2,17 @@
 // Issue #139: Test this.member string assignment in scopes (ADR-016)
 
 scope Logger {
-    string<64> message <- "";
+    public string<64> message <- "";
 
-    void setMessage() {
+    public void setMessage() {
         this.message <- "Hello from scope";
     }
 
-    void clear() {
+    public void clear() {
         this.message <- "";
     }
 
-    void setCustom() {
+    public void setCustom() {
         this.message <- "Custom";
     }
 }

--- a/tests/switch/switch-inside-scope.expected.c
+++ b/tests/switch/switch-inside-scope.expected.c
@@ -10,8 +10,8 @@
 uint32_t globalResult = 0;
 
 /* Scope: CommandProcessor */
-uint32_t CommandProcessor_lastCommand = 0;
-uint32_t CommandProcessor_result = 0;
+static uint32_t CommandProcessor_lastCommand = 0;
+static uint32_t CommandProcessor_result = 0;
 
 void CommandProcessor_execute(uint32_t* command) {
     CommandProcessor_lastCommand = (*command);
@@ -40,10 +40,10 @@ uint32_t CommandProcessor_getResult(void) {
 }
 
 /* Scope: Calculator */
-uint32_t Calculator_mode = 0;
-uint32_t Calculator_a = 0;
-uint32_t Calculator_b = 0;
-uint32_t Calculator_output = 0;
+static uint32_t Calculator_mode = 0;
+static uint32_t Calculator_a = 0;
+static uint32_t Calculator_b = 0;
+static uint32_t Calculator_output = 0;
 
 void Calculator_setOperands(uint32_t* x, uint32_t* y) {
     Calculator_a = (*x);

--- a/tests/switch/switch-inside-scope.test.cnx
+++ b/tests/switch/switch-inside-scope.test.cnx
@@ -7,7 +7,7 @@ scope CommandProcessor {
     u32 lastCommand <- 0;
     u32 result <- 0;
 
-    void execute(u32 command) {
+    public void execute(u32 command) {
         this.lastCommand <- command;
 
         switch (command) {
@@ -26,7 +26,7 @@ scope CommandProcessor {
         }
     }
 
-    u32 getResult() {
+    public u32 getResult() {
         return this.result;
     }
 }
@@ -37,12 +37,12 @@ scope Calculator {
     u32 b <- 0;
     u32 output <- 0;
 
-    void setOperands(u32 x, u32 y) {
+    public void setOperands(u32 x, u32 y) {
         this.a <- x;
         this.b <- y;
     }
 
-    void compute(u32 operation) {
+    public void compute(u32 operation) {
         this.mode <- operation;
 
         switch (operation) {
@@ -64,7 +64,7 @@ scope Calculator {
         }
     }
 
-    u32 getOutput() {
+    public u32 getOutput() {
         return this.output;
     }
 }


### PR DESCRIPTION
## Summary
- Fix scope member default visibility from `public` to `private` per ADR-016
- ADR-016 specifies: "Private by default — Only members marked `public` are accessible outside"
- The bug caused all scope members without explicit visibility to be public (no `static` in C)

## Changes
- **CodeGenerator.ts**: Change line 2427 default from `"public"` to `"private"`
- **Test source files**: Add explicit `public` keyword to ~30 scope members that need external access
- **Expected C files**: Regenerate all snapshots (private members now have `static` prefix)

## Example
```cnx
scope Counter {
    i32 value <- 100;         // No modifier = PRIVATE (was incorrectly PUBLIC)
    public i32 test() { ... } // Explicit public = PUBLIC
}
```
Now correctly generates:
```c
static int32_t Counter_value = 100;  // 'static' = file-scoped (private) ✓
int32_t Counter_test(void) { ... }   // No 'static' = public ✓
```

## Test plan
- [x] All 579 tests pass
- [x] Prettier passes
- [x] OxLint passes
- [x] Analyze script passes
- [x] Verified generated C output shows correct `static` prefix for private members

Fixes #166

🤖 Generated with [Claude Code](https://claude.com/claude-code)