### PR TITLE
Add generator infrastructure for modular code generation (Issue #178)

### DIFF
--- a/src/codegen/generators/GeneratorRegistry.ts
+++ b/src/codegen/generators/GeneratorRegistry.ts
@@ -1,0 +1,139 @@
+/**
+ * Generator Registry
+ *
+ * Registry for extracted code generators using the "strangler fig" pattern.
+ * Generators are registered here as they're extracted from CodeGenerator.ts.
+ *
+ * During migration:
+ * - The registry starts empty
+ * - As generators are extracted (A2-A5), they register here
+ * - CodeGenerator checks the registry before falling back to inline methods
+ * - Tests pass throughout the migration
+ */
+
+import { ParserRuleContext } from "antlr4ng";
+import TGeneratorFn from "./TGeneratorFn";
+
+/**
+ * Registry for extracted generators.
+ *
+ * Enables gradual migration from monolithic CodeGenerator to modular generators.
+ * Each generator category (declarations, statements, expressions) has its own map
+ * keyed by the specific kind of node it handles.
+ *
+ * Example usage (in future A2-A5 issues):
+ * ```typescript
+ * // In expressionGenerators/ternary.ts
+ * export const generateTernary: TGeneratorFn<TernaryExprContext> = (node, input, state, orch) => {
+ *   const condition = orch.generateExpression(node.condition());
+ *   // ...
+ *   return { code: `${condition} ? ${trueBranch} : ${falseBranch}`, effects: [] };
+ * };
+ *
+ * // In CodeGenerator initialization
+ * registry.registerExpression('ternary', generateTernary);
+ * ```
+ */
+export default class GeneratorRegistry {
+  /**
+   * Declaration generators indexed by declaration kind.
+   * Example kinds: 'scope', 'struct', 'enum', 'function', 'variable'
+   */
+  private declarations = new Map<string, TGeneratorFn<ParserRuleContext>>();
+
+  /**
+   * Statement generators indexed by statement kind.
+   * Example kinds: 'if', 'while', 'for', 'assignment', 'return', 'switch'
+   */
+  private statements = new Map<string, TGeneratorFn<ParserRuleContext>>();
+
+  /**
+   * Expression generators indexed by expression kind.
+   * Example kinds: 'ternary', 'binary', 'unary', 'call', 'member', 'literal'
+   */
+  private expressions = new Map<string, TGeneratorFn<ParserRuleContext>>();
+
+  // =========================================================================
+  // Registration Methods
+  // =========================================================================
+
+  /**
+   * Register a declaration generator.
+   * @param kind - Declaration kind (e.g., 'struct', 'enum', 'function')
+   * @param fn - Generator function
+   */
+  registerDeclaration(kind: string, fn: TGeneratorFn<ParserRuleContext>): void {
+    this.declarations.set(kind, fn);
+  }
+
+  /**
+   * Register a statement generator.
+   * @param kind - Statement kind (e.g., 'if', 'while', 'assignment')
+   * @param fn - Generator function
+   */
+  registerStatement(kind: string, fn: TGeneratorFn<ParserRuleContext>): void {
+    this.statements.set(kind, fn);
+  }
+
+  /**
+   * Register an expression generator.
+   * @param kind - Expression kind (e.g., 'ternary', 'binary', 'call')
+   * @param fn - Generator function
+   */
+  registerExpression(kind: string, fn: TGeneratorFn<ParserRuleContext>): void {
+    this.expressions.set(kind, fn);
+  }
+
+  // =========================================================================
+  // Query Methods
+  // =========================================================================
+
+  /**
+   * Check if a declaration generator is registered.
+   */
+  hasDeclaration(kind: string): boolean {
+    return this.declarations.has(kind);
+  }
+
+  /**
+   * Check if a statement generator is registered.
+   */
+  hasStatement(kind: string): boolean {
+    return this.statements.has(kind);
+  }
+
+  /**
+   * Check if an expression generator is registered.
+   */
+  hasExpression(kind: string): boolean {
+    return this.expressions.has(kind);
+  }
+
+  // =========================================================================
+  // Getter Methods
+  // =========================================================================
+
+  /**
+   * Get a declaration generator by kind.
+   * @returns The generator function, or undefined if not registered
+   */
+  getDeclaration(kind: string): TGeneratorFn<ParserRuleContext> | undefined {
+    return this.declarations.get(kind);
+  }
+
+  /**
+   * Get a statement generator by kind.
+   * @returns The generator function, or undefined if not registered
+   */
+  getStatement(kind: string): TGeneratorFn<ParserRuleContext> | undefined {
+    return this.statements.get(kind);
+  }
+
+  /**
+   * Get an expression generator by kind.
+   * @returns The generator function, or undefined if not registered
+   */
+  getExpression(kind: string): TGeneratorFn<ParserRuleContext> | undefined {
+    return this.expressions.get(kind);
+  }
+}

--- a/src/codegen/generators/IGeneratorInput.ts
+++ b/src/codegen/generators/IGeneratorInput.ts
@@ -1,0 +1,41 @@
+/**
+ * Read-only input built before generation begins.
+ * Contains all the context a generator needs to produce code.
+ * Immutable - generators cannot modify this.
+ */
+import TTypeInfo from "../types/TTypeInfo";
+import IFunctionSignature from "../types/IFunctionSignature";
+import ICallbackTypeInfo from "../types/ICallbackTypeInfo";
+import ITargetCapabilities from "../types/ITargetCapabilities";
+import SymbolTable from "../../symbols/SymbolTable";
+
+interface IGeneratorInput {
+  /** Symbol table from parsed C/C++ headers (may be null for single-file transpilation) */
+  readonly symbolTable: SymbolTable | null;
+
+  /** Variable type information indexed by scoped name */
+  readonly typeRegistry: ReadonlyMap<string, TTypeInfo>;
+
+  /** Function signatures for parameter validation */
+  readonly functionSignatures: ReadonlyMap<string, IFunctionSignature>;
+
+  /** Set of C-Next defined function names */
+  readonly knownFunctions: ReadonlySet<string>;
+
+  /** Set of known struct type names */
+  readonly knownStructs: ReadonlySet<string>;
+
+  /** Compile-time constant values (for array sizes, etc.) */
+  readonly constValues: ReadonlyMap<string, number>;
+
+  /** Callback/function-as-type definitions */
+  readonly callbackTypes: ReadonlyMap<string, ICallbackTypeInfo>;
+
+  /** Target platform capabilities (affects atomic operations, etc.) */
+  readonly targetCapabilities: ITargetCapabilities;
+
+  /** Debug mode - affects overflow helper generation */
+  readonly debugMode: boolean;
+}
+
+export default IGeneratorInput;

--- a/src/codegen/generators/IGeneratorOutput.ts
+++ b/src/codegen/generators/IGeneratorOutput.ts
@@ -1,0 +1,15 @@
+/**
+ * Output from every generator function.
+ * Contains the generated code and any side effects.
+ */
+import TGeneratorEffect from "./TGeneratorEffect";
+
+interface IGeneratorOutput {
+  /** The generated C code */
+  readonly code: string;
+
+  /** Side effects to be processed by the orchestrator */
+  readonly effects: readonly TGeneratorEffect[];
+}
+
+export default IGeneratorOutput;

--- a/src/codegen/generators/IGeneratorState.ts
+++ b/src/codegen/generators/IGeneratorState.ts
@@ -1,0 +1,31 @@
+/**
+ * Transient state snapshot during generation.
+ * Represents the current position in the AST traversal.
+ * Generators read this but return effects to modify it.
+ */
+import TParameterInfo from "../types/TParameterInfo";
+
+interface IGeneratorState {
+  /** Current scope name (null if at file level) */
+  readonly currentScope: string | null;
+
+  /** Current indentation level */
+  readonly indentLevel: number;
+
+  /** Whether we're inside a function body */
+  readonly inFunctionBody: boolean;
+
+  /** Parameters of the current function */
+  readonly currentParameters: ReadonlyMap<string, TParameterInfo>;
+
+  /** Local variables in the current function */
+  readonly localVariables: ReadonlySet<string>;
+
+  /** Local arrays in the current function (no & needed for pass-by-ref) */
+  readonly localArrays: ReadonlySet<string>;
+
+  /** Expected type for inferred struct initializers */
+  readonly expectedType: string | null;
+}
+
+export default IGeneratorState;

--- a/src/codegen/generators/IOrchestrator.ts
+++ b/src/codegen/generators/IOrchestrator.ts
@@ -1,0 +1,40 @@
+/**
+ * Interface that CodeGenerator implements to orchestrate generators.
+ *
+ * Provides:
+ * - Access to read-only input and current state
+ * - Effect processing to update mutable state
+ * - Utility methods needed by generators
+ *
+ * This abstraction enables:
+ * - Testing generators with mock orchestrators
+ * - Gradual migration via "strangler fig" pattern
+ */
+import IGeneratorInput from "./IGeneratorInput";
+import IGeneratorState from "./IGeneratorState";
+import TGeneratorEffect from "./TGeneratorEffect";
+
+interface IOrchestrator {
+  // === State Access ===
+
+  /** Get the immutable input context */
+  getInput(): IGeneratorInput;
+
+  /** Get a snapshot of the current generation state */
+  getState(): IGeneratorState;
+
+  // === Effect Processing ===
+
+  /** Process effects returned by a generator, updating internal state */
+  applyEffects(effects: readonly TGeneratorEffect[]): void;
+
+  // === Utilities ===
+
+  /** Get the current indentation string */
+  getIndent(): string;
+
+  /** Resolve an identifier to its fully-scoped name */
+  resolveIdentifier(name: string): string;
+}
+
+export default IOrchestrator;

--- a/src/codegen/generators/TGeneratorEffect.ts
+++ b/src/codegen/generators/TGeneratorEffect.ts
@@ -1,0 +1,20 @@
+/**
+ * Side effects returned by generators instead of mutating state.
+ *
+ * Using a discriminated union enables:
+ * - Exhaustive switch handling (TypeScript catches missing cases)
+ * - Type-safe payloads per effect type
+ * - Central effect processing in the orchestrator
+ */
+import TTypeInfo from "../types/TTypeInfo";
+import TIncludeHeader from "./TIncludeHeader";
+
+type TGeneratorEffect =
+  | { type: "include"; header: TIncludeHeader }
+  | { type: "isr" } // Needs ISR typedef
+  | { type: "helper"; operation: string; cnxType: string } // Overflow clamp helper
+  | { type: "safe-div"; operation: "div" | "mod"; cnxType: string } // Safe division helper
+  | { type: "register-type"; name: string; info: TTypeInfo } // Register variable type
+  | { type: "register-local"; name: string; isArray: boolean }; // Register local variable
+
+export default TGeneratorEffect;

--- a/src/codegen/generators/TGeneratorFn.ts
+++ b/src/codegen/generators/TGeneratorFn.ts
@@ -1,0 +1,25 @@
+/**
+ * Generator function signature.
+ *
+ * A pure function that transforms an AST node into generated code + effects.
+ *
+ * @param node - The AST node to generate code for
+ * @param input - Read-only context (symbols, types, config)
+ * @param state - Current generation state (scope, indent, etc.)
+ * @param orchestrator - For delegating to other generators or utilities
+ * @returns Generated code and any side effects
+ */
+import { ParserRuleContext } from "antlr4ng";
+import IGeneratorInput from "./IGeneratorInput";
+import IGeneratorState from "./IGeneratorState";
+import IGeneratorOutput from "./IGeneratorOutput";
+import IOrchestrator from "./IOrchestrator";
+
+type TGeneratorFn<T extends ParserRuleContext> = (
+  node: T,
+  input: IGeneratorInput,
+  state: IGeneratorState,
+  orchestrator: IOrchestrator,
+) => IGeneratorOutput;
+
+export default TGeneratorFn;

--- a/src/codegen/generators/TIncludeHeader.ts
+++ b/src/codegen/generators/TIncludeHeader.ts
@@ -1,0 +1,6 @@
+/**
+ * Header include types that can be required by generators.
+ */
+type TIncludeHeader = "stdint" | "stdbool" | "string" | "cmsis";
+
+export default TIncludeHeader;


### PR DESCRIPTION
## Summary

- Create foundational types and registry for extracting generators from CodeGenerator.ts (ADR-053)
- Add `src/codegen/generators/` directory with core infrastructure
- Implement IOrchestrator interface in CodeGenerator

## Changes

**New files in `src/codegen/generators/`:**
| File | Purpose |
|------|---------|
| `IGeneratorInput.ts` | Read-only context for generators |
| `IGeneratorState.ts` | Transient state snapshot |
| `TGeneratorEffect.ts` | Discriminated union for side effects |
| `IGeneratorOutput.ts` | Code + effects return type |
| `IOrchestrator.ts` | Interface implemented by CodeGenerator |
| `TGeneratorFn.ts` | Generator function signature |
| `TIncludeHeader.ts` | Include header type |
| `GeneratorRegistry.ts` | Registry for extracted generators |

**CodeGenerator.ts:**
- Implements `IOrchestrator` with `getInput()`, `getState()`, `applyEffects()`, `getIndent()`, `resolveIdentifier()`
- Adds `GeneratorRegistry` instance (empty, ready for A2-A5)

## Test plan

- [x] TypeScript compiles cleanly (`npm run typecheck`)
- [x] Oxlint passes (`npm run oxlint:check`)
- [x] All 588 tests pass (`npm test`)
- [x] No behavior changes - infrastructure only

Closes #178

🤖 Generated with [Claude Code](https://claude.com/claude-code)