### PR TITLE
Fix bit-range register writes to use correct memory access width (Issue #187)

### DIFF
--- a/src/codegen/generators/ISymbolInfo.ts
+++ b/src/codegen/generators/ISymbolInfo.ts
@@ -78,6 +78,16 @@ interface ISymbolInfo {
 
   /** Register member types: "scope.reg.field" -> typeName */
   readonly registerMemberTypes: ReadonlyMap<string, string>;
+
+  // Issue #187: Register address info for width-appropriate memory access
+  /** Register base addresses: registerName -> base address expression */
+  readonly registerBaseAddresses: ReadonlyMap<string, string>;
+
+  /** Register member offsets: "reg_member" -> offset expression */
+  readonly registerMemberOffsets: ReadonlyMap<string, string>;
+
+  /** Register member C types: "reg_member" -> C type (e.g., "uint32_t") */
+  readonly registerMemberCTypes: ReadonlyMap<string, string>;
 }
 
 export default ISymbolInfo;

--- a/tests/register/register-memory-width.expected.c
+++ b/tests/register/register-memory-width.expected.c
@@ -5,8 +5,7 @@
 
 #include <stdint.h>
 
-// Tests: Memory access width must match bit-range width
-// BUG: Currently generates uint32_t* for 16-bit writes - WRONG!
+// Tests: Memory access width must match bit-range width (Issue #187)
 // For embedded systems, the memory access WIDTH matters for hardware behavior
 // u32 register with different access widths
 /* Register: REG32 @ 0x40000000 */
@@ -19,32 +18,32 @@ void write32(uint32_t* data) {
 
 // Write lower 16 bits - MUST use uint16_t* for correct hardware behavior
 void write16_at_0(uint16_t* data) {
-    REG32_DR = (((*data) & 0xFFFFU) << 0);
+    *((volatile uint16_t*)(0x40000000 + 0x00)) = ((*data));
 }
 
 // Write upper 16 bits - MUST use uint16_t* at offset +2
 void write16_at_16(uint16_t* data) {
-    REG32_DR = (((*data) & 0xFFFFU) << 16);
+    *((volatile uint16_t*)(0x40000000 + 0x00 + 2)) = ((*data));
 }
 
 // Write lower 8 bits - MUST use uint8_t*
 void write8_at_0(uint8_t* data) {
-    REG32_DR = (((*data) & 0xFFU) << 0);
+    *((volatile uint8_t*)(0x40000000 + 0x00)) = ((*data));
 }
 
 // Write byte at offset 1 - MUST use uint8_t* at offset +1
 void write8_at_8(uint8_t* data) {
-    REG32_DR = (((*data) & 0xFFU) << 8);
+    *((volatile uint8_t*)(0x40000000 + 0x00 + 1)) = ((*data));
 }
 
 // Write byte at offset 2 - MUST use uint8_t* at offset +2
 void write8_at_16(uint8_t* data) {
-    REG32_DR = (((*data) & 0xFFU) << 16);
+    *((volatile uint8_t*)(0x40000000 + 0x00 + 2)) = ((*data));
 }
 
 // Write byte at offset 3 - MUST use uint8_t* at offset +3
 void write8_at_24(uint8_t* data) {
-    REG32_DR = (((*data) & 0xFFU) << 24);
+    *((volatile uint8_t*)(0x40000000 + 0x00 + 3)) = ((*data));
 }
 
 int main(void) {

--- a/tests/register/register-memory-width.test.cnx
+++ b/tests/register/register-memory-width.test.cnx
@@ -1,5 +1,4 @@
-// Tests: Memory access width must match bit-range width
-// BUG: Currently generates uint32_t* for 16-bit writes - WRONG!
+// Tests: Memory access width must match bit-range width (Issue #187)
 // For embedded systems, the memory access WIDTH matters for hardware behavior
 
 // u32 register with different access widths


### PR DESCRIPTION
## Summary
- Fixes critical bug where bit-range writes on write-only registers used full 32-bit memory access regardless of the specified bit width
- For embedded systems, hardware peripherals (CRC, SPI FIFOs, DMA triggers) often behave differently based on memory access width
- Now generates width-appropriate inline casts for byte-aligned writes (8, 16, or 32 bits)

## Changes
- Extended `SymbolCollector` to track register base addresses, member offsets, and C types
- Updated `ISymbolInfo` interface with new register address properties
- Modified `CodeGenerator` to detect byte-aligned sub-width writes and generate correct memory access

## Before/After
```c
// Before (Bug): 32-bit memory access for 16-bit write
REG32_DR = (((*data) & 0xFFFFU) << 0);

// After (Fixed): Actual 16-bit memory access
*((volatile uint16_t*)(0x40000000 + 0x00)) = ((*data));
```

## Test plan
- [x] Specific test `register-memory-width.test.cnx` passes
- [x] Full test suite (592 tests) passes
- [x] Linter passes (oxlint)

Closes #187

🤖 Generated with [Claude Code](https://claude.com/claude-code)