### PR TITLE
Add persistent cache layer for parsed C/C++ header symbols (Issue #183)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -105,6 +105,7 @@ function showHelp(): void {
     "  --exclude-headers  Don't generate header files (default: generate)",
   );
   console.log("  --no-preprocess    Don't run C preprocessor on headers");
+  console.log("  --no-cache         Disable symbol cache (.cnx/ directory)");
   console.log("  -D<name>[=value]   Define preprocessor macro");
   console.log("  --pio-install      Setup PlatformIO integration");
   console.log("  --pio-uninstall    Remove PlatformIO integration");
@@ -188,6 +189,7 @@ async function runUnifiedMode(
   preprocess: boolean,
   verbose: boolean,
   outputExtension: ".c" | ".cpp",
+  noCache: boolean,
 ): Promise<void> {
   // Step 1: Expand directories to .cnx files
   let files: string[];
@@ -256,6 +258,7 @@ async function runUnifiedMode(
     preprocess,
     defines,
     outputExtension,
+    noCache,
   });
 
   // Step 5: Compile
@@ -466,6 +469,7 @@ async function main(): Promise<void> {
   let cliOutputExtension: ".c" | ".cpp" | undefined;
   let preprocess = true;
   let verbose = false;
+  let noCache = false;
 
   for (let i = 0; i < args.length; i++) {
     const arg = args[i];
@@ -482,6 +486,8 @@ async function main(): Promise<void> {
       cliOutputExtension = ".cpp";
     } else if (arg === "--no-preprocess") {
       preprocess = false;
+    } else if (arg === "--no-cache") {
+      noCache = true;
     } else if (arg.startsWith("-D")) {
       const define = arg.slice(2);
       const eqIndex = define.indexOf("=");
@@ -520,6 +526,7 @@ async function main(): Promise<void> {
     preprocess,
     verbose,
     outputExtension,
+    noCache,
   );
 }
 

--- a/src/pipeline/CacheManager.ts
+++ b/src/pipeline/CacheManager.ts
@@ -1,0 +1,363 @@
+/**
+ * CacheManager
+ *
+ * Manages persistent cache for parsed C/C++ header symbols.
+ * Cache is stored in .cnx/ directory (similar to .git/).
+ *
+ * Cache structure:
+ *   .cnx/
+ *     config.json     - Cache metadata (version, timestamps)
+ *     cache/
+ *       symbols.json  - Cached symbols per file
+ */
+
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  writeFileSync,
+  statSync,
+} from "fs";
+import { join } from "path";
+import ISymbol from "../types/ISymbol";
+import IStructFieldInfo from "../symbols/types/IStructFieldInfo";
+import ICacheConfig from "./types/ICacheConfig";
+import ICacheSymbols from "./types/ICacheSymbols";
+import ICachedFileEntry from "./types/ICachedFileEntry";
+import ISerializedSymbol from "./types/ISerializedSymbol";
+
+/** Current cache format version - increment when serialization format changes */
+const CACHE_VERSION = 1;
+
+// Read version from package.json
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const packageJson = require("../../package.json");
+const TRANSPILER_VERSION = packageJson.version as string;
+
+/**
+ * Manages symbol cache for faster incremental builds
+ */
+class CacheManager {
+  private projectRoot: string;
+  private cacheDir: string;
+  private configPath: string;
+  private symbolsPath: string;
+
+  /** In-memory cache of file entries */
+  private entries: Map<string, ICachedFileEntry> = new Map();
+
+  /** Whether the cache has been modified and needs flushing */
+  private dirty = false;
+
+  constructor(projectRoot: string) {
+    this.projectRoot = projectRoot;
+    this.cacheDir = join(projectRoot, ".cnx");
+    this.configPath = join(this.cacheDir, "config.json");
+    this.symbolsPath = join(this.cacheDir, "cache", "symbols.json");
+  }
+
+  /**
+   * Initialize the cache directory and load existing cache
+   */
+  async initialize(): Promise<void> {
+    // Create .cnx directory structure
+    if (!existsSync(this.cacheDir)) {
+      mkdirSync(this.cacheDir, { recursive: true });
+    }
+
+    const cacheSubdir = join(this.cacheDir, "cache");
+    if (!existsSync(cacheSubdir)) {
+      mkdirSync(cacheSubdir, { recursive: true });
+    }
+
+    // Load or create config
+    const config = this.loadOrCreateConfig();
+
+    // Check if cache should be invalidated
+    if (this.shouldInvalidateCache(config)) {
+      this.invalidateAll();
+      this.saveConfig();
+      return;
+    }
+
+    // Load existing symbols cache
+    this.loadSymbolsCache();
+  }
+
+  /**
+   * Check if a file's cache is valid (not modified since cached)
+   */
+  isValid(filePath: string): boolean {
+    const entry = this.entries.get(filePath);
+    if (!entry) {
+      return false;
+    }
+
+    try {
+      const stats = statSync(filePath);
+      return stats.mtimeMs <= entry.mtime;
+    } catch {
+      // File doesn't exist or can't be read
+      return false;
+    }
+  }
+
+  /**
+   * Get cached symbols and struct fields for a file
+   */
+  getSymbols(filePath: string): {
+    symbols: ISymbol[];
+    structFields: Map<string, Map<string, IStructFieldInfo>>;
+  } | null {
+    const entry = this.entries.get(filePath);
+    if (!entry) {
+      return null;
+    }
+
+    // Deserialize symbols
+    const symbols = entry.symbols.map((s) => this.deserializeSymbol(s));
+
+    // Convert struct fields from plain objects to Maps
+    const structFields = new Map<string, Map<string, IStructFieldInfo>>();
+    for (const [structName, fields] of Object.entries(entry.structFields)) {
+      const fieldMap = new Map<string, IStructFieldInfo>();
+      for (const [fieldName, fieldInfo] of Object.entries(fields)) {
+        fieldMap.set(fieldName, fieldInfo);
+      }
+      structFields.set(structName, fieldMap);
+    }
+
+    return { symbols, structFields };
+  }
+
+  /**
+   * Store symbols and struct fields for a file
+   */
+  setSymbols(
+    filePath: string,
+    symbols: ISymbol[],
+    structFields: Map<string, Map<string, IStructFieldInfo>>,
+  ): void {
+    // Get current mtime
+    let mtime: number;
+    try {
+      const stats = statSync(filePath);
+      mtime = stats.mtimeMs;
+    } catch {
+      // If we can't stat the file, don't cache it
+      return;
+    }
+
+    // Serialize symbols
+    const serializedSymbols = symbols.map((s) => this.serializeSymbol(s));
+
+    // Convert struct fields from Maps to plain objects
+    const serializedFields: Record<
+      string,
+      Record<string, IStructFieldInfo>
+    > = {};
+    for (const [structName, fields] of structFields) {
+      serializedFields[structName] = {};
+      for (const [fieldName, fieldInfo] of fields) {
+        serializedFields[structName][fieldName] = fieldInfo;
+      }
+    }
+
+    // Create entry
+    const entry: ICachedFileEntry = {
+      filePath,
+      mtime,
+      symbols: serializedSymbols,
+      structFields: serializedFields,
+    };
+
+    this.entries.set(filePath, entry);
+    this.dirty = true;
+  }
+
+  /**
+   * Invalidate cache for a specific file
+   */
+  invalidate(filePath: string): void {
+    if (this.entries.has(filePath)) {
+      this.entries.delete(filePath);
+      this.dirty = true;
+    }
+  }
+
+  /**
+   * Invalidate all cached entries
+   */
+  invalidateAll(): void {
+    this.entries.clear();
+    this.dirty = true;
+  }
+
+  /**
+   * Flush cache to disk if modified
+   */
+  async flush(): Promise<void> {
+    if (!this.dirty) {
+      return;
+    }
+
+    // Convert entries map to array
+    const cacheSymbols: ICacheSymbols = {
+      entries: Array.from(this.entries.values()),
+    };
+
+    // Write symbols cache
+    writeFileSync(
+      this.symbolsPath,
+      JSON.stringify(cacheSymbols, null, 2),
+      "utf-8",
+    );
+
+    this.dirty = false;
+  }
+
+  /**
+   * Get the cache directory path
+   */
+  getCacheDir(): string {
+    return this.cacheDir;
+  }
+
+  /**
+   * Load or create config file
+   */
+  private loadOrCreateConfig(): ICacheConfig {
+    if (existsSync(this.configPath)) {
+      try {
+        const content = readFileSync(this.configPath, "utf-8");
+        return JSON.parse(content) as ICacheConfig;
+      } catch {
+        // Config is corrupted, create new one
+      }
+    }
+
+    // Create new config
+    const config: ICacheConfig = {
+      version: CACHE_VERSION,
+      created: Date.now(),
+      transpilerVersion: TRANSPILER_VERSION,
+    };
+
+    this.saveConfig(config);
+    return config;
+  }
+
+  /**
+   * Save config file
+   */
+  private saveConfig(config?: ICacheConfig): void {
+    const configToSave = config ?? {
+      version: CACHE_VERSION,
+      created: Date.now(),
+      transpilerVersion: TRANSPILER_VERSION,
+    };
+
+    writeFileSync(
+      this.configPath,
+      JSON.stringify(configToSave, null, 2),
+      "utf-8",
+    );
+  }
+
+  /**
+   * Check if cache should be invalidated based on version
+   */
+  private shouldInvalidateCache(config: ICacheConfig): boolean {
+    // Invalidate if cache version changed
+    if (config.version !== CACHE_VERSION) {
+      return true;
+    }
+
+    // Invalidate if transpiler version changed
+    if (config.transpilerVersion !== TRANSPILER_VERSION) {
+      return true;
+    }
+
+    return false;
+  }
+
+  /**
+   * Load symbols cache from disk
+   */
+  private loadSymbolsCache(): void {
+    if (!existsSync(this.symbolsPath)) {
+      return;
+    }
+
+    try {
+      const content = readFileSync(this.symbolsPath, "utf-8");
+      const cacheSymbols = JSON.parse(content) as ICacheSymbols;
+
+      for (const entry of cacheSymbols.entries) {
+        this.entries.set(entry.filePath, entry);
+      }
+    } catch {
+      // Cache file is corrupted, start fresh
+      this.entries.clear();
+    }
+  }
+
+  /**
+   * Serialize an ISymbol to JSON-safe format
+   */
+  private serializeSymbol(symbol: ISymbol): ISerializedSymbol {
+    const serialized: ISerializedSymbol = {
+      name: symbol.name,
+      kind: symbol.kind, // Already a string from enum
+      sourceFile: symbol.sourceFile,
+      sourceLine: symbol.sourceLine,
+      sourceLanguage: symbol.sourceLanguage, // Already a string from enum
+      isExported: symbol.isExported,
+    };
+
+    // Add optional fields only if present
+    if (symbol.type !== undefined) serialized.type = symbol.type;
+    if (symbol.isDeclaration !== undefined)
+      serialized.isDeclaration = symbol.isDeclaration;
+    if (symbol.signature !== undefined) serialized.signature = symbol.signature;
+    if (symbol.parent !== undefined) serialized.parent = symbol.parent;
+    if (symbol.accessModifier !== undefined)
+      serialized.accessModifier = symbol.accessModifier;
+    if (symbol.size !== undefined) serialized.size = symbol.size;
+    if (symbol.parameters !== undefined)
+      serialized.parameters = symbol.parameters;
+
+    return serialized;
+  }
+
+  /**
+   * Deserialize a symbol from JSON format back to ISymbol
+   */
+  private deserializeSymbol(serialized: ISerializedSymbol): ISymbol {
+    const symbol: ISymbol = {
+      name: serialized.name,
+      kind: serialized.kind as ISymbol["kind"], // Cast string back to enum
+      sourceFile: serialized.sourceFile,
+      sourceLine: serialized.sourceLine,
+      sourceLanguage: serialized.sourceLanguage as ISymbol["sourceLanguage"],
+      isExported: serialized.isExported,
+    };
+
+    // Add optional fields only if present
+    if (serialized.type !== undefined) symbol.type = serialized.type;
+    if (serialized.isDeclaration !== undefined)
+      symbol.isDeclaration = serialized.isDeclaration;
+    if (serialized.signature !== undefined)
+      symbol.signature = serialized.signature;
+    if (serialized.parent !== undefined) symbol.parent = serialized.parent;
+    if (serialized.accessModifier !== undefined)
+      symbol.accessModifier = serialized.accessModifier;
+    if (serialized.size !== undefined) symbol.size = serialized.size;
+    if (serialized.parameters !== undefined)
+      symbol.parameters = serialized.parameters;
+
+    return symbol;
+  }
+}
+
+export default CacheManager;

--- a/src/pipeline/types/ICacheConfig.ts
+++ b/src/pipeline/types/ICacheConfig.ts
@@ -1,0 +1,13 @@
+/**
+ * Cache configuration stored in .cnx/config.json
+ */
+interface ICacheConfig {
+  /** Cache format version - increment when serialization format changes */
+  version: number;
+  /** Timestamp when cache was created (ms since epoch) */
+  created: number;
+  /** Transpiler version for compatibility checking */
+  transpilerVersion: string;
+}
+
+export default ICacheConfig;

--- a/src/pipeline/types/ICacheSymbols.ts
+++ b/src/pipeline/types/ICacheSymbols.ts
@@ -1,0 +1,12 @@
+/**
+ * Root structure for cached symbols stored in .cnx/cache/symbols.json
+ */
+
+import ICachedFileEntry from "./ICachedFileEntry";
+
+interface ICacheSymbols {
+  /** All cached file entries */
+  entries: ICachedFileEntry[];
+}
+
+export default ICacheSymbols;

--- a/src/pipeline/types/ICachedFileEntry.ts
+++ b/src/pipeline/types/ICachedFileEntry.ts
@@ -1,0 +1,19 @@
+/**
+ * Cached entry for a single header file
+ */
+
+import IStructFieldInfo from "../../symbols/types/IStructFieldInfo";
+import ISerializedSymbol from "./ISerializedSymbol";
+
+interface ICachedFileEntry {
+  /** Absolute path to the header file */
+  filePath: string;
+  /** File modification time (ms since epoch) */
+  mtime: number;
+  /** Symbols extracted from this file */
+  symbols: ISerializedSymbol[];
+  /** Struct fields: struct name -> (field name -> field info) */
+  structFields: Record<string, Record<string, IStructFieldInfo>>;
+}
+
+export default ICachedFileEntry;

--- a/src/pipeline/types/IPipelineConfig.ts
+++ b/src/pipeline/types/IPipelineConfig.ts
@@ -37,6 +37,9 @@ interface IPipelineConfig {
 
   /** Issue #35: Collect grammar rule coverage during parsing */
   collectGrammarCoverage?: boolean;
+
+  /** Issue #183: Disable symbol caching (default: false = cache enabled) */
+  noCache?: boolean;
 }
 
 export default IPipelineConfig;

--- a/src/pipeline/types/ISerializedSymbol.ts
+++ b/src/pipeline/types/ISerializedSymbol.ts
@@ -1,0 +1,40 @@
+/**
+ * Serialized symbol for JSON storage
+ * Uses string values for enums to ensure clean JSON serialization
+ */
+interface ISerializedSymbol {
+  /** Symbol name */
+  name: string;
+  /** Kind of symbol (function, variable, type, etc.) */
+  kind: string;
+  /** Type of the symbol */
+  type?: string;
+  /** Source file where the symbol is defined */
+  sourceFile: string;
+  /** Line number in the source file */
+  sourceLine: number;
+  /** Source language (c, cpp, cnext) */
+  sourceLanguage: string;
+  /** Whether this symbol is exported/public */
+  isExported: boolean;
+  /** Whether this is a declaration (not definition) */
+  isDeclaration?: boolean;
+  /** Function signature for overload detection */
+  signature?: string;
+  /** Parent namespace or class name */
+  parent?: string;
+  /** Access modifier for register members */
+  accessModifier?: string;
+  /** For arrays: element count. For integers: bit width */
+  size?: number;
+  /** Function parameters for header generation */
+  parameters?: Array<{
+    name: string;
+    type: string;
+    isConst: boolean;
+    isArray: boolean;
+    arrayDimensions?: string[];
+  }>;
+}
+
+export default ISerializedSymbol;

--- a/src/project/Project.ts
+++ b/src/project/Project.ts
@@ -50,6 +50,7 @@ class Project {
       preprocess: this.config.preprocess,
       generateHeaders: this.config.generateHeaders,
       outputExtension: this.config.outputExtension,
+      noCache: this.config.noCache,
     });
   }
 

--- a/src/project/types/IProjectConfig.ts
+++ b/src/project/types/IProjectConfig.ts
@@ -31,6 +31,9 @@ interface IProjectConfig {
 
   /** Output file extension (default: ".c") */
   outputExtension?: ".c" | ".cpp";
+
+  /** Issue #183: Disable symbol caching (default: false = cache enabled) */
+  noCache?: boolean;
 }
 
 export default IProjectConfig;


### PR DESCRIPTION
## Summary

- Implement a `.cnx/` directory cache (similar to `.git/`) that stores parsed C/C++ header symbols
- Cache enables faster incremental builds by avoiding re-parsing unchanged headers
- Add `--no-cache` CLI flag to disable caching when needed

## Key Changes

- **CacheManager class** (`src/pipeline/CacheManager.ts`): Core cache management with initialization, validation, get/set operations, and disk persistence
- **Cache types** (`src/pipeline/types/ICacheConfig.ts`, `ICachedFileEntry.ts`, etc.): Type definitions for cache configuration and serialized symbols
- **SymbolTable helpers** (`src/symbols/SymbolTable.ts`): Added `getAllStructFields()`, `restoreStructFields()`, and `getStructNamesByFile()` methods
- **Pipeline integration** (`src/pipeline/Pipeline.ts`): Cache lookup before parsing, cache storage after parsing
- **CLI flag** (`src/index.ts`): Added `--no-cache` option

## Cache Architecture

```
.cnx/
├── cache/
│   └── symbols.json    # Per-file cached symbols + struct fields
└── config.json         # Cache metadata (version, timestamps)
```

**Invalidation Strategy:**
1. Version-based: Invalidates entire cache when transpiler or cache format version changes
2. Mtime-based: Invalidates individual files when modification time exceeds cached mtime

## Test Plan

- [x] Run existing test suite (588/592 pass - 4 pre-existing failures in scope tests)
- [x] Manual test: cache created on first run
- [x] Manual test: cache hit on subsequent runs
- [x] Manual test: cache invalidation when headers modified
- [x] Manual test: `--no-cache` flag disables caching

Closes #183

---
Generated with [Claude Code](https://claude.com/claude-code)