### PR TITLE
Extract support generators for modular code generation (Issue #185)

### DIFF
--- a/src/codegen/generators/support/CommentUtils.ts
+++ b/src/codegen/generators/support/CommentUtils.ts
@@ -1,0 +1,63 @@
+/**
+ * Comment handling utilities.
+ * Extracted from CodeGenerator.ts as part of ADR-053 A5.
+ */
+import IComment from "../../types/IComment";
+import CommentExtractor from "../../CommentExtractor";
+import CommentFormatter from "../../CommentFormatter";
+
+/**
+ * Get comments that appear before a parse tree node
+ */
+const getLeadingComments = (
+  ctx: { start?: { tokenIndex: number } | null },
+  extractor: CommentExtractor | null,
+): IComment[] => {
+  if (!extractor || !ctx.start) return [];
+  return extractor.getCommentsBefore(ctx.start.tokenIndex);
+};
+
+/**
+ * Get inline comments that appear after a parse tree node (same line)
+ */
+const getTrailingComments = (
+  ctx: { stop?: { tokenIndex: number } | null },
+  extractor: CommentExtractor | null,
+): IComment[] => {
+  if (!extractor || !ctx.stop) return [];
+  return extractor.getCommentsAfter(ctx.stop.tokenIndex);
+};
+
+/**
+ * Format leading comments with current indentation
+ */
+const formatLeadingComments = (
+  comments: IComment[],
+  formatter: CommentFormatter,
+  indent: string,
+): string[] => {
+  if (comments.length === 0) return [];
+  return formatter.formatLeadingComments(comments, indent);
+};
+
+/**
+ * Format a trailing/inline comment
+ */
+const formatTrailingComment = (
+  comments: IComment[],
+  formatter: CommentFormatter,
+): string => {
+  if (comments.length === 0) return "";
+  // Only use the first comment for inline
+  return formatter.formatTrailingComment(comments[0]);
+};
+
+// Export as an object for consistent module pattern
+const commentUtils = {
+  getLeadingComments,
+  getTrailingComments,
+  formatLeadingComments,
+  formatTrailingComment,
+};
+
+export default commentUtils;

--- a/src/codegen/generators/support/HelperGenerator.ts
+++ b/src/codegen/generators/support/HelperGenerator.ts
@@ -1,0 +1,361 @@
+/**
+ * Helper function generators for overflow-safe arithmetic and safe division.
+ * Extracted from CodeGenerator.ts as part of ADR-053 A5.
+ */
+import TYPE_MAP from "../../types/TYPE_MAP";
+import WIDER_TYPE_MAP from "../../types/WIDER_TYPE_MAP";
+import TYPE_LIMITS from "../../types/TYPE_LIMITS";
+
+const { TYPE_MAX, TYPE_MIN } = TYPE_LIMITS;
+
+/**
+ * Generate a single overflow helper function (clamps on overflow)
+ */
+function generateSingleHelper(
+  operation: string,
+  cnxType: string,
+): string | null {
+  const cType = TYPE_MAP[cnxType];
+  const widerType = WIDER_TYPE_MAP[cnxType] || cType;
+  const maxValue = TYPE_MAX[cnxType];
+  const minValue = TYPE_MIN[cnxType];
+
+  if (!cType || !maxValue) {
+    return null;
+  }
+
+  const isUnsigned = cnxType.startsWith("u");
+
+  // For signed types narrower than i64, use wider arithmetic to avoid UB (Issue #94)
+  const useWiderArithmetic =
+    !isUnsigned && widerType !== cType && cnxType !== "i64";
+
+  switch (operation) {
+    case "add":
+      if (isUnsigned) {
+        // Unsigned addition: use wider type for b to prevent truncation (Issue #94)
+        return `static inline ${cType} cnx_clamp_add_${cnxType}(${cType} a, ${widerType} b) {
+    if (b > ${maxValue} - a) return ${maxValue};
+    return a + (${cType})b;
+}`;
+      } else if (useWiderArithmetic) {
+        // Signed addition: compute in wider type, then clamp (Issue #94)
+        // This avoids UB from casting out-of-range values
+        return `static inline ${cType} cnx_clamp_add_${cnxType}(${cType} a, ${widerType} b) {
+    ${widerType} result = (${widerType})a + b;
+    if (result > ${maxValue}) return ${maxValue};
+    if (result < ${minValue}) return ${minValue};
+    return (${cType})result;
+}`;
+      } else {
+        // i64: already widest type, use original check logic
+        return `static inline ${cType} cnx_clamp_add_${cnxType}(${cType} a, ${cType} b) {
+    if (b > 0 && a > ${maxValue} - b) return ${maxValue};
+    if (b < 0 && a < ${minValue} - b) return ${minValue};
+    return a + b;
+}`;
+      }
+
+    case "sub":
+      if (isUnsigned) {
+        // Unsigned subtraction: use wider type for b to prevent truncation (Issue #94)
+        // Cast a to wider type for comparison to handle b > type max
+        return `static inline ${cType} cnx_clamp_sub_${cnxType}(${cType} a, ${widerType} b) {
+    if (b >= (${widerType})a) return 0;
+    return a - (${cType})b;
+}`;
+      } else if (useWiderArithmetic) {
+        // Signed subtraction: compute in wider type, then clamp (Issue #94)
+        return `static inline ${cType} cnx_clamp_sub_${cnxType}(${cType} a, ${widerType} b) {
+    ${widerType} result = (${widerType})a - b;
+    if (result > ${maxValue}) return ${maxValue};
+    if (result < ${minValue}) return ${minValue};
+    return (${cType})result;
+}`;
+      } else {
+        // i64: already widest type, use original check logic
+        return `static inline ${cType} cnx_clamp_sub_${cnxType}(${cType} a, ${cType} b) {
+    if (b < 0 && a > ${maxValue} + b) return ${maxValue};
+    if (b > 0 && a < ${minValue} + b) return ${minValue};
+    return a - b;
+}`;
+      }
+
+    case "mul":
+      if (isUnsigned) {
+        // Unsigned multiplication: use wider type for b to prevent truncation (Issue #94)
+        return `static inline ${cType} cnx_clamp_mul_${cnxType}(${cType} a, ${widerType} b) {
+    if (b != 0 && a > ${maxValue} / b) return ${maxValue};
+    return a * (${cType})b;
+}`;
+      } else if (useWiderArithmetic) {
+        // Signed multiplication: compute in wider type, then clamp (Issue #94)
+        return `static inline ${cType} cnx_clamp_mul_${cnxType}(${cType} a, ${widerType} b) {
+    ${widerType} result = (${widerType})a * b;
+    if (result > ${maxValue}) return ${maxValue};
+    if (result < ${minValue}) return ${minValue};
+    return (${cType})result;
+}`;
+      } else {
+        // i64: already widest type, use original check logic
+        return `static inline ${cType} cnx_clamp_mul_${cnxType}(${cType} a, ${cType} b) {
+    if (a == 0 || b == 0) return 0;
+    if (a > 0 && b > 0 && a > ${maxValue} / b) return ${maxValue};
+    if (a < 0 && b < 0 && a < ${maxValue} / b) return ${maxValue};
+    if (a > 0 && b < 0 && b < ${minValue} / a) return ${minValue};
+    if (a < 0 && b > 0 && a < ${minValue} / b) return ${minValue};
+    return a * b;
+}`;
+      }
+
+    default:
+      return null;
+  }
+}
+
+/**
+ * Generate a single debug helper function (panics on overflow)
+ */
+function generateDebugHelper(
+  operation: string,
+  cnxType: string,
+): string | null {
+  const cType = TYPE_MAP[cnxType];
+  const widerType = WIDER_TYPE_MAP[cnxType] || cType;
+  const maxValue = TYPE_MAX[cnxType];
+  const minValue = TYPE_MIN[cnxType];
+
+  if (!cType || !maxValue) {
+    return null;
+  }
+
+  const isUnsigned = cnxType.startsWith("u");
+  const opName =
+    operation === "add"
+      ? "addition"
+      : operation === "sub"
+        ? "subtraction"
+        : "multiplication";
+
+  // For signed types narrower than i64, use wider arithmetic to avoid UB (Issue #94)
+  const useWiderArithmetic =
+    !isUnsigned && widerType !== cType && cnxType !== "i64";
+
+  switch (operation) {
+    case "add":
+      if (isUnsigned) {
+        // Use wider type for b to prevent truncation (Issue #94)
+        return `static inline ${cType} cnx_clamp_add_${cnxType}(${cType} a, ${widerType} b) {
+    if (b > ${maxValue} - a) {
+        fprintf(stderr, "PANIC: Integer overflow in ${cnxType} ${opName}\\n");
+        abort();
+    }
+    return a + (${cType})b;
+}`;
+      } else if (useWiderArithmetic) {
+        // Signed addition: compute in wider type, check bounds (Issue #94)
+        return `static inline ${cType} cnx_clamp_add_${cnxType}(${cType} a, ${widerType} b) {
+    ${widerType} result = (${widerType})a + b;
+    if (result > ${maxValue} || result < ${minValue}) {
+        fprintf(stderr, "PANIC: Integer overflow in ${cnxType} ${opName}\\n");
+        abort();
+    }
+    return (${cType})result;
+}`;
+      } else {
+        // i64: already widest type, use original check logic
+        return `static inline ${cType} cnx_clamp_add_${cnxType}(${cType} a, ${cType} b) {
+    if ((b > 0 && a > ${maxValue} - b) || (b < 0 && a < ${minValue} - b)) {
+        fprintf(stderr, "PANIC: Integer overflow in ${cnxType} ${opName}\\n");
+        abort();
+    }
+    return a + b;
+}`;
+      }
+
+    case "sub":
+      if (isUnsigned) {
+        // Use wider type for b to prevent truncation (Issue #94)
+        return `static inline ${cType} cnx_clamp_sub_${cnxType}(${cType} a, ${widerType} b) {
+    if (b >= (${widerType})a) {
+        fprintf(stderr, "PANIC: Integer underflow in ${cnxType} ${opName}\\n");
+        abort();
+    }
+    return a - (${cType})b;
+}`;
+      } else if (useWiderArithmetic) {
+        // Signed subtraction: compute in wider type, check bounds (Issue #94)
+        return `static inline ${cType} cnx_clamp_sub_${cnxType}(${cType} a, ${widerType} b) {
+    ${widerType} result = (${widerType})a - b;
+    if (result > ${maxValue} || result < ${minValue}) {
+        fprintf(stderr, "PANIC: Integer overflow in ${cnxType} ${opName}\\n");
+        abort();
+    }
+    return (${cType})result;
+}`;
+      } else {
+        // i64: already widest type, use original check logic
+        return `static inline ${cType} cnx_clamp_sub_${cnxType}(${cType} a, ${cType} b) {
+    if ((b < 0 && a > ${maxValue} + b) || (b > 0 && a < ${minValue} + b)) {
+        fprintf(stderr, "PANIC: Integer overflow in ${cnxType} ${opName}\\n");
+        abort();
+    }
+    return a - b;
+}`;
+      }
+
+    case "mul":
+      if (isUnsigned) {
+        // Use wider type for b to prevent truncation (Issue #94)
+        return `static inline ${cType} cnx_clamp_mul_${cnxType}(${cType} a, ${widerType} b) {
+    if (b != 0 && a > ${maxValue} / b) {
+        fprintf(stderr, "PANIC: Integer overflow in ${cnxType} ${opName}\\n");
+        abort();
+    }
+    return a * (${cType})b;
+}`;
+      } else if (useWiderArithmetic) {
+        // Signed multiplication: compute in wider type, check bounds (Issue #94)
+        return `static inline ${cType} cnx_clamp_mul_${cnxType}(${cType} a, ${widerType} b) {
+    ${widerType} result = (${widerType})a * b;
+    if (result > ${maxValue} || result < ${minValue}) {
+        fprintf(stderr, "PANIC: Integer overflow in ${cnxType} ${opName}\\n");
+        abort();
+    }
+    return (${cType})result;
+}`;
+      } else {
+        // i64: already widest type, use original check logic
+        return `static inline ${cType} cnx_clamp_mul_${cnxType}(${cType} a, ${cType} b) {
+    if (a != 0 && b != 0) {
+        if ((a > 0 && b > 0 && a > ${maxValue} / b) ||
+            (a < 0 && b < 0 && a < ${maxValue} / b) ||
+            (a > 0 && b < 0 && b < ${minValue} / a) ||
+            (a < 0 && b > 0 && a < ${minValue} / b)) {
+            fprintf(stderr, "PANIC: Integer overflow in ${cnxType} ${opName}\\n");
+            abort();
+        }
+    }
+    return a * b;
+}`;
+      }
+
+    default:
+      return null;
+  }
+}
+
+/**
+ * Generate all needed overflow helper functions
+ * ADR-044: Overflow helper functions with clamping or panic behavior
+ */
+const generateOverflowHelpers = (
+  usedClampOps: ReadonlySet<string>,
+  debugMode: boolean,
+): string[] => {
+  if (usedClampOps.size === 0) {
+    return [];
+  }
+
+  const lines: string[] = [];
+
+  if (debugMode) {
+    lines.push(
+      "// ADR-044: Debug overflow helper functions (panic on overflow)",
+    );
+    lines.push("#include <limits.h>");
+    lines.push("#include <stdio.h>");
+    lines.push("#include <stdlib.h>");
+  } else {
+    lines.push("// ADR-044: Overflow helper functions");
+    lines.push("#include <limits.h>");
+  }
+  lines.push("");
+
+  // Sort for deterministic output
+  const sortedOps = Array.from(usedClampOps).sort();
+
+  for (const op of sortedOps) {
+    const [operation, cnxType] = op.split("_");
+    const helper = debugMode
+      ? generateDebugHelper(operation, cnxType)
+      : generateSingleHelper(operation, cnxType);
+    if (helper) {
+      lines.push(helper);
+      lines.push("");
+    }
+  }
+
+  return lines;
+};
+
+/**
+ * Generate safe division helper functions for used integer types only
+ * ADR-051: Safe division helpers that return error flag on division by zero
+ */
+const generateSafeDivHelpers = (
+  usedSafeDivOps: ReadonlySet<string>,
+): string[] => {
+  if (usedSafeDivOps.size === 0) {
+    return [];
+  }
+
+  const lines: string[] = [];
+
+  lines.push("// ADR-051: Safe division helper functions");
+  lines.push("#include <stdbool.h>");
+  lines.push("");
+
+  const integerTypes = ["u8", "u16", "u32", "u64", "i8", "i16", "i32", "i64"];
+
+  for (const cnxType of integerTypes) {
+    const needsDiv = usedSafeDivOps.has(`div_${cnxType}`);
+    const needsMod = usedSafeDivOps.has(`mod_${cnxType}`);
+
+    if (!needsDiv && !needsMod) {
+      continue; // Skip types that aren't used
+    }
+
+    const cType = TYPE_MAP[cnxType];
+
+    // Generate safe_div helper if needed
+    if (needsDiv) {
+      lines.push(
+        `static inline bool cnx_safe_div_${cnxType}(${cType}* output, ${cType} numerator, ${cType} divisor, ${cType} defaultValue) {`,
+      );
+      lines.push(`    if (divisor == 0) {`);
+      lines.push(`        *output = defaultValue;`);
+      lines.push(`        return true;  // Error occurred`);
+      lines.push(`    }`);
+      lines.push(`    *output = numerator / divisor;`);
+      lines.push(`    return false;  // Success`);
+      lines.push(`}`);
+      lines.push("");
+    }
+
+    // Generate safe_mod helper if needed
+    if (needsMod) {
+      lines.push(
+        `static inline bool cnx_safe_mod_${cnxType}(${cType}* output, ${cType} numerator, ${cType} divisor, ${cType} defaultValue) {`,
+      );
+      lines.push(`    if (divisor == 0) {`);
+      lines.push(`        *output = defaultValue;`);
+      lines.push(`        return true;  // Error occurred`);
+      lines.push(`    }`);
+      lines.push(`    *output = numerator % divisor;`);
+      lines.push(`    return false;  // Success`);
+      lines.push(`}`);
+      lines.push("");
+    }
+  }
+
+  return lines;
+};
+
+// Export as an object for consistent module pattern
+const helperGenerators = {
+  generateOverflowHelpers,
+  generateSafeDivHelpers,
+};
+
+export default helperGenerators;

--- a/src/codegen/generators/support/IncludeGenerator.ts
+++ b/src/codegen/generators/support/IncludeGenerator.ts
@@ -1,0 +1,134 @@
+/**
+ * Include directive and preprocessor handling.
+ * Extracted from CodeGenerator.ts as part of ADR-053 A5.
+ */
+import * as fs from "fs";
+import * as path from "path";
+import * as Parser from "../../../parser/grammar/CNextParser";
+
+/**
+ * ADR-010: Transform #include directives, converting .cnx to .h
+ * Validates that .cnx files exist if sourcePath is available
+ * Supports both <file.cnx> and "file.cnx" forms
+ */
+const transformIncludeDirective = (
+  includeText: string,
+  sourcePath: string | null,
+): string => {
+  // Match: #include <file.cnx> or #include "file.cnx"
+  const angleMatch = includeText.match(/#\s*include\s*<([^>]+)\.cnx>/);
+  const quoteMatch = includeText.match(/#\s*include\s*"([^"]+)\.cnx"/);
+
+  if (angleMatch) {
+    const filename = angleMatch[1];
+    // Angle brackets: system/library includes - no validation needed
+    return includeText.replace(`<${filename}.cnx>`, `<${filename}.h>`);
+  } else if (quoteMatch) {
+    const filepath = quoteMatch[1];
+
+    // Validate .cnx file exists if we have source path
+    if (sourcePath) {
+      const sourceDir = path.dirname(sourcePath);
+      const cnxPath = path.resolve(sourceDir, `${filepath}.cnx`);
+
+      if (!fs.existsSync(cnxPath)) {
+        throw new Error(
+          `Error: Included C-Next file not found: ${filepath}.cnx\n` +
+            `  Searched at: ${cnxPath}\n` +
+            `  Referenced in: ${sourcePath}`,
+        );
+      }
+    }
+
+    // Transform to .h
+    return includeText.replace(`"${filepath}.cnx"`, `"${filepath}.h"`);
+  }
+
+  // Not a .cnx include - pass through unchanged
+  return includeText;
+};
+
+/**
+ * Extract the macro name from a #define directive
+ */
+const extractDefineName = (text: string): string => {
+  const match = text.match(/#\s*define\s+([a-zA-Z_][a-zA-Z0-9_]*)/);
+  return match ? match[1] : "unknown";
+};
+
+/**
+ * Process a #define directive
+ * Only flag-only defines are allowed; value and function macros produce errors
+ */
+const processDefineDirective = (
+  ctx: Parser.DefineDirectiveContext,
+): string | null => {
+  const text = ctx.getText();
+
+  // Check for function-like macro: #define NAME(
+  if (ctx.DEFINE_FUNCTION()) {
+    const name = extractDefineName(text);
+    const line = ctx.start?.line ?? 0;
+    throw new Error(
+      `E0501: Function-like macro '${name}' is not allowed. ` +
+        `Use inline functions instead. Line ${line}`,
+    );
+  }
+
+  // Check for value define: #define NAME value
+  if (ctx.DEFINE_WITH_VALUE()) {
+    const name = extractDefineName(text);
+    const line = ctx.start?.line ?? 0;
+    throw new Error(
+      `E0502: #define with value '${name}' is not allowed. ` +
+        `Use 'const' instead: const u32 ${name} <- value; Line ${line}`,
+    );
+  }
+
+  // Flag-only define: pass through
+  if (ctx.DEFINE_FLAG()) {
+    return text.trim();
+  }
+
+  return null;
+};
+
+/**
+ * Process a conditional compilation directive (#ifdef, #ifndef, #else, #endif)
+ * These are passed through unchanged
+ */
+const processConditionalDirective = (
+  ctx: Parser.ConditionalDirectiveContext,
+): string => {
+  return ctx.getText().trim();
+};
+
+/**
+ * Process a preprocessor directive
+ * - Flag-only defines (#define FLAG): pass through
+ * - Value defines (#define FLAG value): ERROR E0502
+ * - Function macros (#define NAME(args)): ERROR E0501
+ * - Conditional directives: pass through
+ */
+const processPreprocessorDirective = (
+  ctx: Parser.PreprocessorDirectiveContext,
+): string | null => {
+  if (ctx.defineDirective()) {
+    return processDefineDirective(ctx.defineDirective()!);
+  }
+  if (ctx.conditionalDirective()) {
+    return processConditionalDirective(ctx.conditionalDirective()!);
+  }
+  return null;
+};
+
+// Export as an object for consistent module pattern
+const includeGenerators = {
+  transformIncludeDirective,
+  extractDefineName,
+  processDefineDirective,
+  processConditionalDirective,
+  processPreprocessorDirective,
+};
+
+export default includeGenerators;

--- a/src/codegen/generators/support/index.ts
+++ b/src/codegen/generators/support/index.ts
@@ -1,0 +1,37 @@
+/**
+ * Support generators barrel export.
+ * ADR-053 A5: Modular support/utility code generation
+ */
+import helperGenerators from "./HelperGenerator";
+import includeGenerators from "./IncludeGenerator";
+import commentUtils from "./CommentUtils";
+
+// Re-export individual generators for convenience
+const { generateOverflowHelpers, generateSafeDivHelpers } = helperGenerators;
+
+const { transformIncludeDirective, processPreprocessorDirective } =
+  includeGenerators;
+
+const {
+  getLeadingComments,
+  getTrailingComments,
+  formatLeadingComments,
+  formatTrailingComment,
+} = commentUtils;
+
+// Combined export
+const supportGenerators = {
+  // Helper generators
+  generateOverflowHelpers,
+  generateSafeDivHelpers,
+  // Include generators
+  transformIncludeDirective,
+  processPreprocessorDirective,
+  // Comment utilities
+  getLeadingComments,
+  getTrailingComments,
+  formatLeadingComments,
+  formatTrailingComment,
+};
+
+export default supportGenerators;

--- a/src/codegen/types/TYPE_LIMITS.ts
+++ b/src/codegen/types/TYPE_LIMITS.ts
@@ -1,0 +1,38 @@
+/**
+ * Maps C-Next types to C limit macros from limits.h
+ */
+
+/**
+ * Maps C-Next types to C max value macros
+ */
+const TYPE_MAX: Record<string, string> = {
+  u8: "UINT8_MAX",
+  u16: "UINT16_MAX",
+  u32: "UINT32_MAX",
+  u64: "UINT64_MAX",
+  i8: "INT8_MAX",
+  i16: "INT16_MAX",
+  i32: "INT32_MAX",
+  i64: "INT64_MAX",
+};
+
+/**
+ * Maps C-Next types to C min value macros
+ */
+const TYPE_MIN: Record<string, string> = {
+  u8: "0",
+  u16: "0",
+  u32: "0",
+  u64: "0",
+  i8: "INT8_MIN",
+  i16: "INT16_MIN",
+  i32: "INT32_MIN",
+  i64: "INT64_MIN",
+};
+
+const TYPE_LIMITS = {
+  TYPE_MAX,
+  TYPE_MIN,
+};
+
+export default TYPE_LIMITS;

--- a/src/codegen/types/TYPE_MAP.ts
+++ b/src/codegen/types/TYPE_MAP.ts
@@ -1,0 +1,20 @@
+/**
+ * Maps C-Next types to C types
+ */
+const TYPE_MAP: Record<string, string> = {
+  u8: "uint8_t",
+  u16: "uint16_t",
+  u32: "uint32_t",
+  u64: "uint64_t",
+  i8: "int8_t",
+  i16: "int16_t",
+  i32: "int32_t",
+  i64: "int64_t",
+  f32: "float",
+  f64: "double",
+  bool: "bool",
+  void: "void",
+  ISR: "ISR", // ADR-040: Interrupt Service Routine function pointer
+};
+
+export default TYPE_MAP;

--- a/src/codegen/types/WIDER_TYPE_MAP.ts
+++ b/src/codegen/types/WIDER_TYPE_MAP.ts
@@ -1,0 +1,16 @@
+/**
+ * Maps C-Next types to wider C types for clamp helper operands
+ * Issue #94: Prevents silent truncation when operand exceeds target type range
+ */
+const WIDER_TYPE_MAP: Record<string, string> = {
+  u8: "uint32_t",
+  u16: "uint32_t",
+  u32: "uint64_t",
+  u64: "uint64_t", // Already widest
+  i8: "int32_t",
+  i16: "int32_t",
+  i32: "int64_t",
+  i64: "int64_t", // Already widest
+};
+
+export default WIDER_TYPE_MAP;


### PR DESCRIPTION
## Summary
- Extract support/utility code from CodeGenerator.ts into modular generator files (ADR-053 A5)
- Create new type constant files: TYPE_MAP, WIDER_TYPE_MAP, TYPE_LIMITS
- Create support generators: HelperGenerator, IncludeGenerator, CommentUtils
- CodeGenerator now delegates to extracted modules via strangler fig pattern

## Test plan
- [x] All 592 tests pass
- [x] Linting passes (0 errors)
- [x] No breaking changes to public interface

🤖 Generated with [Claude Code](https://claude.com/claude-code)