### PR TITLE
Add TypeScript type checking to CI and fix 25 errors

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -39,6 +39,11 @@ jobs:
         run: npm run antlr:all
         continue-on-error: true
 
+      - name: Check TypeScript types
+        id: typecheck
+        run: npm run typecheck
+        continue-on-error: true
+
       - name: Run tests
         id: test
         run: npm test
@@ -90,6 +95,13 @@ jobs:
             FAILED=1
           else
             echo "✅ Parser generation passed"
+          fi
+
+          if [ "${{ steps.typecheck.outcome }}" != "success" ]; then
+            echo "❌ TypeScript type check failed"
+            FAILED=1
+          else
+            echo "✅ TypeScript type check passed"
           fi
 
           if [ "${{ steps.test.outcome }}" != "success" ]; then

--- a/src/codegen/generators/GeneratorRegistry.ts
+++ b/src/codegen/generators/GeneratorRegistry.ts
@@ -62,8 +62,11 @@ export default class GeneratorRegistry {
    * @param kind - Declaration kind (e.g., 'struct', 'enum', 'function')
    * @param fn - Generator function
    */
-  registerDeclaration(kind: string, fn: TGeneratorFn<ParserRuleContext>): void {
-    this.declarations.set(kind, fn);
+  registerDeclaration<T extends ParserRuleContext>(
+    kind: string,
+    fn: TGeneratorFn<T>,
+  ): void {
+    this.declarations.set(kind, fn as TGeneratorFn<ParserRuleContext>);
   }
 
   /**
@@ -71,8 +74,11 @@ export default class GeneratorRegistry {
    * @param kind - Statement kind (e.g., 'if', 'while', 'assignment')
    * @param fn - Generator function
    */
-  registerStatement(kind: string, fn: TGeneratorFn<ParserRuleContext>): void {
-    this.statements.set(kind, fn);
+  registerStatement<T extends ParserRuleContext>(
+    kind: string,
+    fn: TGeneratorFn<T>,
+  ): void {
+    this.statements.set(kind, fn as TGeneratorFn<ParserRuleContext>);
   }
 
   /**
@@ -80,8 +86,11 @@ export default class GeneratorRegistry {
    * @param kind - Expression kind (e.g., 'ternary', 'binary', 'call')
    * @param fn - Generator function
    */
-  registerExpression(kind: string, fn: TGeneratorFn<ParserRuleContext>): void {
-    this.expressions.set(kind, fn);
+  registerExpression<T extends ParserRuleContext>(
+    kind: string,
+    fn: TGeneratorFn<T>,
+  ): void {
+    this.expressions.set(kind, fn as TGeneratorFn<ParserRuleContext>);
   }
 
   // =========================================================================

--- a/src/codegen/generators/declarationGenerators/ScopeGenerator.ts
+++ b/src/codegen/generators/declarationGenerators/ScopeGenerator.ts
@@ -268,7 +268,7 @@ function generateScopedBitmapInline(
     lines.push(" */");
   } else {
     // Fall back to AST parsing
-    const fields = node.bitmapField();
+    const fields = node.bitmapMember();
     if (fields.length > 0) {
       lines.push("/* Fields:");
       let bitOffset = 0;

--- a/src/codegen/generators/expressions/CallExprGenerator.ts
+++ b/src/codegen/generators/expressions/CallExprGenerator.ts
@@ -7,7 +7,10 @@
  * - C function calls with pass-by-value semantics
  * - Const-to-non-const validation (ADR-013)
  */
-import { ArgumentListContext } from "../../../parser/grammar/CNextParser";
+import {
+  ArgumentListContext,
+  ExpressionContext,
+} from "../../../parser/grammar/CNextParser";
 import IGeneratorOutput from "../IGeneratorOutput";
 import TGeneratorEffect from "../TGeneratorEffect";
 import IGeneratorInput from "../IGeneratorInput";
@@ -94,7 +97,7 @@ const generateFunctionCall = (
  */
 const generateSafeDivMod = (
   funcName: string,
-  argExprs: ReturnType<ArgumentListContext["expression"]>,
+  argExprs: ExpressionContext[],
   input: IGeneratorInput,
   orchestrator: IOrchestrator,
   effects: TGeneratorEffect[],
@@ -157,7 +160,7 @@ const generateSafeDivMod = (
  */
 const validateConstToNonConst = (
   funcName: string,
-  argExprs: ReturnType<ArgumentListContext["expression"]>,
+  argExprs: ExpressionContext[],
   input: IGeneratorInput,
   orchestrator: IOrchestrator,
 ): void => {


### PR DESCRIPTION
## Summary

Closes #224

- Adds `npm run typecheck` step to PR checks workflow
- Fixes 25 TypeScript errors that accumulated on main
- **Notably fixes an actual runtime bug** in ScopeGenerator.ts

## Changes

| File | Errors Fixed | Description |
|------|--------------|-------------|
| `.github/workflows/pr-checks.yml` | - | Added typecheck step + reporting |
| `ScopeGenerator.ts` | 1 | **Runtime bug**: `bitmapField()` → `bitmapMember()` |
| `GeneratorRegistry.ts` | 6 | Made registration methods generic: `<T extends ParserRuleContext>` |
| `CallExprGenerator.ts` | 18 | Changed `ReturnType<...>` to explicit `ExpressionContext[]` |

## Test plan

- [ ] `npm run typecheck` passes with 0 errors
- [ ] `npm test` passes (600/600)
- [ ] CI workflow runs typecheck step
- [ ] CI reports typecheck result in summary

🤖 Generated with [Claude Code](https://claude.com/claude-code)