### PR TITLE
refactor: extract shared test utilities (#239)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,6 +21,41 @@
 - Legacy errors in untouched files can be ignored (fix as you go)
 - Pre-commit hooks use `lint-staged` to only check files you're committing
 
+### TypeScript Coding Standards
+
+**Default exports only** - The project uses oxlint's `no-named-export` rule.
+
+**Static classes for utilities** - Use static classes (not object literals) for modules with multiple related functions:
+
+```typescript
+// ✅ Correct
+class TestUtils {
+  static normalize(str: string): string { ... }
+  static validate(file: string): IResult { ... }
+}
+export default TestUtils;
+```
+
+**No destructuring** - Always use the class name prefix for self-documenting code:
+
+```typescript
+// ✅ Correct - self-documenting
+TestUtils.normalize(actualErrors) === TestUtils.normalize(expectedErrors);
+
+// ❌ Wrong - obscures origin
+const { normalize } = TestUtils;
+normalize(actualErrors) === normalize(expectedErrors);
+```
+
+**Shared types in `/types` directories** - One interface per file with default export:
+
+```
+src/pipeline/types/IFileResult.ts
+scripts/types/ITools.ts
+```
+
+See `CONTRIBUTING.md` for complete TypeScript coding standards.
+
 ## Testing Requirements
 
 **Tests are mandatory for all feature work:**

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -162,6 +162,90 @@ npm run eslint:check
 - **Zero ESLint errors**: In files you touch (fix as you go)
 - **Formatting**: Use Prettier (automatic with `prettier:fix`)
 
+### TypeScript Coding Standards
+
+#### Default Exports Only
+
+The project uses oxlint's `no-named-export` rule. All modules must use default exports:
+
+```typescript
+// ✅ Correct - default export
+class TestUtils {
+  static normalize(str: string): string { ... }
+}
+export default TestUtils;
+
+// ❌ Wrong - named exports
+export function normalize(str: string): string { ... }
+export const helper = () => { ... };
+```
+
+#### Static Classes for Utility Modules
+
+Use static classes (not object literals) for utility modules with multiple related functions:
+
+```typescript
+// ✅ Correct - static class
+class TestUtils {
+  static normalize(str: string): string { ... }
+  static validateCompilation(file: string): IResult { ... }
+}
+
+// ❌ Wrong - object literal with composed functions
+function normalize(str: string): string { ... }
+function validateCompilation(file: string): IResult { ... }
+const testUtils = { normalize, validateCompilation };
+```
+
+**Why static classes?**
+
+- Methods reference siblings via `ClassName.method()` which survives destructuring
+- Clear namespace and IDE autocomplete
+- Self-documenting code
+
+#### No Destructuring of Utility Classes
+
+Always use the class name prefix for self-documenting code:
+
+```typescript
+// ✅ Correct - self-documenting
+import TestUtils from "./test-utils";
+if (TestUtils.normalize(a) === TestUtils.normalize(b)) { ... }
+const result = TestUtils.validateCompilation(file, tools, rootDir);
+
+// ❌ Wrong - obscures origin
+import TestUtils from "./test-utils";
+const { normalize, validateCompilation } = TestUtils;
+if (normalize(a) === normalize(b)) { ... }  // Where does normalize come from?
+```
+
+#### Shared Types in `/types` Directory
+
+Interfaces shared across multiple files go in a dedicated `types/` directory with one interface per file:
+
+```
+scripts/
+├── test-utils.ts
+├── test.ts
+├── test-worker.ts
+└── types/
+    ├── ITools.ts          # One interface per file
+    ├── ITestResult.ts
+    └── IValidationResult.ts
+```
+
+```typescript
+// types/ITools.ts
+interface ITools {
+  gcc: boolean;
+  cppcheck: boolean;
+}
+export default ITools;
+
+// Consumer
+import ITools from "./types/ITools";
+```
+
 ### Code Verification
 
 ```bash

--- a/scripts/test-utils.test.ts
+++ b/scripts/test-utils.test.ts
@@ -1,0 +1,163 @@
+/**
+ * Tests for test-utils.ts shared module
+ *
+ * This test file is written BEFORE test-utils.ts exists (TDD approach).
+ * It verifies the public API contract for the shared test utilities.
+ */
+
+import TestUtils from "./test-utils";
+
+// Import shared types
+import ITools from "./types/ITools";
+import ITestResult from "./types/ITestResult";
+import IValidationResult from "./types/IValidationResult";
+
+describe("test-utils exports", () => {
+  it("should export ITools interface", () => {
+    // TypeScript compile-time check - just verify we can use the type
+    const tools: ITools = {
+      gcc: true,
+      cppcheck: false,
+      clangTidy: false,
+      misra: false,
+    };
+    expect(tools.gcc).toBe(true);
+  });
+
+  it("should export ITestResult interface", () => {
+    const result: ITestResult = {
+      passed: true,
+      message: "Test message",
+    };
+    expect(result.passed).toBe(true);
+  });
+
+  it("should export IValidationResult interface", () => {
+    const result: IValidationResult = {
+      valid: true,
+      message: "Validation passed",
+    };
+    expect(result.valid).toBe(true);
+  });
+});
+
+describe("normalize", () => {
+  it("should trim trailing whitespace from each line", () => {
+    const input = "line1   \nline2  \nline3";
+    const expected = "line1\nline2\nline3";
+    expect(TestUtils.normalize(input)).toBe(expected);
+  });
+
+  it("should normalize line endings", () => {
+    const input = "line1\r\nline2\nline3\r\n";
+    // After split on \n, \r remains at end of lines, trimEnd removes it
+    const result = TestUtils.normalize(input);
+    expect(result).not.toContain("\r");
+  });
+
+  it("should trim leading and trailing whitespace from the whole string", () => {
+    const input = "  \n  content  \n  ";
+    const result = TestUtils.normalize(input);
+    expect(result).toBe("content");
+  });
+
+  it("should handle empty string", () => {
+    expect(TestUtils.normalize("")).toBe("");
+  });
+
+  it("should handle single line", () => {
+    expect(TestUtils.normalize("hello world  ")).toBe("hello world");
+  });
+});
+
+describe("hasNoWarningsMarker", () => {
+  it("should return true for source with /* test-no-warnings */ marker", () => {
+    const source = "/* test-no-warnings */\nvoid main() {}";
+    expect(TestUtils.hasNoWarningsMarker(source)).toBe(true);
+  });
+
+  it("should return true with extra whitespace in marker", () => {
+    const source = "/*   test-no-warnings   */\nvoid main() {}";
+    expect(TestUtils.hasNoWarningsMarker(source)).toBe(true);
+  });
+
+  it("should be case insensitive", () => {
+    const source = "/* TEST-NO-WARNINGS */\nvoid main() {}";
+    expect(TestUtils.hasNoWarningsMarker(source)).toBe(true);
+  });
+
+  it("should return false for source without marker", () => {
+    const source = "void main() {}";
+    expect(TestUtils.hasNoWarningsMarker(source)).toBe(false);
+  });
+
+  it("should return false for line comment marker", () => {
+    // Only block comments should count
+    const source = "// test-no-warnings\nvoid main() {}";
+    expect(TestUtils.hasNoWarningsMarker(source)).toBe(false);
+  });
+});
+
+describe("TestUtils.requiresCpp14", () => {
+  it("should be a function", () => {
+    expect(typeof TestUtils.requiresCpp14).toBe("function");
+  });
+
+  // Note: Full testing requires file system access, which is covered by integration tests
+});
+
+describe("requiresArmRuntime", () => {
+  it("should return true for code with cmsis_gcc.h include", () => {
+    const cCode = '#include "cmsis_gcc.h"\nvoid main() {}';
+    expect(TestUtils.requiresArmRuntime(cCode)).toBe(true);
+  });
+
+  it("should return true for code with __LDREX", () => {
+    const cCode = "void main() { __LDREX(&x); }";
+    expect(TestUtils.requiresArmRuntime(cCode)).toBe(true);
+  });
+
+  it("should return true for code with __STREX", () => {
+    const cCode = "void main() { __STREX(1, &x); }";
+    expect(TestUtils.requiresArmRuntime(cCode)).toBe(true);
+  });
+
+  it("should return true for code with __get_PRIMASK", () => {
+    const cCode = "void main() { __get_PRIMASK(); }";
+    expect(TestUtils.requiresArmRuntime(cCode)).toBe(true);
+  });
+
+  it("should return true for code with __set_PRIMASK", () => {
+    const cCode = "void main() { __set_PRIMASK(0); }";
+    expect(TestUtils.requiresArmRuntime(cCode)).toBe(true);
+  });
+
+  it("should return true for code with __disable_irq", () => {
+    const cCode = "void main() { __disable_irq(); }";
+    expect(TestUtils.requiresArmRuntime(cCode)).toBe(true);
+  });
+
+  it("should return true for code with __enable_irq", () => {
+    const cCode = "void main() { __enable_irq(); }";
+    expect(TestUtils.requiresArmRuntime(cCode)).toBe(true);
+  });
+
+  it("should return false for regular C code", () => {
+    const cCode = "int main() { return 0; }";
+    expect(TestUtils.requiresArmRuntime(cCode)).toBe(false);
+  });
+});
+
+describe("getExecutablePath", () => {
+  it("should return a path in the temp directory", () => {
+    const result = TestUtils.getExecutablePath("/path/to/test.test.cnx");
+    expect(result).toContain("cnx-test-");
+    expect(result).toContain("test");
+  });
+
+  it("should generate unique paths for the same input", () => {
+    const path1 = TestUtils.getExecutablePath("/path/to/test.test.cnx");
+    const path2 = TestUtils.getExecutablePath("/path/to/test.test.cnx");
+    expect(path1).not.toBe(path2);
+  });
+});

--- a/scripts/test-utils.ts
+++ b/scripts/test-utils.ts
@@ -1,0 +1,412 @@
+/**
+ * Shared Test Utilities
+ *
+ * Common interfaces and validation functions used by both
+ * test.ts (main runner) and test-worker.ts (parallel worker).
+ *
+ * This module centralizes duplicated code to prevent drift
+ * (e.g., validateMisra missing -I flag in one file but not the other).
+ */
+
+import { readFileSync, existsSync, unlinkSync } from "fs";
+import { join, dirname, basename } from "path";
+import { execFileSync } from "child_process";
+import { tmpdir } from "os";
+import { randomBytes } from "crypto";
+import ITools from "./types/ITools";
+import IValidationResult from "./types/IValidationResult";
+
+class TestUtils {
+  /**
+   * Normalize output for comparison (trim trailing whitespace, normalize line endings)
+   */
+  static normalize(str: string): string {
+    return str
+      .split("\n")
+      .map((line) => line.trimEnd())
+      .join("\n")
+      .trim();
+  }
+
+  /**
+   * Check if source has test-no-warnings marker in block comment
+   */
+  static hasNoWarningsMarker(source: string): boolean {
+    return /\/\*\s*test-no-warnings\s*\*\//i.test(source);
+  }
+
+  /**
+   * Check if generated C code requires ARM runtime (can't execute on x86)
+   */
+  static requiresArmRuntime(cCode: string): boolean {
+    return (
+      cCode.includes("cmsis_gcc.h") ||
+      cCode.includes("__LDREX") ||
+      cCode.includes("__STREX") ||
+      cCode.includes("__get_PRIMASK") ||
+      cCode.includes("__set_PRIMASK") ||
+      cCode.includes("__disable_irq") ||
+      cCode.includes("__enable_irq")
+    );
+  }
+
+  /**
+   * Get a unique path for a test executable in the temp directory
+   */
+  static getExecutablePath(cnxFile: string): string {
+    const testName = basename(cnxFile, ".test.cnx");
+    const uniqueId = randomBytes(4).toString("hex");
+    return join(tmpdir(), `cnx-test-${testName}-${uniqueId}`);
+  }
+
+  /**
+   * Detect if a C file includes headers with C++14 features
+   * Checks for typed enums (enum Foo : type {) which require C++14 parser
+   *
+   * @param cFile - Path to the C file
+   * @param _rootDir - Project root directory (unused, kept for API consistency)
+   */
+  static requiresCpp14(cFile: string, _rootDir?: string): boolean {
+    try {
+      const cCode = readFileSync(cFile, "utf-8");
+      const cFileDir = dirname(cFile);
+
+      // Find all #include "local_header.h" directives
+      const includePattern = /#include\s+"([^"]+)"/g;
+      let match;
+
+      while ((match = includePattern.exec(cCode)) !== null) {
+        const headerPath = join(cFileDir, match[1]);
+        if (existsSync(headerPath)) {
+          const headerContent = readFileSync(headerPath, "utf-8");
+          // Check for C++14 typed enum syntax: enum Name : type {
+          if (/enum\s+\w+\s*:\s*\w+\s*\{/.test(headerContent)) {
+            return true;
+          }
+        }
+      }
+      return false;
+    } catch {
+      return false;
+    }
+  }
+
+  /**
+   * Validate that a C file compiles without errors
+   * Uses gcc with -fsyntax-only for fast syntax checking
+   * Auto-detects C++14 headers and uses g++ when needed
+   *
+   * @param cFile - Path to the C file
+   * @param _tools - Available tools (unused, kept for API consistency)
+   * @param rootDir - Project root directory for include paths
+   */
+  static validateCompilation(
+    cFile: string,
+    _tools: ITools,
+    rootDir: string,
+  ): IValidationResult {
+    try {
+      // Auto-detect C++14 headers and use g++ when needed
+      const useCpp = TestUtils.requiresCpp14(cFile);
+      const compiler = useCpp ? "g++" : "gcc";
+      const stdFlag = useCpp ? "-std=c++14" : "-std=c99";
+
+      // Use compiler to check syntax only (no object file generated)
+      // Suppress warnings about unused variables and void main (common in tests)
+      // -I tests/include for stub headers (e.g., cmsis_gcc.h for ARM intrinsics)
+      execFileSync(
+        compiler,
+        [
+          "-fsyntax-only",
+          stdFlag,
+          "-Wno-unused-variable",
+          "-Wno-main",
+          "-I",
+          join(rootDir, "tests/include"),
+          cFile,
+        ],
+        { encoding: "utf-8", timeout: 10000, stdio: "pipe" },
+      );
+      return { valid: true };
+    } catch (error: unknown) {
+      const err = error as {
+        stderr?: string;
+        stdout?: string;
+        message: string;
+      };
+      // Extract just the error messages
+      const output = err.stderr || err.stdout || err.message;
+      const errors = output
+        .split("\n")
+        .filter((line) => line.includes("error:"))
+        .map((line) => line.replace(cFile + ":", ""))
+        .slice(0, 5)
+        .join("\n");
+      return {
+        valid: false,
+        message: errors || "Compilation failed",
+      };
+    }
+  }
+
+  /**
+   * Validate that a C file passes cppcheck static analysis
+   */
+  static validateCppcheck(cFile: string): IValidationResult {
+    try {
+      execFileSync(
+        "cppcheck",
+        [
+          "--error-exitcode=1",
+          "--enable=warning,performance",
+          "--suppress=unusedFunction",
+          "--suppress=missingIncludeSystem",
+          "--suppress=unusedVariable",
+          "--quiet",
+          cFile,
+        ],
+        { encoding: "utf-8", timeout: 90000, stdio: "pipe" },
+      );
+      return { valid: true };
+    } catch (error: unknown) {
+      const err = error as {
+        stderr?: string;
+        stdout?: string;
+        message: string;
+      };
+      const output = err.stderr || err.stdout || err.message;
+      const issues = output
+        .split("\n")
+        .filter((line) => line.trim().length > 0)
+        .slice(0, 5)
+        .join("\n");
+      return {
+        valid: false,
+        message: issues || "Cppcheck failed",
+      };
+    }
+  }
+
+  /**
+   * Validate that a C file passes clang-tidy analysis
+   */
+  static validateClangTidy(cFile: string): IValidationResult {
+    try {
+      // Run clang-tidy with safety and readability checks
+      execFileSync(
+        "clang-tidy",
+        [cFile, "--", "-std=c99", "-Wno-unused-variable"],
+        { encoding: "utf-8", timeout: 30000, stdio: "pipe" },
+      );
+      return { valid: true };
+    } catch (error: unknown) {
+      const err = error as {
+        stderr?: string;
+        stdout?: string;
+        message: string;
+      };
+      const output = err.stderr || err.stdout || err.message;
+      // Filter for actual warnings/errors (not notes)
+      const issues = output
+        .split("\n")
+        .filter((line) => line.includes("warning:") || line.includes("error:"))
+        .slice(0, 5)
+        .join("\n");
+      // clang-tidy returns non-zero even for warnings, only fail on errors
+      if (issues.includes("error:")) {
+        return {
+          valid: false,
+          message: issues || "Clang-tidy failed",
+        };
+      }
+      return { valid: true };
+    }
+  }
+
+  /**
+   * Validate that a C file passes MISRA C compliance check
+   * Uses cppcheck's MISRA addon
+   *
+   * @param cFile - Path to the C file
+   * @param rootDir - Project root directory for include paths
+   */
+  static validateMisra(cFile: string, rootDir: string): IValidationResult {
+    try {
+      // Run cppcheck with MISRA addon
+      // Include -I flag for tests/include to resolve stub headers
+      execFileSync(
+        "cppcheck",
+        [
+          "--addon=misra",
+          "--error-exitcode=1",
+          "--suppress=missingIncludeSystem",
+          "--suppress=unusedFunction",
+          "--quiet",
+          "-I",
+          join(rootDir, "tests/include"),
+          cFile,
+        ],
+        { encoding: "utf-8", timeout: 60000, stdio: "pipe" },
+      );
+      return { valid: true };
+    } catch (error: unknown) {
+      const err = error as {
+        stderr?: string;
+        stdout?: string;
+        message: string;
+      };
+      const output = err.stderr || err.stdout || err.message;
+      const issues = output
+        .split("\n")
+        .filter((line) => line.includes("misra") || line.includes("MISRA"))
+        .slice(0, 5)
+        .join("\n");
+      return {
+        valid: false,
+        message: issues || "MISRA check failed",
+      };
+    }
+  }
+
+  /**
+   * Validate that a C file compiles without any warnings
+   * Uses gcc with -Werror to treat all warnings as errors
+   *
+   * @param cFile - Path to the C file
+   * @param rootDir - Project root directory for include paths
+   */
+  static validateNoWarnings(cFile: string, rootDir: string): IValidationResult {
+    try {
+      // Auto-detect C++14 headers and use g++ when needed
+      const useCpp = TestUtils.requiresCpp14(cFile);
+      const compiler = useCpp ? "g++" : "gcc";
+      const stdFlag = useCpp ? "-std=c++14" : "-std=c99";
+
+      // Compile with -Werror to treat warnings as errors
+      // Include common warning flags that catch issues like -Wstringop-overflow
+      execFileSync(
+        compiler,
+        [
+          "-fsyntax-only",
+          stdFlag,
+          "-Wall",
+          "-Wextra",
+          "-Werror",
+          "-Wno-unused-variable",
+          "-Wno-main",
+          "-I",
+          join(rootDir, "tests/include"),
+          cFile,
+        ],
+        { encoding: "utf-8", timeout: 10000, stdio: "pipe" },
+      );
+      return { valid: true };
+    } catch (error: unknown) {
+      const err = error as {
+        stderr?: string;
+        stdout?: string;
+        message: string;
+      };
+      // Extract just the warning/error messages
+      const output = err.stderr || err.stdout || err.message;
+      const warnings = output
+        .split("\n")
+        .filter((line) => line.includes("warning:") || line.includes("error:"))
+        .map((line) => line.replace(cFile + ":", ""))
+        .slice(0, 5)
+        .join("\n");
+      return {
+        valid: false,
+        message: warnings || "Compilation produced warnings",
+      };
+    }
+  }
+
+  /**
+   * Compile and execute a C file, validating exit code
+   *
+   * @param cFile - Path to the C file
+   * @param rootDir - Project root directory for include paths
+   * @param expectedExitCode - Expected exit code (default: 0)
+   */
+  static executeTest(
+    cFile: string,
+    rootDir: string,
+    expectedExitCode: number = 0,
+  ): IValidationResult & { stdout?: string } {
+    const execPath = TestUtils.getExecutablePath(cFile);
+
+    // Auto-detect C++14 headers and use g++ when needed
+    const useCpp = TestUtils.requiresCpp14(cFile);
+    const compiler = useCpp ? "g++" : "gcc";
+    const stdFlag = useCpp ? "-std=c++14" : "-std=c99";
+
+    try {
+      // Compile to executable
+      execFileSync(
+        compiler,
+        [
+          stdFlag,
+          "-Wno-unused-variable",
+          "-Wno-main",
+          "-I",
+          join(rootDir, "tests/include"),
+          "-o",
+          execPath,
+          cFile,
+        ],
+        { encoding: "utf-8", timeout: 30000, stdio: "pipe" },
+      );
+
+      // Execute the compiled program
+      try {
+        const stdout = execFileSync(execPath, [], {
+          encoding: "utf-8",
+          timeout: 5000,
+          stdio: "pipe",
+        });
+
+        // Program exited with 0
+        if (expectedExitCode !== 0) {
+          return {
+            valid: false,
+            message: `Expected exit ${expectedExitCode}, got 0`,
+            stdout,
+          };
+        }
+        return { valid: true, stdout };
+      } catch (execError: unknown) {
+        const err = execError as { status?: number; stdout?: string };
+        const actualCode = err.status || 1;
+
+        if (actualCode === expectedExitCode) {
+          return { valid: true, stdout: err.stdout };
+        }
+
+        return {
+          valid: false,
+          message: `Expected exit 0, got ${actualCode}`,
+          stdout: err.stdout,
+        };
+      }
+    } catch (compileError: unknown) {
+      const err = compileError as { stderr?: string; message: string };
+      const output = err.stderr || err.message;
+      return {
+        valid: false,
+        message: `Compile failed: ${output.split("\n")[0]}`,
+      };
+    } finally {
+      // Clean up executable
+      try {
+        if (existsSync(execPath)) {
+          unlinkSync(execPath);
+        }
+      } catch {
+        // Ignore cleanup errors
+      }
+    }
+  }
+}
+
+export default TestUtils;

--- a/scripts/test.ts
+++ b/scripts/test.ts
@@ -37,13 +37,17 @@ import {
   statSync,
   unlinkSync,
 } from "fs";
-import { join, dirname, basename } from "path";
+import { join, dirname } from "path";
 import { fileURLToPath } from "url";
 import { execFileSync, fork, ChildProcess } from "child_process";
-import { tmpdir, cpus } from "os";
-import { randomBytes } from "crypto";
+import { cpus } from "os";
 import Pipeline from "../src/pipeline/Pipeline";
 import IFileResult from "../src/pipeline/types/IFileResult";
+import ITools from "./types/ITools";
+import ITestResult from "./types/ITestResult";
+
+// Import shared test utilities
+import TestUtils from "./test-utils";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -58,37 +62,6 @@ const colors = {
   cyan: "\x1b[36m",
   dim: "\x1b[2m",
 };
-
-interface ITools {
-  gcc: boolean;
-  cppcheck: boolean;
-  clangTidy: boolean;
-  misra: boolean;
-}
-
-interface ITestResult {
-  passed: boolean;
-  message?: string;
-  expected?: string;
-  actual?: string;
-  updated?: boolean;
-  skippedExec?: boolean;
-  noSnapshot?: boolean;
-  execError?: string;
-  warningError?: string;
-}
-
-/**
- * Check if source has test-no-warnings marker in block comment
- */
-function hasNoWarningsMarker(source: string): boolean {
-  return /\/\*\s*test-no-warnings\s*\*\//i.test(source);
-}
-
-interface IValidationResult {
-  valid: boolean;
-  message?: string;
-}
 
 interface IWorkerResult {
   type: "result" | "ready" | "loaded";
@@ -117,342 +90,9 @@ function findCnxFiles(dir: string): string[] {
   return files;
 }
 
-/**
- * Normalize output for comparison (trim trailing whitespace, normalize line endings)
- */
-function normalize(str: string): string {
-  return str
-    .split("\n")
-    .map((line) => line.trimEnd())
-    .join("\n")
-    .trim();
-}
-
-/**
- * Detect if a C file includes headers with C++14 features
- * Checks for typed enums (enum Foo : type {) which require C++14 parser
- */
-function requiresCpp14(cFile: string): boolean {
-  try {
-    const cCode = readFileSync(cFile, "utf-8");
-    const cFileDir = dirname(cFile);
-
-    // Find all #include "local_header.h" directives
-    const includePattern = /#include\s+"([^"]+)"/g;
-    let match;
-
-    while ((match = includePattern.exec(cCode)) !== null) {
-      const headerPath = join(cFileDir, match[1]);
-      if (existsSync(headerPath)) {
-        const headerContent = readFileSync(headerPath, "utf-8");
-        // Check for C++14 typed enum syntax: enum Name : type {
-        if (/enum\s+\w+\s*:\s*\w+\s*\{/.test(headerContent)) {
-          return true;
-        }
-      }
-    }
-    return false;
-  } catch {
-    return false;
-  }
-}
-
-/**
- * Validate that a C file compiles without errors
- * Uses gcc with -fsyntax-only for fast syntax checking
- * Auto-detects C++14 headers and uses g++ when needed
- */
-function validateCompilation(cFile: string): IValidationResult {
-  try {
-    // Auto-detect C++14 headers and use g++ when needed
-    const useCpp = requiresCpp14(cFile);
-    const compiler = useCpp ? "g++" : "gcc";
-    const stdFlag = useCpp ? "-std=c++14" : "-std=c99";
-
-    // Use compiler to check syntax only (no object file generated)
-    // Suppress warnings about unused variables and void main (common in tests)
-    // -I tests/include for stub headers (e.g., cmsis_gcc.h for ARM intrinsics)
-    execFileSync(
-      compiler,
-      [
-        "-fsyntax-only",
-        stdFlag,
-        "-Wno-unused-variable",
-        "-Wno-main",
-        "-I",
-        join(rootDir, "tests/include"),
-        cFile,
-      ],
-      { encoding: "utf-8", timeout: 10000, stdio: "pipe" },
-    );
-    return { valid: true };
-  } catch (error: unknown) {
-    const err = error as { stderr?: string; stdout?: string; message: string };
-    // Extract just the error messages
-    const output = err.stderr || err.stdout || err.message;
-    const errors = output
-      .split("\n")
-      .filter((line) => line.includes("error:"))
-      .map((line) => line.replace(cFile + ":", ""))
-      .slice(0, 5)
-      .join("\n");
-    return {
-      valid: false,
-      message: errors || "Compilation failed",
-    };
-  }
-}
-
-/**
- * Validate that a C file passes cppcheck static analysis
- */
-function validateCppcheck(cFile: string): IValidationResult {
-  try {
-    execFileSync(
-      "cppcheck",
-      [
-        "--error-exitcode=1",
-        "--enable=warning,performance",
-        "--suppress=unusedFunction",
-        "--suppress=missingIncludeSystem",
-        "--suppress=unusedVariable",
-        "--quiet",
-        cFile,
-      ],
-      { encoding: "utf-8", timeout: 90000, stdio: "pipe" },
-    );
-    return { valid: true };
-  } catch (error: unknown) {
-    const err = error as { stderr?: string; stdout?: string; message: string };
-    const output = err.stderr || err.stdout || err.message;
-    const issues = output
-      .split("\n")
-      .filter((line) => line.trim().length > 0)
-      .slice(0, 5)
-      .join("\n");
-    return {
-      valid: false,
-      message: issues || "Cppcheck failed",
-    };
-  }
-}
-
-/**
- * Validate that a C file passes clang-tidy analysis
- */
-function validateClangTidy(cFile: string): IValidationResult {
-  try {
-    // Run clang-tidy with safety and readability checks
-    execFileSync(
-      "clang-tidy",
-      [cFile, "--", "-std=c99", "-Wno-unused-variable"],
-      { encoding: "utf-8", timeout: 30000, stdio: "pipe" },
-    );
-    return { valid: true };
-  } catch (error: unknown) {
-    const err = error as { stderr?: string; stdout?: string; message: string };
-    const output = err.stderr || err.stdout || err.message;
-    // Filter for actual warnings/errors (not notes)
-    const issues = output
-      .split("\n")
-      .filter((line) => line.includes("warning:") || line.includes("error:"))
-      .slice(0, 5)
-      .join("\n");
-    // clang-tidy returns non-zero even for warnings, only fail on errors
-    if (issues.includes("error:")) {
-      return {
-        valid: false,
-        message: issues || "Clang-tidy failed",
-      };
-    }
-    return { valid: true };
-  }
-}
-
-/**
- * Validate that a C file passes MISRA C compliance check
- * Uses cppcheck's MISRA addon
- */
-function validateMisra(cFile: string): IValidationResult {
-  try {
-    // Run cppcheck with MISRA addon
-    execFileSync(
-      "cppcheck",
-      [
-        "--addon=misra",
-        "--error-exitcode=1",
-        "--suppress=missingIncludeSystem",
-        "--suppress=unusedFunction",
-        "--quiet",
-        cFile,
-      ],
-      { encoding: "utf-8", timeout: 60000, stdio: "pipe" },
-    );
-    return { valid: true };
-  } catch (error: unknown) {
-    const err = error as { stderr?: string; stdout?: string; message: string };
-    const output = err.stderr || err.stdout || err.message;
-    const issues = output
-      .split("\n")
-      .filter((line) => line.includes("misra") || line.includes("MISRA"))
-      .slice(0, 5)
-      .join("\n");
-    return {
-      valid: false,
-      message: issues || "MISRA check failed",
-    };
-  }
-}
-
-/**
- * Validate that a C file compiles without any warnings
- * Uses gcc with -Werror to treat all warnings as errors
- */
-function validateNoWarnings(cFile: string): IValidationResult {
-  try {
-    // Auto-detect C++14 headers and use g++ when needed
-    const useCpp = requiresCpp14(cFile);
-    const compiler = useCpp ? "g++" : "gcc";
-    const stdFlag = useCpp ? "-std=c++14" : "-std=c99";
-
-    // Compile with -Werror to treat warnings as errors
-    // Include common warning flags that catch issues like -Wstringop-overflow
-    execFileSync(
-      compiler,
-      [
-        "-fsyntax-only",
-        stdFlag,
-        "-Wall",
-        "-Wextra",
-        "-Werror",
-        "-Wno-unused-variable",
-        "-Wno-main",
-        "-I",
-        join(rootDir, "tests/include"),
-        cFile,
-      ],
-      { encoding: "utf-8", timeout: 10000, stdio: "pipe" },
-    );
-    return { valid: true };
-  } catch (error: unknown) {
-    const err = error as { stderr?: string; stdout?: string; message: string };
-    // Extract just the warning/error messages
-    const output = err.stderr || err.stdout || err.message;
-    const warnings = output
-      .split("\n")
-      .filter((line) => line.includes("warning:") || line.includes("error:"))
-      .map((line) => line.replace(cFile + ":", ""))
-      .slice(0, 5)
-      .join("\n");
-    return {
-      valid: false,
-      message: warnings || "Compilation produced warnings",
-    };
-  }
-}
-
-/**
- * Get a unique path for a test executable in the temp directory
- */
-function getExecutablePath(cnxFile: string): string {
-  const testName = basename(cnxFile, ".test.cnx");
-  const uniqueId = randomBytes(4).toString("hex");
-  return join(tmpdir(), `cnx-test-${testName}-${uniqueId}`);
-}
-
-/**
- * Check if generated C code requires ARM runtime (can't execute on x86)
- */
-function requiresArmRuntime(cCode: string): boolean {
-  return (
-    cCode.includes("cmsis_gcc.h") ||
-    cCode.includes("__LDREX") ||
-    cCode.includes("__STREX") ||
-    cCode.includes("__get_PRIMASK") ||
-    cCode.includes("__set_PRIMASK") ||
-    cCode.includes("__disable_irq") ||
-    cCode.includes("__enable_irq")
-  );
-}
-
-/**
- * Compile and execute a C file, validating exit code
- */
-function executeTest(
-  cFile: string,
-  expectedExitCode: number = 0,
-): IValidationResult {
-  const execPath = getExecutablePath(cFile);
-
-  // Auto-detect C++14 headers and use g++ when needed
-  const useCpp = requiresCpp14(cFile);
-  const compiler = useCpp ? "g++" : "gcc";
-  const stdFlag = useCpp ? "-std=c++14" : "-std=c99";
-
-  try {
-    // Compile to executable
-    execFileSync(
-      compiler,
-      [
-        stdFlag,
-        "-Wno-unused-variable",
-        "-Wno-main",
-        "-I",
-        join(rootDir, "tests/include"),
-        "-o",
-        execPath,
-        cFile,
-      ],
-      { encoding: "utf-8", timeout: 30000, stdio: "pipe" },
-    );
-
-    // Execute the compiled program
-    try {
-      execFileSync(execPath, [], {
-        encoding: "utf-8",
-        timeout: 5000,
-        stdio: "pipe",
-      });
-
-      // Program exited with 0
-      if (expectedExitCode !== 0) {
-        return {
-          valid: false,
-          message: `Expected exit ${expectedExitCode}, got 0`,
-        };
-      }
-      return { valid: true };
-    } catch (execError: unknown) {
-      const err = execError as { status?: number };
-      const actualCode = err.status || 1;
-
-      if (actualCode === expectedExitCode) {
-        return { valid: true };
-      }
-
-      return {
-        valid: false,
-        message: `Expected exit 0, got ${actualCode}`,
-      };
-    }
-  } catch (compileError: unknown) {
-    const err = compileError as { stderr?: string; message: string };
-    const output = err.stderr || err.message;
-    return {
-      valid: false,
-      message: `Compile failed: ${output.split("\n")[0]}`,
-    };
-  } finally {
-    // Clean up executable
-    try {
-      if (existsSync(execPath)) {
-        unlinkSync(execPath);
-      }
-    } catch {
-      // Ignore cleanup errors
-    }
-  }
-}
+// normalize, hasNoWarningsMarker, requiresArmRuntime, requiresCpp14,
+// validateCompilation, validateCppcheck, validateClangTidy, validateMisra,
+// validateNoWarnings, executeTest, getExecutablePath imported from ./test-utils
 
 /**
  * Check if validation tools are available
@@ -560,7 +200,9 @@ async function runTest(
       return { passed: true, message: "Updated error snapshot", updated: true };
     }
 
-    if (normalize(actualErrors) === normalize(expectedErrors)) {
+    if (
+      TestUtils.normalize(actualErrors) === TestUtils.normalize(expectedErrors)
+    ) {
       return { passed: true };
     }
 
@@ -603,12 +245,16 @@ async function runTest(
       return { passed: true, message: "Updated C snapshot", updated: true };
     }
 
-    if (normalize(result.code) === normalize(expectedC)) {
+    if (TestUtils.normalize(result.code) === TestUtils.normalize(expectedC)) {
       // Snapshot matches - now run all validation steps
 
       // Step 1: GCC compilation
       if (tools.gcc) {
-        const compileResult = validateCompilation(expectedCFile);
+        const compileResult = TestUtils.validateCompilation(
+          expectedCFile,
+          tools,
+          rootDir,
+        );
         if (!compileResult.valid) {
           return {
             passed: false,
@@ -620,7 +266,7 @@ async function runTest(
 
       // Step 2: Cppcheck static analysis
       if (tools.cppcheck) {
-        const cppcheckResult = validateCppcheck(expectedCFile);
+        const cppcheckResult = TestUtils.validateCppcheck(expectedCFile);
         if (!cppcheckResult.valid) {
           return {
             passed: false,
@@ -632,7 +278,7 @@ async function runTest(
 
       // Step 3: Clang-tidy analysis
       if (tools.clangTidy) {
-        const clangTidyResult = validateClangTidy(expectedCFile);
+        const clangTidyResult = TestUtils.validateClangTidy(expectedCFile);
         if (!clangTidyResult.valid) {
           return {
             passed: false,
@@ -644,7 +290,7 @@ async function runTest(
 
       // Step 4: MISRA compliance check
       if (tools.misra) {
-        const misraResult = validateMisra(expectedCFile);
+        const misraResult = TestUtils.validateMisra(expectedCFile, rootDir);
         if (!misraResult.valid) {
           return {
             passed: false,
@@ -655,8 +301,11 @@ async function runTest(
       }
 
       // Step 5: No-warnings check (if /* test-no-warnings */ marker present)
-      if (hasNoWarningsMarker(source)) {
-        const noWarningsResult = validateNoWarnings(expectedCFile);
+      if (TestUtils.hasNoWarningsMarker(source)) {
+        const noWarningsResult = TestUtils.validateNoWarnings(
+          expectedCFile,
+          rootDir,
+        );
         if (!noWarningsResult.valid) {
           return {
             passed: false,
@@ -668,11 +317,11 @@ async function runTest(
 
       // Step 6: Execution test (if // test-execution marker present)
       if (/^\s*\/\/\s*test-execution\s*$/m.test(source)) {
-        if (requiresArmRuntime(result.code)) {
+        if (TestUtils.requiresArmRuntime(result.code)) {
           return { passed: true, skippedExec: true };
         }
 
-        const execResult = executeTest(expectedCFile, 0);
+        const execResult = TestUtils.executeTest(expectedCFile, rootDir, 0);
         if (!execResult.valid) {
           return {
             passed: false,
@@ -692,8 +341,8 @@ async function runTest(
       writeFileSync(tempCFile, result.code);
 
       try {
-        if (!requiresArmRuntime(result.code)) {
-          const execResult = executeTest(tempCFile, 0);
+        if (!TestUtils.requiresArmRuntime(result.code)) {
+          const execResult = TestUtils.executeTest(tempCFile, rootDir, 0);
           if (!execResult.valid) {
             return {
               passed: false,

--- a/scripts/types/ITestResult.ts
+++ b/scripts/types/ITestResult.ts
@@ -1,0 +1,16 @@
+/**
+ * Result of running a single test
+ */
+interface ITestResult {
+  passed: boolean;
+  message?: string;
+  expected?: string;
+  actual?: string;
+  updated?: boolean;
+  skippedExec?: boolean;
+  noSnapshot?: boolean;
+  execError?: string;
+  warningError?: string;
+}
+
+export default ITestResult;

--- a/scripts/types/ITools.ts
+++ b/scripts/types/ITools.ts
@@ -1,0 +1,11 @@
+/**
+ * Available validation tools on the system
+ */
+interface ITools {
+  gcc: boolean;
+  cppcheck: boolean;
+  clangTidy: boolean;
+  misra: boolean;
+}
+
+export default ITools;

--- a/scripts/types/IValidationResult.ts
+++ b/scripts/types/IValidationResult.ts
@@ -1,0 +1,9 @@
+/**
+ * Result of a validation step (compilation, static analysis, etc.)
+ */
+interface IValidationResult {
+  valid: boolean;
+  message?: string;
+}
+
+export default IValidationResult;

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -5,7 +5,7 @@ export default defineConfig({
     // Co-locate tests with source files (*.test.ts pattern)
     // This is intentional - vitest globals are enabled to avoid
     // explicit imports of describe/it/expect in every test file
-    include: ["src/**/*.test.ts"],
+    include: ["src/**/*.test.ts", "scripts/**/*.test.ts"],
     exclude: ["tests/**", "node_modules/**"],
     globals: true,
     coverage: {


### PR DESCRIPTION
## Summary
- Extract ~660 lines of duplicated code from `test.ts` and `test-worker.ts` into shared `test-utils.ts` module
- Fix bug where `validateMisra()` in `test.ts` was missing the `-I` include flag that `test-worker.ts` had
- Add 24 unit tests for the shared module

## Changes
| File | Action |
|------|--------|
| `scripts/test-utils.ts` | **NEW** - Shared utilities module |
| `scripts/test-utils.test.ts` | **NEW** - 24 unit tests |
| `scripts/test.ts` | **MODIFIED** - Import from test-utils |
| `scripts/test-worker.ts` | **MODIFIED** - Import from test-utils |
| `vitest.config.ts` | **MODIFIED** - Include scripts/**/*.test.ts |

## Test plan
- [x] `npm run typecheck` - TypeScript compiles without errors
- [x] `npm run unit` - All 74 unit tests pass (including 24 new tests)
- [x] `npm test` - All 606 C-Next integration tests pass

Closes #239

🤖 Generated with [Claude Code](https://claude.com/claude-code)