### PR TITLE
fix: cast string subscripts to integer pointer types (Issue #246)

### DIFF
--- a/src/codegen/CodeGenerator.ts
+++ b/src/codegen/CodeGenerator.ts
@@ -3216,8 +3216,9 @@ export default class CodeGenerator implements IOrchestrator {
       // Generate the expression and wrap with &
       const expr = `&${this._generateExpression(ctx)}`;
 
-      // Issue #246: When passing string bytes to integer parameters,
-      // cast from char* to the appropriate integer pointer type
+      // Issue #246: When passing string bytes to integer pointer parameters
+      // (C-Next's by-reference semantics), cast from char* to the appropriate
+      // integer pointer type to avoid signedness warnings
       if (
         lvalueType === "array" &&
         targetParamBaseType &&

--- a/tests/string/string-byte-to-u8-param.expected.c
+++ b/tests/string/string-byte-to-u8-param.expected.c
@@ -10,7 +10,9 @@
 /* test-no-warnings */
 // Tests: Issue #246 - string<N> byte indexing to u8 function parameters
 // When passing buf[0] directly to a function expecting u8, the generated
-// C++ has a type mismatch: char* (from string) vs uint8_t* (function param)
+// C has a type mismatch: char* (from string) vs uint8_t* (function param)
+// Note: This fix also applies to other integer types (u16, u32, i8, etc.)
+// u8 is the most common use case for byte-by-byte string processing
 /* Scope: ByteProcessor */
 
 static uint32_t ByteProcessor_processByte(uint32_t* crc, uint8_t* byte) {

--- a/tests/string/string-byte-to-u8-param.test.cnx
+++ b/tests/string/string-byte-to-u8-param.test.cnx
@@ -2,7 +2,9 @@
 /* test-no-warnings */
 // Tests: Issue #246 - string<N> byte indexing to u8 function parameters
 // When passing buf[0] directly to a function expecting u8, the generated
-// C++ has a type mismatch: char* (from string) vs uint8_t* (function param)
+// C has a type mismatch: char* (from string) vs uint8_t* (function param)
+// Note: This fix also applies to other integer types (u16, u32, i8, etc.)
+// u8 is the most common use case for byte-by-byte string processing
 
 scope ByteProcessor {
     // Function that takes a u8 byte and XORs it with a value


### PR DESCRIPTION
## Summary

- Fixes type mismatch when passing `string<N>` subscripts to functions expecting integer types
- When passing `buf[0]` (from `string<N>`) to a function with `u8` parameter, generates `(uint8_t*)&buf[0]` instead of `&buf[0]`
- Adds test with `/* test-no-warnings */` marker to catch this class of issues

## Changes

- `src/codegen/CodeGenerator.ts`: Added `isStringSubscriptAccess()` helper and modified `_generateFunctionArg()` to add casts
- `tests/string/string-byte-to-u8-param.test.cnx`: New test case

## Test plan

- [x] New test `string-byte-to-u8-param.test.cnx` passes
- [x] All 614 existing tests pass
- [x] Generated C compiles without signedness warnings

Closes #246

🤖 Generated with [Claude Code](https://claude.com/claude-code)