### PR TITLE
feat(vscode): update completion provider with recent language features

### DIFF
--- a/vscode-extension/README.md
+++ b/vscode-extension/README.md
@@ -8,10 +8,11 @@ Syntax highlighting and live C preview for **C-Next**, a safer C for embedded sy
 
 Full syntax highlighting for `.cnx` files including:
 
-- Keywords (`register`, `namespace`, `if`, `for`, etc.)
-- Types (`u8`, `u32`, `bool`, etc.)
+- Keywords (`register`, `scope`, `atomic`, `critical`, `if`, `for`, etc.)
+- Types (`u8`, `u32`, `bool`, `string`, `bitmap8`, `ISR`, etc.)
 - Operators (`<-` assignment, `@` address)
-- Literals, comments, strings
+- Modifiers (`clamp`, `wrap` for overflow behavior)
+- Literals (`true`, `false`, `null`, `NULL`), comments, strings
 
 ### Live C Preview
 
@@ -53,7 +54,7 @@ register GPIO7 @ 0x42004000 {
 
 u32 LED_BIT <- 3;
 
-namespace LED {
+scope LED {
     void toggle() {
         GPIO7.DR_TOGGLE[LED_BIT] <- true;
     }
@@ -72,6 +73,20 @@ void LED_toggle(void) {
 }
 ```
 
+### Atomic and Critical Sections
+
+```cnx
+atomic u32 counter <- 0;
+
+scope Counter {
+    void increment() {
+        critical {
+            counter <- counter + 1;
+        }
+    }
+}
+```
+
 ## About C-Next
 
 C-Next is a safer C for embedded systems that transpiles to clean, readable C code.
@@ -83,6 +98,10 @@ Key features:
 - Type-safe register bindings
 - Type-aware bit indexing
 - Static allocation only (no heap)
+- `atomic` variables with hardware-backed atomicity
+- `critical { }` sections for interrupt-safe code
+- Overflow control with `clamp` and `wrap` modifiers
+- Null-safe C interop with `c_` prefix pattern
 
 Learn more: [github.com/jlaustill/c-next](https://github.com/jlaustill/c-next)
 

--- a/vscode-extension/src/completionProvider.ts
+++ b/vscode-extension/src/completionProvider.ts
@@ -23,9 +23,11 @@ function debug(message: string): void {
 const KEYWORDS = [
   "register",
   "namespace",
+  "scope",
   "class",
   "struct",
   "enum",
+  "bitmap",
   "if",
   "else",
   "for",
@@ -45,6 +47,8 @@ const KEYWORDS = [
   "inline",
   "typedef",
   "sizeof",
+  "atomic",
+  "critical",
 ];
 
 /**
@@ -63,6 +67,12 @@ const TYPES = [
   "f64",
   "bool",
   "void",
+  "string",
+  "ISR",
+  "bitmap8",
+  "bitmap16",
+  "bitmap24",
+  "bitmap32",
 ];
 
 /**
@@ -71,9 +81,14 @@ const TYPES = [
 const ACCESS_MODIFIERS = ["rw", "ro", "wo", "w1c", "w1s"];
 
 /**
- * Boolean literals
+ * Boolean and null literals
  */
-const BOOL_LITERALS = ["true", "false"];
+const LITERALS = ["true", "false", "null", "NULL"];
+
+/**
+ * Overflow behavior modifiers (ADR-044)
+ */
+const OVERFLOW_MODIFIERS = ["clamp", "wrap"];
 
 /**
  * Common Arduino symbols that might not be returned by executeCompletionItemProvider
@@ -864,13 +879,23 @@ export default class CNextCompletionProvider
       items.push(item);
     }
 
-    // Add boolean literals
-    for (const lit of BOOL_LITERALS) {
+    // Add boolean and null literals
+    for (const lit of LITERALS) {
       const item = new vscode.CompletionItem(
         lit,
         vscode.CompletionItemKind.Constant,
       );
-      item.detail = "bool";
+      item.detail = lit === "true" || lit === "false" ? "bool" : "null pointer";
+      items.push(item);
+    }
+
+    // Add overflow modifiers
+    for (const mod of OVERFLOW_MODIFIERS) {
+      const item = new vscode.CompletionItem(
+        mod,
+        vscode.CompletionItemKind.Keyword,
+      );
+      item.detail = "overflow modifier";
       items.push(item);
     }
 


### PR DESCRIPTION
## Summary

- Add missing keywords to completion provider: `scope`, `bitmap`, `atomic`, `critical`
- Add missing types: `string`, `ISR`, `bitmap8`, `bitmap16`, `bitmap24`, `bitmap32`
- Add null literals: `null`, `NULL`
- Add overflow modifiers: `clamp`, `wrap`
- Update README with new feature documentation and examples

## Test plan

- [ ] Install the extension locally and verify new keywords appear in autocomplete
- [ ] Verify new types appear when typing in a type context
- [ ] Verify `null`/`NULL` literals appear in completions
- [ ] Verify `clamp`/`wrap` modifiers appear in completions
- [ ] Build extension with `npm run compile` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)