### PR TITLE
feat: add flawfinder CWE-based security scanner (Issue #270)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,7 +16,7 @@ src/parser/
 # *.c
 
 # Static analysis temp files
-.analysis-temp/
+analysis-temp/
 
 # Large hardware documentation PDFs (download instructions in README)
 examples/teensy4/docs/IMXRT1060RM_rev3.pdf

--- a/docs/decisions/adr-012-static-analysis.md
+++ b/docs/decisions/adr-012-static-analysis.md
@@ -41,6 +41,7 @@ C-Next already aligns with many MISRA rules by design:
 | 1     | **cppcheck**      | General static analysis, easy baseline |
 | 2     | **clang-tidy**    | Comprehensive checks, CERT guidelines  |
 | 3     | **MISRA checker** | Full MISRA C 2012 compliance           |
+| 4     | **flawfinder**    | CWE-based security vulnerability scan  |
 
 ### Long-term Goal
 
@@ -107,6 +108,37 @@ Checks: >
 4. **Polyspace** — Commercial, automotive-focused
 
 **Recommendation:** Start with cppcheck + clang-tidy. Evaluate commercial tools if/when C-Next targets safety-critical applications.
+
+### Phase 4: flawfinder Integration
+
+**Install:**
+
+```bash
+pip install flawfinder
+```
+
+**Risk Levels (0-5 scale):**
+
+| Level | Severity | Description                          |
+| ----- | -------- | ------------------------------------ |
+| 5     | Critical | Almost certainly exploitable         |
+| 4     | High     | Likely exploitable                   |
+| 3     | Medium   | Potential vulnerability              |
+| 2     | Low      | Minor issue, rarely exploitable      |
+| 1     | Info     | Informational, likely false positive |
+| 0     | None     | No risk (suppressed findings)        |
+
+**Integration Approach:**
+
+- **Test runner (`npm test`)**: Uses `--minlevel=3` to skip low-risk findings
+  - Level 2 char[] warnings are false positives for C-Next (static allocation per ADR-003)
+- **Manual analysis (`npm run analyze`)**: Uses `--minlevel=1` to show all actionable findings
+- **Exit behavior**: `--error-level=3` returns non-zero for level 3+ findings in test runner
+- **Timeout**: 30 seconds (flawfinder is fast, matches clang-tidy)
+
+**CWE Mapping:**
+
+flawfinder maps findings to CWE (Common Weakness Enumeration) identifiers, providing standardized vulnerability classification for security audits.
 
 ---
 

--- a/scripts/static-analysis.sh
+++ b/scripts/static-analysis.sh
@@ -6,7 +6,7 @@ set -e
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
-TEMP_DIR="${PROJECT_ROOT}/.analysis-temp"
+TEMP_DIR="${PROJECT_ROOT}/analysis-temp"
 TOOLS_DIR="${PROJECT_ROOT}/tools"
 
 # Colors for output
@@ -137,6 +137,59 @@ else
 fi
 
 echo ""
+
+# Run flawfinder if available (CWE-based security scanner)
+if command -v flawfinder &> /dev/null; then
+    echo -e "${BLUE}Running flawfinder (CWE security scanner)...${NC}"
+    echo ""
+
+    # Run flawfinder with --minlevel=1 to show all actionable findings
+    set +e  # Temporarily disable exit on error
+    FLAWFINDER_OUTPUT=$(flawfinder --minlevel=1 --dataonly "$TEMP_DIR" 2>&1)
+    set -e
+
+    # Count findings by risk level (flawfinder uses levels 0-5)
+    count_level() {
+        local level=$1
+        local count
+        count=$(echo "$FLAWFINDER_OUTPUT" | grep -c "\[${level}\]" 2>/dev/null) || count=0
+        echo "$count"
+    }
+
+    LEVEL_5=$(count_level 5)
+    LEVEL_4=$(count_level 4)
+    LEVEL_3=$(count_level 3)
+    LEVEL_2=$(count_level 2)
+    LEVEL_1=$(count_level 1)
+
+    echo -e "${BLUE}=== flawfinder Results ===${NC}"
+    echo ""
+
+    if [ -n "$FLAWFINDER_OUTPUT" ]; then
+        echo "$FLAWFINDER_OUTPUT"
+        echo ""
+    fi
+
+    echo -e "${BLUE}Summary (by risk level):${NC}"
+    echo -e "  Level 5 (critical):  ${RED}${LEVEL_5}${NC}"
+    echo -e "  Level 4 (high):      ${RED}${LEVEL_4}${NC}"
+    echo -e "  Level 3 (medium):    ${YELLOW}${LEVEL_3}${NC}"
+    echo -e "  Level 2 (low):       ${LEVEL_2}"
+    echo -e "  Level 1 (info):      ${LEVEL_1}"
+    echo ""
+
+    TOTAL_FLAWFINDER=$((LEVEL_5 + LEVEL_4 + LEVEL_3 + LEVEL_2 + LEVEL_1))
+    if [ "$TOTAL_FLAWFINDER" -eq 0 ]; then
+        echo -e "${GREEN}No security issues found!${NC}"
+    else
+        echo -e "${YELLOW}Total security findings: ${TOTAL_FLAWFINDER}${NC}"
+    fi
+    echo ""
+else
+    echo -e "${YELLOW}flawfinder not installed. Install with: pip install flawfinder${NC}"
+    echo ""
+fi
+
 echo -e "${BLUE}Generated files are in: ${TEMP_DIR}${NC}"
 echo ""
 

--- a/scripts/test-worker.ts
+++ b/scripts/test-worker.ts
@@ -177,6 +177,18 @@ async function runTest(
         }
       }
 
+      // Flawfinder security analysis
+      if (tools.flawfinder) {
+        const flawfinderResult = TestUtils.validateFlawfinder(expectedCFile);
+        if (!flawfinderResult.valid) {
+          return {
+            passed: false,
+            message: "Flawfinder security check failed",
+            actual: flawfinderResult.message,
+          };
+        }
+      }
+
       // No-warnings check if marker present
       if (TestUtils.hasNoWarningsMarker(source)) {
         const noWarningsResult = TestUtils.validateNoWarnings(

--- a/scripts/types/ITools.ts
+++ b/scripts/types/ITools.ts
@@ -6,6 +6,7 @@ interface ITools {
   cppcheck: boolean;
   clangTidy: boolean;
   misra: boolean;
+  flawfinder: boolean;
 }
 
 export default ITools;


### PR DESCRIPTION
## Summary

- Integrates flawfinder into the test validation pipeline as Phase 4 of static analysis
- Scans generated C code for CWE-mapped security vulnerabilities
- Uses `--minlevel=3` to avoid false positives from static char[] buffers (ADR-003)
- Adds flawfinder section to `npm run analyze` with risk level breakdown

## Changes

- `scripts/types/ITools.ts` - Add `flawfinder` field to interface
- `scripts/test-utils.ts` - Add `validateFlawfinder()` method
- `scripts/test.ts` - Add tool detection and validation step
- `scripts/test-worker.ts` - Mirror validation for parallel execution
- `scripts/static-analysis.sh` - Add flawfinder section after cppcheck
- `docs/decisions/adr-012-static-analysis.md` - Document Phase 4

## Test plan

- [x] Single test shows "flawfinder" in validation tools list
- [x] All 643 tests pass with flawfinder validation
- [x] `npm run analyze` shows flawfinder results section
- [x] Verify flawfinder correctly fails on level 3+ security issues

Closes #270

🤖 Generated with [Claude Code](https://claude.com/claude-code)