### PR TITLE
chore: release v0.1.18

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "c-next",
-  "version": "0.1.17",
+  "version": "0.1.18",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "c-next",
-      "version": "0.1.17",
+      "version": "0.1.18",
       "license": "MIT",
       "dependencies": {
         "antlr4ng": "^3.0.16",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "c-next",
-  "version": "0.1.17",
+  "version": "0.1.18",
   "description": "A safer C for embedded systems development. Transpiles to clean, readable C.",
   "main": "src/index.ts",
   "bin": {

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "c-next",
   "displayName": "C-Next",
   "description": "Syntax highlighting and live C preview for C-Next, a safer C for embedded systems",
-  "version": "0.0.8",
+  "version": "0.1.18",
   "publisher": "jlaustill",
   "license": "MIT",
   "repository": {

--- a/vscode-extension/src/completionProvider.ts
+++ b/vscode-extension/src/completionProvider.ts
@@ -44,6 +44,10 @@ const KEYWORDS = [
   "sizeof",
   "atomic",
   "critical",
+  "public",
+  "private",
+  "this",
+  "global",
 ];
 
 /**


### PR DESCRIPTION
## Summary
- Bump main package version to 0.1.18
- Bump VS Code extension version from 0.0.8 to 0.1.18 (sync with main package)
- Add missing keywords to completion provider (`public`, `private`, `this`, `global`)

## Test plan
- [ ] Verify package.json version is 0.1.18
- [ ] Verify VS Code extension package.json version is 0.1.18
- [ ] Verify completion provider includes all C-Next keywords
- [ ] Run `npm test` to ensure no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)