### PR TITLE
Release v0.1.20

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.20] - 2026-01-21
+
+### Added
+
+- E0504 error for `.h` includes when `.cnx` alternative exists (PR #316)
+
+### Fixed
+
+- Pass primitive struct members by value in cross-file calls (Issue #315, PR #318)
+- Use `::` syntax for `global.X.method()` in C++ mode (Issue #314, PR #317)
+
 ## [0.1.19] - 2026-01-21
 
 ### Added
@@ -224,7 +235,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - 38 legacy ESLint errors (non-blocking, tracked for future cleanup)
 
-[Unreleased]: https://github.com/jlaustill/c-next/compare/v0.1.19...HEAD
+[Unreleased]: https://github.com/jlaustill/c-next/compare/v0.1.20...HEAD
+[0.1.20]: https://github.com/jlaustill/c-next/compare/v0.1.19...v0.1.20
 [0.1.19]: https://github.com/jlaustill/c-next/compare/v0.1.18...v0.1.19
 [0.1.18]: https://github.com/jlaustill/c-next/compare/v0.1.17...v0.1.18
 [0.1.17]: https://github.com/jlaustill/c-next/compare/v0.1.16...v0.1.17

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "c-next",
-  "version": "0.1.19",
+  "version": "0.1.20",
   "description": "A safer C for embedded systems development. Transpiles to clean, readable C.",
   "main": "src/index.ts",
   "bin": {

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "c-next",
   "displayName": "C-Next",
   "description": "Syntax highlighting and live C preview for C-Next, a safer C for embedded systems",
-  "version": "0.1.19",
+  "version": "0.1.20",
   "publisher": "jlaustill",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
## Summary

- Bump version to 0.1.20 in package.json and vscode-extension/package.json
- Update CHANGELOG.md with release notes

### Changes in v0.1.20

**Added:**
- E0504 error for `.h` includes when `.cnx` alternative exists (PR #316)

**Fixed:**
- Pass primitive struct members by value in cross-file calls (Issue #315, PR #318)
- Use `::` syntax for `global.X.method()` in C++ mode (Issue #314, PR #317)

## Test plan

- [x] All 667 tests pass
- [x] TypeScript typecheck passes
- [ ] Merge PR
- [ ] Tag `v0.1.20` and push tag to trigger npm publish

🤖 Generated with [Claude Code](https://claude.com/claude-code)