### PR TITLE
chore: release v0.1.22

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.22] - 2026-01-22
+
+### Fixed
+
+- False symbol conflict with C-Next generated headers during incremental migration (Issue #328)
+
 ## [0.1.21] - 2026-01-22
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "c-next",
-  "version": "0.1.21",
+  "version": "0.1.22",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "c-next",
-      "version": "0.1.21",
+      "version": "0.1.22",
       "license": "MIT",
       "dependencies": {
         "antlr4ng": "^3.0.16",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "c-next",
-  "version": "0.1.21",
+  "version": "0.1.22",
   "description": "A safer C for embedded systems development. Transpiles to clean, readable C.",
   "main": "src/index.ts",
   "bin": {

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "c-next",
   "displayName": "C-Next",
   "description": "Syntax highlighting and live C preview for C-Next, a safer C for embedded systems",
-  "version": "0.1.21",
+  "version": "0.1.22",
   "publisher": "jlaustill",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
## Summary
- Bumps version to 0.1.22
- Updates CHANGELOG with fix for Issue #328

## Changes in this release
### Fixed
- False symbol conflict with C-Next generated headers during incremental migration (Issue #328)

## Test plan
- [x] All tests pass
- [x] Version numbers updated in package.json, package-lock.json, and vscode-extension/package.json
- [x] CHANGELOG updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)