### PR TITLE
feat(vscode): add file nesting for generated files

### DIFF
--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "c-next",
   "displayName": "C-Next",
   "description": "Syntax highlighting and live C preview for C-Next, a safer C for embedded systems",
-  "version": "0.1.22",
+  "version": "0.1.24",
   "publisher": "jlaustill",
   "license": "MIT",
   "repository": {
@@ -137,6 +137,13 @@
           "default": 500,
           "description": "Delay in milliseconds before updating the .c file after typing"
         }
+      }
+    },
+    "configurationDefaults": {
+      "explorer.fileNesting.enabled": true,
+      "explorer.fileNesting.expand": false,
+      "explorer.fileNesting.patterns": {
+        "*.cnx": "${capture}.c, ${capture}.cpp, ${capture}.h, ${capture}.hpp"
       }
     }
   },


### PR DESCRIPTION
## Summary
- Add VS Code file nesting configuration to collapse generated files under `.cnx` source files
- Generated files (`.c`, `.cpp`, `.h`, `.hpp`) are now nested under their parent `.cnx` files
- Files are collapsed by default, making the file tree cleaner
- Helps identify misplaced or orphaned files that don't have a matching source

## Changes
- Added `configurationDefaults` to `package.json` with file nesting patterns
- Bumped extension version to 0.1.24

## Test plan
- [x] Rebuild and install the extension
- [x] Verify `.c` files appear nested under `.cnx` files in the Explorer
- [x] Verify orphaned files (without matching `.cnx`) remain visible at top level

🤖 Generated with [Claude Code](https://claude.com/claude-code)