### PR TITLE
feat(vscode): add snippets, formatter defaults, and roadmap

### DIFF
--- a/vscode-extension/README.md
+++ b/vscode-extension/README.md
@@ -87,6 +87,46 @@ scope Counter {
 }
 ```
 
+## Code Snippets
+
+Type these prefixes and press Tab to expand:
+
+| Prefix             | Description                           |
+| ------------------ | ------------------------------------- |
+| `scope` / `scopep` | Scope with private/public sections    |
+| `register`         | Hardware register block               |
+| `struct` / `enum`  | Type definitions                      |
+| `fn` / `pfn`       | Function / public function            |
+| `for` / `while`    | Loop templates                        |
+| `if` / `ife`       | Conditionals                          |
+| `switch` / `case`  | Switch with required braces (ADR-025) |
+| `clamp` / `wrap`   | Variables with overflow behavior      |
+
+See all snippets: type `Ctrl+Space` in a `.cnx` file.
+
+## Formatting with Prettier
+
+This extension auto-configures Prettier as the default formatter for `.cnx` files with format-on-save enabled.
+
+**To enable formatting:**
+
+1. Install the [Prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode)
+2. Add `prettier-plugin-cnext` to your project:
+   ```bash
+   npm install -D prettier prettier-plugin-cnext
+   ```
+3. Format-on-save works automatically
+
+If you don't have Prettier installed, you can disable the default by adding to your settings:
+
+```json
+{
+  "[cnext]": {
+    "editor.formatOnSave": false
+  }
+}
+```
+
 ## About C-Next
 
 C-Next is a safer C for embedded systems that transpiles to clean, readable C code.

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "c-next",
   "displayName": "C-Next",
   "description": "Syntax highlighting and live C preview for C-Next, a safer C for embedded systems",
-  "version": "0.1.24",
+  "version": "0.1.25",
   "publisher": "jlaustill",
   "license": "MIT",
   "repository": {
@@ -39,6 +39,12 @@
         "language": "cnext",
         "scopeName": "source.cnext",
         "path": "./syntaxes/cnext.tmLanguage.json"
+      }
+    ],
+    "snippets": [
+      {
+        "language": "cnext",
+        "path": "./snippets/cnext.json"
       }
     ],
     "commands": [
@@ -144,6 +150,10 @@
       "explorer.fileNesting.expand": false,
       "explorer.fileNesting.patterns": {
         "*.cnx": "${capture}.c, ${capture}.cpp, ${capture}.h, ${capture}.hpp"
+      },
+      "[cnext]": {
+        "editor.defaultFormatter": "esbenp.prettier-vscode",
+        "editor.formatOnSave": true
       }
     }
   },

--- a/vscode-extension/roadmap.md
+++ b/vscode-extension/roadmap.md
@@ -1,0 +1,120 @@
+# C-Next VS Code Extension Roadmap
+
+This document tracks planned features and improvements for the C-Next VS Code extension.
+
+## Current Features
+
+- **Syntax highlighting** - TextMate grammar for `.cnx` files
+- **Live C preview** - Side-by-side transpilation view
+- **Diagnostics** - Parse errors shown as squiggles
+- **Auto-completion** - Keywords, types, symbols, C/C++ stdlib via generated files
+- **Hover info** - Types, keywords, symbols, C library documentation
+- **Go-to-definition** - Navigate to symbol definitions (Ctrl+Click / F12)
+- **Workspace indexing** - Cross-file symbol resolution
+- **File nesting** - Generated files (.c, .cpp, .h, .hpp) collapsed under .cnx files
+- **Formatter defaults** - Auto-configures Prettier as default formatter for .cnx files
+- **Code snippets** - Templates for scope, register, struct, enum, loops, functions, etc.
+
+## Planned Features
+
+### Medium Priority
+
+#### Document Outline / Symbols
+
+Implement `DocumentSymbolProvider` to show file structure in the Outline view:
+
+- Scopes, registers, structs, enums at top level
+- Functions and methods nested under their containers
+- Fields and members nested under their parents
+
+Enables:
+
+- Outline view in Explorer sidebar
+- "Go to Symbol in Editor" (Cmd+Shift+O)
+- Breadcrumb navigation
+
+**Effort:** Medium | **Impact:** High
+
+#### Rename Symbol
+
+Implement `RenameProvider` for safe refactoring:
+
+- Rename variables, functions, types across the file
+- Workspace-wide rename using WorkspaceIndex
+- Preview changes before applying
+
+**Effort:** Medium | **Impact:** High
+
+#### Find All References
+
+Implement `ReferenceProvider`:
+
+- Find all usages of a symbol
+- Works across workspace using WorkspaceIndex
+- Integrates with "Find All References" (Shift+F12)
+
+**Effort:** Medium | **Impact:** Medium
+
+#### Signature Help
+
+Implement `SignatureHelpProvider`:
+
+- Show parameter hints while typing function calls
+- Display parameter types and names
+- Highlight current parameter
+
+**Effort:** Medium | **Impact:** Medium
+
+### Lower Priority
+
+#### Code Actions / Quick Fixes
+
+Implement `CodeActionProvider` for common fixes:
+
+- "Did you mean `u32` instead of `uint32`?" (type suggestions)
+- "Add missing return statement"
+- "Convert to scope member" (add `this.` prefix)
+- Import suggestions for cross-file symbols
+
+**Effort:** High | **Impact:** Medium
+
+#### Semantic Highlighting
+
+Implement `DocumentSemanticTokensProvider`:
+
+- More accurate syntax coloring based on actual parsing
+- Distinguish between types, variables, functions by context
+- Highlight scope members differently from globals
+
+**Effort:** High | **Impact:** Low-Medium
+
+#### Workspace Symbol Search
+
+Implement `WorkspaceSymbolProvider`:
+
+- "Go to Symbol in Workspace" (Cmd+T)
+- Search for symbols across all .cnx files
+- Leverage existing WorkspaceIndex
+
+**Effort:** Low | **Impact:** Medium
+
+## Ideas for Future Consideration
+
+- **Inlay hints** - Show inferred types, parameter names inline
+- **Call hierarchy** - "Who calls this?" / "What does this call?"
+- **Code lens** - Show reference counts above functions
+- **Folding ranges** - Custom folding for scopes, registers, multi-line comments
+- **Linked editing** - Edit matching identifiers simultaneously
+- **Color decorators** - Preview hex colors in register definitions
+- **Problem matchers** - Parse C compiler output for .cnx line mapping
+- **Debug adapter** - Source-level debugging (maps to generated C)
+- **Test integration** - Run .test.cnx files from VS Code
+
+## Contributing
+
+When implementing a feature:
+
+1. Update this roadmap to mark it as in-progress
+2. Add tests where applicable
+3. Update the extension's README with new features
+4. Bump the version in package.json

--- a/vscode-extension/snippets/cnext.json
+++ b/vscode-extension/snippets/cnext.json
@@ -1,0 +1,207 @@
+{
+  "Scope": {
+    "prefix": "scope",
+    "body": [
+      "scope ${1:Name} {",
+      "\tprivate {",
+      "\t\t$2",
+      "\t}",
+      "",
+      "\tpublic {",
+      "\t\t$0",
+      "\t}",
+      "}"
+    ],
+    "description": "C-Next scope (singleton service with prefixed members)"
+  },
+  "Scope Simple": {
+    "prefix": "scopep",
+    "body": ["scope ${1:Name} {", "\tpublic {", "\t\t$0", "\t}", "}"],
+    "description": "C-Next scope with public section only"
+  },
+  "Register": {
+    "prefix": "register",
+    "body": [
+      "register ${1:Name} @ ${2:0x00000000} {",
+      "\t${3:field}: ${4:u32} ${5|rw,ro,wo,w1c,w1s|};",
+      "\t$0",
+      "}"
+    ],
+    "description": "Hardware register binding for memory-mapped I/O"
+  },
+  "Register Member": {
+    "prefix": "regmem",
+    "body": "${1:field}: ${2:u32} ${3|rw,ro,wo,w1c,w1s|};",
+    "description": "Register member with access modifier"
+  },
+  "Struct": {
+    "prefix": "struct",
+    "body": ["struct ${1:Name} {", "\t${2:field}: ${3:u32};", "\t$0", "}"],
+    "description": "C-Next struct definition"
+  },
+  "Enum": {
+    "prefix": "enum",
+    "body": [
+      "enum ${1:Name}: ${2:u8} {",
+      "\t${3:Value1},",
+      "\t${4:Value2},",
+      "\t$0",
+      "}"
+    ],
+    "description": "C-Next type-safe enumeration"
+  },
+  "Bitmap": {
+    "prefix": "bitmap",
+    "body": [
+      "bitmap ${1:Name}: ${2|bitmap8,bitmap16,bitmap24,bitmap32|} {",
+      "\t${3:flag1},",
+      "\t${4:flag2},",
+      "\t$0",
+      "}"
+    ],
+    "description": "C-Next bitmap type for flag sets"
+  },
+  "Function": {
+    "prefix": "fn",
+    "body": ["${1:void} ${2:functionName}(${3}) {", "\t$0", "}"],
+    "description": "Function definition"
+  },
+  "Public Function": {
+    "prefix": "pfn",
+    "body": ["public ${1:void} ${2:functionName}(${3}) {", "\t$0", "}"],
+    "description": "Public function definition (inside scope)"
+  },
+  "Main Function": {
+    "prefix": "main",
+    "body": ["void main() {", "\t$0", "}"],
+    "description": "Main entry point"
+  },
+  "Main with Return": {
+    "prefix": "mainret",
+    "body": ["u32 main() {", "\t$0", "\treturn 0;", "}"],
+    "description": "Main entry point with return value"
+  },
+  "For Loop": {
+    "prefix": "for",
+    "body": [
+      "for (${1:u32} ${2:i} <- ${3:0}; ${2:i} < ${4:count}; ${2:i}++) {",
+      "\t$0",
+      "}"
+    ],
+    "description": "For loop with C-Next assignment operator"
+  },
+  "For Range": {
+    "prefix": "forr",
+    "body": [
+      "for (${1:u32} ${2:i} <- ${3:0}; ${2:i} < ${4:array}.length; ${2:i}++) {",
+      "\t$0",
+      "}"
+    ],
+    "description": "For loop iterating over array"
+  },
+  "While Loop": {
+    "prefix": "while",
+    "body": ["while (${1:condition}) {", "\t$0", "}"],
+    "description": "While loop"
+  },
+  "Do-While Loop": {
+    "prefix": "dowhile",
+    "body": ["do {", "\t$0", "} while (${1:condition});"],
+    "description": "Do-while loop (executes at least once)"
+  },
+  "If": {
+    "prefix": "if",
+    "body": ["if (${1:condition}) {", "\t$0", "}"],
+    "description": "If statement"
+  },
+  "If-Else": {
+    "prefix": "ife",
+    "body": ["if (${1:condition}) {", "\t$2", "} else {", "\t$0", "}"],
+    "description": "If-else statement"
+  },
+  "If-Else If-Else": {
+    "prefix": "ifei",
+    "body": [
+      "if (${1:condition1}) {",
+      "\t$2",
+      "} else if (${3:condition2}) {",
+      "\t$4",
+      "} else {",
+      "\t$0",
+      "}"
+    ],
+    "description": "If-else if-else statement"
+  },
+  "Switch": {
+    "prefix": "switch",
+    "body": [
+      "switch (${1:expression}) {",
+      "\tcase ${2:value1}: {",
+      "\t\t$3",
+      "\t}",
+      "\tcase ${4:value2}: {",
+      "\t\t$5",
+      "\t}",
+      "\tdefault: {",
+      "\t\t$0",
+      "\t}",
+      "}"
+    ],
+    "description": "Switch statement with required braces per case (ADR-025)"
+  },
+  "Switch Case": {
+    "prefix": "case",
+    "body": ["case ${1:value}: {", "\t$0", "}"],
+    "description": "Switch case with required braces"
+  },
+  "Const": {
+    "prefix": "const",
+    "body": "const ${1:NAME}: ${2:u32} <- ${3:value};",
+    "description": "Compile-time constant"
+  },
+  "Variable": {
+    "prefix": "var",
+    "body": "${1:u32} ${2:name} <- ${3:value};",
+    "description": "Variable declaration with initialization"
+  },
+  "Array": {
+    "prefix": "arr",
+    "body": "${1:u32} ${2:name}[${3:size}];",
+    "description": "Array declaration"
+  },
+  "Array Initialized": {
+    "prefix": "arri",
+    "body": "${1:u32} ${2:name}[${3:size}] <- {${4:values}};",
+    "description": "Array declaration with initialization"
+  },
+  "Include Local": {
+    "prefix": "incl",
+    "body": "#include \"${1:filename}.h\"",
+    "description": "Include local header file"
+  },
+  "Include System": {
+    "prefix": "incs",
+    "body": "#include <${1:header}.h>",
+    "description": "Include system header file"
+  },
+  "ISR": {
+    "prefix": "isr",
+    "body": ["ISR ${1:interruptName}() {", "\t$0", "}"],
+    "description": "Interrupt Service Routine"
+  },
+  "Ternary": {
+    "prefix": "tern",
+    "body": "${1:condition} ? ${2:trueValue} : ${3:falseValue}",
+    "description": "Ternary conditional expression"
+  },
+  "Clamp Variable": {
+    "prefix": "clamp",
+    "body": "clamp ${1:u16} ${2:name} <- ${3:0};",
+    "description": "Variable with clamp overflow (saturates at min/max)"
+  },
+  "Wrap Variable": {
+    "prefix": "wrap",
+    "body": "wrap ${1:u32} ${2:name} <- ${3:0};",
+    "description": "Variable with wrap overflow (two's complement)"
+  }
+}


### PR DESCRIPTION
## Summary
- Add 30 code snippets for common C-Next patterns
- Configure Prettier as default formatter with format-on-save
- Add roadmap.md documenting current features and planned improvements

## Snippets Added
| Prefix | Description |
|--------|-------------|
| `scope` / `scopep` | Scope with private/public or public only |
| `register` / `regmem` | Register block and members |
| `struct` / `enum` / `bitmap` | Type definitions |
| `fn` / `pfn` / `main` / `mainret` | Function templates |
| `for` / `forr` / `while` / `dowhile` | Loop templates |
| `if` / `ife` / `ifei` | Conditionals |
| `switch` / `case` | ADR-025 style switch |
| `const` / `var` / `arr` / `arri` | Declarations |
| `isr` | Interrupt Service Routine |
| `incl` / `incs` | Include directives |
| `clamp` / `wrap` | Overflow assignments |
| `tern` | Ternary expression |

## Formatter Defaults
```json
"[cnext]": {
  "editor.defaultFormatter": "esbenp.prettier-vscode",
  "editor.formatOnSave": true
}
```

Users with Prettier + `prettier-plugin-cnext` installed get format-on-save automatically.

## Test plan
- [x] Rebuild and install extension
- [x] Verify snippets expand correctly (type `scope` + Tab)
- [x] Verify format-on-save works with Prettier plugin installed

🤖 Generated with [Claude Code](https://claude.com/claude-code)