### PR TITLE
Release v0.1.25

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.25] - 2026-01-22
+
+### Added
+
+- VS Code extension: code snippets for common C-Next patterns
+- VS Code extension: file nesting for generated `.c`/`.h` files under source `.cnx`
+- VS Code extension: formatter defaults and roadmap documentation
+
+### Fixed
+
+- Array member arguments from typedef'd C++ structs now pass correctly (Issue #342)
+- Use relative paths for self-includes with `--header-out` option (Issue #339)
+
 ## [0.1.24] - 2026-01-22
 
 ### Fixed
@@ -268,7 +281,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - 38 legacy ESLint errors (non-blocking, tracked for future cleanup)
 
-[Unreleased]: https://github.com/jlaustill/c-next/compare/v0.1.24...HEAD
+[Unreleased]: https://github.com/jlaustill/c-next/compare/v0.1.25...HEAD
+[0.1.25]: https://github.com/jlaustill/c-next/compare/v0.1.24...v0.1.25
 [0.1.24]: https://github.com/jlaustill/c-next/compare/v0.1.23...v0.1.24
 [0.1.23]: https://github.com/jlaustill/c-next/compare/v0.1.22...v0.1.23
 [0.1.22]: https://github.com/jlaustill/c-next/compare/v0.1.21...v0.1.22

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "c-next",
-  "version": "0.1.24",
+  "version": "0.1.25",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "c-next",
-      "version": "0.1.24",
+      "version": "0.1.25",
       "license": "MIT",
       "dependencies": {
         "antlr4ng": "^3.0.16",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "c-next",
-  "version": "0.1.24",
+  "version": "0.1.25",
   "description": "A safer C for embedded systems development. Transpiles to clean, readable C.",
   "main": "src/index.ts",
   "bin": {


### PR DESCRIPTION
## Release v0.1.25

### Added
- VS Code extension: code snippets for common C-Next patterns
- VS Code extension: file nesting for generated `.c`/`.h` files under source `.cnx`
- VS Code extension: formatter defaults and roadmap documentation

### Fixed
- Array member arguments from typedef'd C++ structs now pass correctly (Issue #342)
- Use relative paths for self-includes with `--header-out` option (Issue #339)

### Checklist
- [x] Version bumped in `package.json` (0.1.24 → 0.1.25)
- [x] VS Code extension version already at 0.1.25
- [x] CHANGELOG.md updated
- [x] All 673 integration tests pass
- [x] All 74 unit tests pass
- [x] TypeScript type check passes

### Post-merge
After merging, tag and push:
```bash
git checkout main && git pull
git tag v0.1.25
git push origin v0.1.25
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)