### PR TITLE
fix: resolve angle-bracket CNX includes with correct directory prefix (#349)

### DIFF
--- a/src/codegen/CodeGenerator.ts
+++ b/src/codegen/CodeGenerator.ts
@@ -255,6 +255,12 @@ export default class CodeGenerator implements IOrchestrator {
   /** ADR-010: Source file path for validating includes */
   private sourcePath: string | null = null;
 
+  /** Issue #349: Include directories for resolving angle-bracket .cnx includes */
+  private includeDirs: string[] = [];
+
+  /** Issue #349: Input directories for calculating relative paths */
+  private inputs: string[] = [];
+
   /** Token stream for comment extraction (ADR-043) */
   private tokenStream: CommonTokenStream | null = null;
 
@@ -1309,6 +1315,10 @@ export default class CodeGenerator implements IOrchestrator {
     // ADR-010: Store source path for include validation
     this.sourcePath = options?.sourcePath ?? null;
 
+    // Issue #349: Store include directories and inputs for angle-bracket include resolution
+    this.includeDirs = options?.includeDirs ?? [];
+    this.inputs = options?.inputs ?? [];
+
     // Issue #250: Store C++ mode for temp variable generation
     this.cppMode = options?.cppMode ?? false;
     // Reset temp var state for each generation
@@ -1617,9 +1627,14 @@ export default class CodeGenerator implements IOrchestrator {
   /**
    * ADR-010: Transform #include directives, converting .cnx to .h
    * ADR-053 A5: Delegates to IncludeGenerator
+   * Issue #349: Now passes includeDirs and inputs for angle-bracket resolution
    */
   private transformIncludeDirective(includeText: string): string {
-    return includeTransformIncludeDirective(includeText, this.sourcePath);
+    return includeTransformIncludeDirective(includeText, {
+      sourcePath: this.sourcePath,
+      includeDirs: this.includeDirs,
+      inputs: this.inputs,
+    });
   }
 
   // Issue #63: validateIncludeNotImplementationFile moved to TypeValidator

--- a/src/codegen/types/ICodeGeneratorOptions.ts
+++ b/src/codegen/types/ICodeGeneratorOptions.ts
@@ -24,6 +24,16 @@ interface ICodeGeneratorOptions {
    * Example: "Display/Utils.cnx" -> #include "Display/Utils.h"
    */
   sourceRelativePath?: string;
+  /**
+   * Issue #349: Include directories for resolving angle-bracket .cnx includes.
+   * Used to search for .cnx files referenced in #include <file.cnx> directives.
+   */
+  includeDirs?: string[];
+  /**
+   * Issue #349: Input directories for calculating relative paths.
+   * Used to determine the correct output path prefix for headers.
+   */
+  inputs?: string[];
 }
 
 export default ICodeGeneratorOptions;

--- a/src/pipeline/Pipeline.ts
+++ b/src/pipeline/Pipeline.ts
@@ -643,6 +643,8 @@ class Pipeline {
           generateHeaders: this.config.generateHeaders, // Issue #230: Enable self-include when headers are generated
           cppMode: this.cppDetected, // Issue #250: C++ compatible code generation
           sourceRelativePath: this.getSourceRelativePath(file.path), // Issue #339: For correct self-include paths
+          includeDirs: this.config.includeDirs, // Issue #349: For angle-bracket include resolution
+          inputs: this.config.inputs, // Issue #349: For calculating relative paths
         },
       );
 

--- a/tests/integration/issue-349-angle-include-paths.test.ts
+++ b/tests/integration/issue-349-angle-include-paths.test.ts
@@ -1,0 +1,376 @@
+#!/usr/bin/env tsx
+/**
+ * Issue #349: Angle-bracket CNX includes missing directory prefix
+ *
+ * Tests that angle-bracket #include <file.cnx> statements in generated .c files
+ * get the correct directory prefix added to match --header-out structure.
+ *
+ * Bug: When source has subdirectories (e.g., src/Display/main.cnx contains
+ * #include <utils.cnx> where utils.cnx is in the same directory), the generated
+ * .c file uses #include <utils.h> instead of #include <Display/utils.h>.
+ *
+ * This causes build failures because the compiler can't find the header file
+ * using -I include/ flag.
+ */
+
+import { existsSync, writeFileSync, mkdirSync, rmSync, readFileSync } from "fs";
+import { join } from "path";
+import Pipeline from "../../src/pipeline/Pipeline";
+
+// Test source files - Utils has a public function which triggers header generation
+const utilsSource = `
+scope Utils {
+    public u8 add(u8 x) {
+        return x + 1;
+    }
+}
+`;
+
+// Main file includes Utils using angle brackets (sibling include)
+const mainSource = `
+#include <utils.cnx>
+
+u8 result;
+
+i32 main() {
+    result <- global.Utils.add(5);
+    return 0;
+}
+`;
+
+// Test directory paths
+const testDir = "/tmp/c-next-test-issue-349";
+const sourceDir = join(testDir, "src");
+const displayDir = join(sourceDir, "Display");
+const codeOutDir = join(testDir, "build");
+const headerOutDir = join(testDir, "include");
+
+function setup() {
+  // Clean up any previous test artifacts
+  if (existsSync(testDir)) {
+    rmSync(testDir, { recursive: true });
+  }
+
+  // Create source directory structure
+  mkdirSync(displayDir, { recursive: true });
+}
+
+let passed = 0;
+let failed = 0;
+
+function check(condition: boolean, description: string) {
+  if (condition) {
+    console.log(`PASS: ${description}`);
+    passed++;
+  } else {
+    console.error(`FAIL: ${description}`);
+    failed++;
+  }
+}
+
+/**
+ * Extract angle-bracket includes only
+ */
+function extractAngleBracketIncludes(content: string): string[] {
+  const includeRegex = /#include\s+<([^>]+)>/g;
+  const includes: string[] = [];
+  let match;
+  while ((match = includeRegex.exec(content)) !== null) {
+    includes.push(match[1]);
+  }
+  return includes;
+}
+
+async function testSiblingAngleBracketInclude() {
+  console.log("\n=== Test 1: Sibling angle-bracket include ===\n");
+  console.log("When main.cnx in Display/ includes <utils.cnx> (sibling file),");
+  console.log("the generated main.c should include <Display/utils.h>.\n");
+
+  setup();
+
+  // Write test source files - both in Display/ subdirectory
+  writeFileSync(join(displayDir, "utils.cnx"), utilsSource, "utf-8");
+  writeFileSync(join(displayDir, "main.cnx"), mainSource, "utf-8");
+
+  const pipeline = new Pipeline({
+    inputs: [sourceDir],
+    outDir: codeOutDir,
+    headerOutDir: headerOutDir,
+    includeDirs: [sourceDir],
+    generateHeaders: true,
+  });
+
+  const result = await pipeline.run();
+  check(result.success, "Pipeline compilation succeeds");
+
+  // Check that main.c includes Display/utils.h (not just utils.h)
+  const mainCodePath = join(codeOutDir, "Display", "main.c");
+  check(existsSync(mainCodePath), "Display/main.c exists");
+
+  if (existsSync(mainCodePath)) {
+    const mainCode = readFileSync(mainCodePath, "utf-8");
+    const includes = extractAngleBracketIncludes(mainCode);
+    console.log("  main.c angle-bracket includes:", includes);
+
+    // BUG CHECK: Should include <Display/utils.h>, not <utils.h>
+    check(
+      includes.includes("Display/utils.h"),
+      "main.c includes <Display/utils.h> (with subdirectory)",
+    );
+    check(
+      !includes.some((inc) => inc === "utils.h"),
+      "main.c does NOT include bare <utils.h>",
+    );
+  }
+}
+
+async function testCrossDirectoryAngleBracketInclude() {
+  console.log("\n=== Test 2: Cross-directory angle-bracket include ===\n");
+  console.log("When a file includes <Display/utils.cnx> explicitly,");
+  console.log("it should become <Display/utils.h>.\n");
+
+  setup();
+
+  // Create a root-level main that includes from a subdirectory
+  const rootMainSource = `
+#include <Display/utils.cnx>
+
+u8 result;
+
+i32 main() {
+    result <- global.Utils.add(5);
+    return 0;
+}
+`;
+
+  writeFileSync(join(displayDir, "utils.cnx"), utilsSource, "utf-8");
+  writeFileSync(join(sourceDir, "main.cnx"), rootMainSource, "utf-8");
+
+  // Clear output directories
+  if (existsSync(codeOutDir)) rmSync(codeOutDir, { recursive: true });
+  if (existsSync(headerOutDir)) rmSync(headerOutDir, { recursive: true });
+
+  const pipeline = new Pipeline({
+    inputs: [sourceDir],
+    outDir: codeOutDir,
+    headerOutDir: headerOutDir,
+    includeDirs: [sourceDir],
+    generateHeaders: true,
+  });
+
+  const result = await pipeline.run();
+  check(result.success, "Pipeline compilation succeeds");
+
+  // Check that main.c includes Display/utils.h
+  const mainCodePath = join(codeOutDir, "main.c");
+  check(existsSync(mainCodePath), "main.c exists at root");
+
+  if (existsSync(mainCodePath)) {
+    const mainCode = readFileSync(mainCodePath, "utf-8");
+    const includes = extractAngleBracketIncludes(mainCode);
+    console.log("  main.c angle-bracket includes:", includes);
+
+    // Explicit path should be preserved
+    check(
+      includes.includes("Display/utils.h"),
+      "main.c includes <Display/utils.h> (explicit path preserved)",
+    );
+  }
+}
+
+async function testRootLevelAngleBracketInclude() {
+  console.log("\n=== Test 3: Root-level angle-bracket include ===\n");
+  console.log(
+    "When files are at the root level, no directory prefix needed.\n",
+  );
+
+  setup();
+
+  // Put both files at root level
+  writeFileSync(join(sourceDir, "utils.cnx"), utilsSource, "utf-8");
+  writeFileSync(join(sourceDir, "main.cnx"), mainSource, "utf-8");
+
+  // Clear output directories
+  if (existsSync(codeOutDir)) rmSync(codeOutDir, { recursive: true });
+  if (existsSync(headerOutDir)) rmSync(headerOutDir, { recursive: true });
+
+  const pipeline = new Pipeline({
+    inputs: [sourceDir],
+    outDir: codeOutDir,
+    headerOutDir: headerOutDir,
+    includeDirs: [sourceDir],
+    generateHeaders: true,
+  });
+
+  const result = await pipeline.run();
+  check(result.success, "Pipeline compilation succeeds");
+
+  const mainCodePath = join(codeOutDir, "main.c");
+  check(existsSync(mainCodePath), "main.c exists");
+
+  if (existsSync(mainCodePath)) {
+    const mainCode = readFileSync(mainCodePath, "utf-8");
+    const includes = extractAngleBracketIncludes(mainCode);
+    console.log("  main.c angle-bracket includes:", includes);
+
+    // At root level, should use bare name
+    check(
+      includes.includes("utils.h"),
+      "main.c includes <utils.h> (bare name for root level)",
+    );
+    // Should not have any weird prefixes
+    check(
+      !includes.some((inc) => inc.startsWith("./") && inc.includes("utils")),
+      "main.c does NOT include <./utils.h>",
+    );
+  }
+}
+
+async function testAngleBracketIncludeFallback() {
+  console.log("\n=== Test 4: Angle-bracket include fallback ===\n");
+  console.log(
+    "When .cnx file is not found, should fall back to simple replacement.\n",
+  );
+
+  setup();
+
+  // Include a non-existent CNX file (e.g., system header)
+  const mainWithExternalInclude = `
+#include <external.cnx>
+
+i32 main() {
+    return 0;
+}
+`;
+
+  writeFileSync(join(sourceDir, "main.cnx"), mainWithExternalInclude, "utf-8");
+
+  // Clear output directories
+  if (existsSync(codeOutDir)) rmSync(codeOutDir, { recursive: true });
+  if (existsSync(headerOutDir)) rmSync(headerOutDir, { recursive: true });
+
+  const pipeline = new Pipeline({
+    inputs: [sourceDir],
+    outDir: codeOutDir,
+    headerOutDir: headerOutDir,
+    includeDirs: [sourceDir],
+    generateHeaders: true,
+  });
+
+  const result = await pipeline.run();
+  check(result.success, "Pipeline compilation succeeds");
+
+  const mainCodePath = join(codeOutDir, "main.c");
+  check(existsSync(mainCodePath), "main.c exists");
+
+  if (existsSync(mainCodePath)) {
+    const mainCode = readFileSync(mainCodePath, "utf-8");
+    const includes = extractAngleBracketIncludes(mainCode);
+    console.log("  main.c angle-bracket includes:", includes);
+
+    // Fallback: when file not found, just do simple replacement
+    check(
+      includes.includes("external.h"),
+      "main.c includes <external.h> (fallback for non-existent file)",
+    );
+  }
+}
+
+async function testNestedDirectoryAngleBracketInclude() {
+  console.log("\n=== Test 5: Deeply nested angle-bracket include ===\n");
+  console.log("Tests that multi-level directory structures are handled.\n");
+
+  setup();
+
+  // Create deeply nested structure: src/A/B/C/Deep.cnx
+  const deepDir = join(sourceDir, "A", "B", "C");
+  mkdirSync(deepDir, { recursive: true });
+
+  const deepUtilsSource = `
+scope DeepUtils {
+    public u8 getDeepValue() {
+        return 99;
+    }
+}
+`;
+
+  // Main in the same deep directory includes sibling
+  const deepMainSource = `
+#include <deep_utils.cnx>
+
+u8 result;
+
+i32 main() {
+    result <- global.DeepUtils.getDeepValue();
+    return 0;
+}
+`;
+
+  writeFileSync(join(deepDir, "deep_utils.cnx"), deepUtilsSource, "utf-8");
+  writeFileSync(join(deepDir, "main.cnx"), deepMainSource, "utf-8");
+
+  // Clear output directories
+  if (existsSync(codeOutDir)) rmSync(codeOutDir, { recursive: true });
+  if (existsSync(headerOutDir)) rmSync(headerOutDir, { recursive: true });
+
+  const pipeline = new Pipeline({
+    inputs: [sourceDir],
+    outDir: codeOutDir,
+    headerOutDir: headerOutDir,
+    includeDirs: [sourceDir],
+    generateHeaders: true,
+  });
+
+  const result = await pipeline.run();
+  check(result.success, "Pipeline compilation succeeds");
+
+  // Check main.c - should include A/B/C/deep_utils.h
+  const mainCodePath = join(codeOutDir, "A", "B", "C", "main.c");
+  check(existsSync(mainCodePath), "A/B/C/main.c exists");
+
+  if (existsSync(mainCodePath)) {
+    const mainCode = readFileSync(mainCodePath, "utf-8");
+    const includes = extractAngleBracketIncludes(mainCode);
+    console.log("  main.c includes:", includes);
+
+    check(
+      includes.includes("A/B/C/deep_utils.h"),
+      "main.c includes <A/B/C/deep_utils.h> (full nested path)",
+    );
+    check(
+      !includes.some((inc) => inc === "deep_utils.h"),
+      "main.c does NOT include bare <deep_utils.h>",
+    );
+  }
+}
+
+async function runTests() {
+  console.log(
+    "Issue #349: Testing angle-bracket include paths match --header-out structure\n",
+  );
+  console.log("=".repeat(60));
+
+  await testSiblingAngleBracketInclude();
+  await testCrossDirectoryAngleBracketInclude();
+  await testRootLevelAngleBracketInclude();
+  await testAngleBracketIncludeFallback();
+  await testNestedDirectoryAngleBracketInclude();
+
+  // Summary
+  console.log("\n" + "=".repeat(60));
+  console.log(`\nResults: ${passed} passed, ${failed} failed\n`);
+
+  if (failed > 0) {
+    console.log(
+      "TEST FAILED: Bug #349 is present - angle-bracket include paths don't match header-out structure",
+    );
+    process.exit(1);
+  }
+
+  console.log("All checks passed! Bug #349 is fixed.");
+}
+
+runTests().catch((err) => {
+  console.error("Test error:", err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

- Fixes angle-bracket `#include <file.cnx>` directives to include the correct directory prefix when source files are in subdirectories
- When transpiling `src/Display/main.cnx` containing `#include <utils.cnx>`, the generated `main.c` now correctly uses `#include <Display/utils.h>` instead of `#include <utils.h>`
- Adds comprehensive integration tests covering sibling includes, cross-directory includes, root-level files, fallback behavior, and deeply nested directories

## Root Cause

The `transformIncludeDirective` function in `IncludeGenerator.ts` was doing simple string replacement for angle-bracket includes without calculating the correct output path based on the source file location.

## Solution

Apply the same pattern used for Issue #339 (self-includes):
1. Search for the `.cnx` file in the source directory and include directories
2. Calculate the relative path from input directories
3. Use that path for the header include

## Test plan

- [x] New integration test passes: `npx tsx tests/integration/issue-349-angle-include-paths.test.ts`
- [x] Regression test passes: `npx tsx tests/integration/issue-339-include-paths.test.ts`
- [x] Full test suite passes: `npm test` (673/673 tests)
- [x] Static analysis passes: `npm run analyze`
- [x] Verified test catches regression when fix is reverted

🤖 Generated with [Claude Code](https://claude.com/claude-code)