### PR TITLE
fix(codegen): generate int return type for main() in header files

### DIFF
--- a/src/codegen/HeaderGenerator.ts
+++ b/src/codegen/HeaderGenerator.ts
@@ -268,7 +268,9 @@ class HeaderGenerator {
     passByValueParams?: TPassByValueParams,
   ): string | null {
     // Map return type from C-Next to C
-    const returnType = sym.type ? mapType(sym.type) : "void";
+    // Special case: main() always returns int for C/C++ compatibility
+    const mappedType = sym.type ? mapType(sym.type) : "void";
+    const returnType = sym.name === "main" ? "int" : mappedType;
 
     // Issue #269: Get pass-by-value parameter names for this function
     const passByValueSet = passByValueParams?.get(sym.name);


### PR DESCRIPTION
## Summary
- Fix HeaderGenerator to use `int` return type for `main()` function in headers
- Previously, headers declared `uint32_t main(void)` while the C file generated `int main(void)`, causing C compilation errors

## Details
The FunctionGenerator already had special handling to convert `u32 main()` or `i32 main()` to `int main()` for C/C++ compatibility, but the HeaderGenerator was missing this same logic.

Found while testing documentation examples for the learn-cnext-in-y-minutes doc.

## Test plan
- [x] All 674 existing tests pass
- [x] Verified generated header and C file both show `int main(void)` for `u32 main()` functions

🤖 Generated with [Claude Code](https://claude.com/claude-code)