### PR TITLE
Release v0.1.26

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.26] - 2026-01-22
+
+### Added
+
+- Test coverage for named typedef struct array member pattern (Issue #347)
+
+### Fixed
+
+- Generate int return type for main() in header files
+- Angle-bracket CNX includes with `--header-out` now get correct directory prefix (Issue #349)
+- CLI now shows helpful error for unrecognized flags like `-I`
+
+### Documentation
+
+- Removed status markers from learn-cnext-in-y-minutes.md
+- Fixed enum and nested struct syntax examples in learn-cnext doc
+
 ## [0.1.25] - 2026-01-22
 
 ### Added
@@ -281,7 +298,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - 38 legacy ESLint errors (non-blocking, tracked for future cleanup)
 
-[Unreleased]: https://github.com/jlaustill/c-next/compare/v0.1.25...HEAD
+[Unreleased]: https://github.com/jlaustill/c-next/compare/v0.1.26...HEAD
+[0.1.26]: https://github.com/jlaustill/c-next/compare/v0.1.25...v0.1.26
 [0.1.25]: https://github.com/jlaustill/c-next/compare/v0.1.24...v0.1.25
 [0.1.24]: https://github.com/jlaustill/c-next/compare/v0.1.23...v0.1.24
 [0.1.23]: https://github.com/jlaustill/c-next/compare/v0.1.22...v0.1.23

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "c-next",
-  "version": "0.1.25",
+  "version": "0.1.26",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "c-next",
-      "version": "0.1.25",
+      "version": "0.1.26",
       "license": "MIT",
       "dependencies": {
         "antlr4ng": "^3.0.16",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "c-next",
-  "version": "0.1.25",
+  "version": "0.1.26",
   "description": "A safer C for embedded systems development. Transpiles to clean, readable C.",
   "main": "src/index.ts",
   "bin": {

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "c-next",
   "displayName": "C-Next",
   "description": "Syntax highlighting and live C preview for C-Next, a safer C for embedded systems",
-  "version": "0.1.25",
+  "version": "0.1.26",
   "publisher": "jlaustill",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
## Summary

Patch release v0.1.26 with bug fixes and documentation improvements.

### Fixed
- Generate int return type for main() in header files
- Angle-bracket CNX includes with `--header-out` now get correct directory prefix (Issue #349)
- CLI now shows helpful error for unrecognized flags like `-I`

### Added
- Test coverage for named typedef struct array member pattern (Issue #347)

### Documentation
- Removed status markers from learn-cnext-in-y-minutes.md
- Fixed enum and nested struct syntax examples in learn-cnext doc

## Test plan
- [x] `npm test` — 673/673 tests pass
- [x] `npm run typecheck` — no TypeScript errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)