### PR TITLE
Release v0.1.27

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.27] - 2026-01-22
+
+### Added
+
+- `StructFieldAnalyzer` (E0355) rejects struct fields named `length` to prevent shadowing built-in `.length` property
+- `SymbolUtils.ts` shared utilities for C/C++ symbol collectors (reduces code duplication)
+- Warnings when C/C++ headers have fields that conflict with C-Next reserved property names
+
+### Fixed
+
+- Array member via pointer generates invalid `static_cast` in C++ mode (Issue #355)
+- `CSymbolCollector.extractDeclaratorName()` now correctly handles recursive `directDeclarator` nodes for array fields
+
 ## [0.1.26] - 2026-01-22
 
 ### Added
@@ -298,7 +311,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - 38 legacy ESLint errors (non-blocking, tracked for future cleanup)
 
-[Unreleased]: https://github.com/jlaustill/c-next/compare/v0.1.26...HEAD
+[Unreleased]: https://github.com/jlaustill/c-next/compare/v0.1.27...HEAD
+[0.1.27]: https://github.com/jlaustill/c-next/compare/v0.1.26...v0.1.27
 [0.1.26]: https://github.com/jlaustill/c-next/compare/v0.1.25...v0.1.26
 [0.1.25]: https://github.com/jlaustill/c-next/compare/v0.1.24...v0.1.25
 [0.1.24]: https://github.com/jlaustill/c-next/compare/v0.1.23...v0.1.24

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "c-next",
-  "version": "0.1.26",
+  "version": "0.1.27",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "c-next",
-      "version": "0.1.26",
+      "version": "0.1.27",
       "license": "MIT",
       "dependencies": {
         "antlr4ng": "^3.0.16",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "c-next",
-  "version": "0.1.26",
+  "version": "0.1.27",
   "description": "A safer C for embedded systems development. Transpiles to clean, readable C.",
   "main": "src/index.ts",
   "bin": {

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "c-next",
   "displayName": "C-Next",
   "description": "Syntax highlighting and live C preview for C-Next, a safer C for embedded systems",
-  "version": "0.1.26",
+  "version": "0.1.27",
   "publisher": "jlaustill",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
## Summary

Patch release v0.1.27 with the fix for Issue #355.

### Changes in this release

**Added**
- `StructFieldAnalyzer` (E0355) rejects struct fields named `length` to prevent shadowing built-in `.length` property
- `SymbolUtils.ts` shared utilities for C/C++ symbol collectors (reduces code duplication)
- Warnings when C/C++ headers have fields that conflict with C-Next reserved property names

**Fixed**
- Array member via pointer generates invalid `static_cast` in C++ mode (Issue #355)
- `CSymbolCollector.extractDeclaratorName()` now correctly handles recursive `directDeclarator` nodes for array fields

## Pre-release checklist

- [x] CHANGELOG.md updated with new version entry
- [x] Version bumped in `package.json` (0.1.26 → 0.1.27)
- [x] Version bumped in `vscode-extension/package.json` (0.1.26 → 0.1.27)
- [x] `package-lock.json` updated
- [x] All 675 tests pass
- [x] TypeScript typecheck passes
- [x] Analyze passes (no security issues)

## After merge

Tag and publish:
```bash
git checkout main && git pull
git tag v0.1.27
git push origin v0.1.27
```

🤖 Generated with [Claude Code](https://claude.ai/code)