### PR TITLE
Release v0.1.28

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.28] - 2026-01-22
+
+### Fixed
+
+- PlatformIO library headers not discovered causing incorrect array member code generation (Issue #355, PR #358)
+- FileDiscovery now includes `.pio/libdeps/` while excluding only `.pio/build/` artifacts
+- IncludeDiscovery automatically searches `.pio/libdeps/<env>/<library>/` for headers when `platformio.ini` exists
+
 ## [0.1.27] - 2026-01-22
 
 ### Added
@@ -311,7 +319,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - 38 legacy ESLint errors (non-blocking, tracked for future cleanup)
 
-[Unreleased]: https://github.com/jlaustill/c-next/compare/v0.1.27...HEAD
+[Unreleased]: https://github.com/jlaustill/c-next/compare/v0.1.28...HEAD
+[0.1.28]: https://github.com/jlaustill/c-next/compare/v0.1.27...v0.1.28
 [0.1.27]: https://github.com/jlaustill/c-next/compare/v0.1.26...v0.1.27
 [0.1.26]: https://github.com/jlaustill/c-next/compare/v0.1.25...v0.1.26
 [0.1.25]: https://github.com/jlaustill/c-next/compare/v0.1.24...v0.1.25

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "c-next",
-  "version": "0.1.27",
+  "version": "0.1.28",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "c-next",
-      "version": "0.1.27",
+      "version": "0.1.28",
       "license": "MIT",
       "dependencies": {
         "antlr4ng": "^3.0.16",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "c-next",
-  "version": "0.1.27",
+  "version": "0.1.28",
   "description": "A safer C for embedded systems development. Transpiles to clean, readable C.",
   "main": "src/index.ts",
   "bin": {

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "c-next",
   "displayName": "C-Next",
   "description": "Syntax highlighting and live C preview for C-Next, a safer C for embedded systems",
-  "version": "0.1.27",
+  "version": "0.1.28",
   "publisher": "jlaustill",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
## Summary

Release preparation for v0.1.28.

### Changes since v0.1.27

- **Fixed**: PlatformIO library headers not discovered causing incorrect array member code generation (Issue #355, PR #358)
- **Fixed**: FileDiscovery now includes `.pio/libdeps/` while excluding only `.pio/build/` artifacts
- **Fixed**: IncludeDiscovery automatically searches `.pio/libdeps/<env>/<library>/` for headers when `platformio.ini` exists

### Release checklist

- [x] CHANGELOG.md updated with v0.1.28 entry
- [x] Version bumped in `package.json` (0.1.28)
- [x] Version bumped in `vscode-extension/package.json` (0.1.28)
- [x] `package-lock.json` updated
- [x] All 676 tests pass
- [x] TypeScript typecheck passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)