### PR TITLE
Release v0.1.29

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.29] - 2026-01-23
+
+### Fixed
+
+- Struct param array member assignment now uses `->` instead of `.` for correct pointer access (PR #363)
+
+### Documentation
+
+- Added ADR-054 for array index overflow semantics with bounded string extension (PR #361, #362)
+- Improved ADR accuracy based on Reddit feedback (PR #360)
+
 ## [0.1.28] - 2026-01-22
 
 ### Fixed
@@ -319,7 +330,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - 38 legacy ESLint errors (non-blocking, tracked for future cleanup)
 
-[Unreleased]: https://github.com/jlaustill/c-next/compare/v0.1.28...HEAD
+[Unreleased]: https://github.com/jlaustill/c-next/compare/v0.1.29...HEAD
+[0.1.29]: https://github.com/jlaustill/c-next/compare/v0.1.28...v0.1.29
 [0.1.28]: https://github.com/jlaustill/c-next/compare/v0.1.27...v0.1.28
 [0.1.27]: https://github.com/jlaustill/c-next/compare/v0.1.26...v0.1.27
 [0.1.26]: https://github.com/jlaustill/c-next/compare/v0.1.25...v0.1.26

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "c-next",
-  "version": "0.1.28",
+  "version": "0.1.29",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "c-next",
-      "version": "0.1.28",
+      "version": "0.1.29",
       "license": "MIT",
       "dependencies": {
         "antlr4ng": "^3.0.16",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "c-next",
-  "version": "0.1.28",
+  "version": "0.1.29",
   "description": "A safer C for embedded systems development. Transpiles to clean, readable C.",
   "main": "src/index.ts",
   "bin": {

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "c-next",
   "displayName": "C-Next",
   "description": "Syntax highlighting and live C preview for C-Next, a safer C for embedded systems",
-  "version": "0.1.28",
+  "version": "0.1.29",
   "publisher": "jlaustill",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
## Summary

- Bump version to 0.1.29
- Fix: Struct param array member assignment uses `->` instead of `.` (PR #363)
- Docs: ADR-054 for array index overflow semantics with bounded string extension
- Docs: Improved ADR accuracy based on Reddit feedback

## Post-Merge Steps

After merging, create and push the tag:
```bash
git checkout main && git pull
git tag v0.1.29
git push origin v0.1.29
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)