### PR TITLE
test: add comprehensive TypeScript unit tests

### DIFF
--- a/src/codegen/CommentExtractor.test.ts
+++ b/src/codegen/CommentExtractor.test.ts
@@ -1,0 +1,623 @@
+/**
+ * Unit tests for CommentExtractor
+ * ADR-043: Comment extraction and MISRA validation
+ */
+import { describe, it, expect, vi } from "vitest";
+import { Token } from "antlr4ng";
+import CommentExtractor from "./CommentExtractor";
+import { CNextLexer } from "../parser/grammar/CNextLexer";
+import ECommentType from "./types/ECommentType";
+
+// Mock token factory
+const createToken = (opts: {
+  type: number;
+  text: string;
+  line: number;
+  column: number;
+  tokenIndex: number;
+  channel?: number;
+}) => ({
+  type: opts.type,
+  text: opts.text,
+  line: opts.line,
+  column: opts.column,
+  tokenIndex: opts.tokenIndex,
+  channel: opts.channel ?? Token.HIDDEN_CHANNEL,
+});
+
+// Mock CommonTokenStream factory - type matches what CommentExtractor expects
+type MockStream = ConstructorParameters<typeof CommentExtractor>[0];
+
+const createMockStream = (
+  tokens: ReturnType<typeof createToken>[],
+): MockStream => {
+  return {
+    fill: vi.fn(),
+    size: tokens.length,
+    get: (i: number) => tokens[i],
+    getHiddenTokensToLeft: vi.fn((idx: number) => {
+      const result = [];
+      for (let i = idx - 1; i >= 0; i--) {
+        if (tokens[i].channel === Token.HIDDEN_CHANNEL) {
+          result.unshift(tokens[i]);
+        } else {
+          break;
+        }
+      }
+      return result.length > 0 ? result : null;
+    }),
+    getHiddenTokensToRight: vi.fn((idx: number) => {
+      const result = [];
+      for (let i = idx + 1; i < tokens.length; i++) {
+        if (tokens[i].channel === Token.HIDDEN_CHANNEL) {
+          result.push(tokens[i]);
+        } else {
+          break;
+        }
+      }
+      return result.length > 0 ? result : null;
+    }),
+  } as unknown as MockStream;
+};
+
+describe("CommentExtractor", () => {
+  // ========================================================================
+  // extractAll
+  // ========================================================================
+
+  describe("extractAll", () => {
+    it("should extract line comments", () => {
+      const tokens = [
+        createToken({
+          type: CNextLexer.LINE_COMMENT,
+          text: "// hello world",
+          line: 1,
+          column: 0,
+          tokenIndex: 0,
+        }),
+      ];
+      const stream = createMockStream(tokens);
+      const extractor = new CommentExtractor(stream);
+
+      const comments = extractor.extractAll();
+
+      expect(comments).toHaveLength(1);
+      expect(comments[0].type).toBe(ECommentType.Line);
+      expect(comments[0].content).toBe(" hello world");
+      expect(comments[0].line).toBe(1);
+    });
+
+    it("should extract block comments", () => {
+      const tokens = [
+        createToken({
+          type: CNextLexer.BLOCK_COMMENT,
+          text: "/* block comment */",
+          line: 1,
+          column: 0,
+          tokenIndex: 0,
+        }),
+      ];
+      const stream = createMockStream(tokens);
+      const extractor = new CommentExtractor(stream);
+
+      const comments = extractor.extractAll();
+
+      expect(comments).toHaveLength(1);
+      expect(comments[0].type).toBe(ECommentType.Block);
+      expect(comments[0].content).toBe(" block comment ");
+    });
+
+    it("should extract doc comments", () => {
+      const tokens = [
+        createToken({
+          type: CNextLexer.DOC_COMMENT,
+          text: "/// Documentation",
+          line: 1,
+          column: 0,
+          tokenIndex: 0,
+        }),
+      ];
+      const stream = createMockStream(tokens);
+      const extractor = new CommentExtractor(stream);
+
+      const comments = extractor.extractAll();
+
+      expect(comments).toHaveLength(1);
+      expect(comments[0].type).toBe(ECommentType.Doc);
+      expect(comments[0].content).toBe("Documentation");
+    });
+
+    it("should cache results on subsequent calls", () => {
+      const tokens = [
+        createToken({
+          type: CNextLexer.LINE_COMMENT,
+          text: "// test",
+          line: 1,
+          column: 0,
+          tokenIndex: 0,
+        }),
+      ];
+      const stream = createMockStream(tokens);
+      const extractor = new CommentExtractor(stream);
+
+      const first = extractor.extractAll();
+      const second = extractor.extractAll();
+
+      expect(first).toBe(second); // Same reference
+      expect(stream.fill).toHaveBeenCalledTimes(1);
+    });
+
+    it("should skip non-comment tokens", () => {
+      const tokens = [
+        createToken({
+          type: CNextLexer.WS, // Whitespace
+          text: "   ",
+          line: 1,
+          column: 0,
+          tokenIndex: 0,
+        }),
+        createToken({
+          type: CNextLexer.LINE_COMMENT,
+          text: "// actual comment",
+          line: 1,
+          column: 3,
+          tokenIndex: 1,
+        }),
+      ];
+      const stream = createMockStream(tokens);
+      const extractor = new CommentExtractor(stream);
+
+      const comments = extractor.extractAll();
+
+      expect(comments).toHaveLength(1);
+      expect(comments[0].content).toBe(" actual comment");
+    });
+
+    it("should skip tokens not on hidden channel", () => {
+      const tokens = [
+        createToken({
+          type: CNextLexer.LINE_COMMENT,
+          text: "// visible",
+          line: 1,
+          column: 0,
+          tokenIndex: 0,
+          channel: Token.DEFAULT_CHANNEL, // Not hidden
+        }),
+      ];
+      const stream = createMockStream(tokens);
+      const extractor = new CommentExtractor(stream);
+
+      const comments = extractor.extractAll();
+
+      expect(comments).toHaveLength(0);
+    });
+  });
+
+  // ========================================================================
+  // getCommentsBefore
+  // ========================================================================
+
+  describe("getCommentsBefore", () => {
+    it("should get comments before a token", () => {
+      const tokens = [
+        createToken({
+          type: CNextLexer.DOC_COMMENT,
+          text: "/// Function docs",
+          line: 1,
+          column: 0,
+          tokenIndex: 0,
+        }),
+        createToken({
+          type: CNextLexer.IDENTIFIER,
+          text: "function",
+          line: 2,
+          column: 0,
+          tokenIndex: 1,
+          channel: Token.DEFAULT_CHANNEL,
+        }),
+      ];
+      const stream = createMockStream(tokens);
+      const extractor = new CommentExtractor(stream);
+
+      const comments = extractor.getCommentsBefore(1);
+
+      expect(comments).toHaveLength(1);
+      expect(comments[0].content).toBe("Function docs");
+    });
+
+    it("should return empty array when no comments before", () => {
+      const tokens = [
+        createToken({
+          type: CNextLexer.IDENTIFIER,
+          text: "x",
+          line: 1,
+          column: 0,
+          tokenIndex: 0,
+          channel: Token.DEFAULT_CHANNEL,
+        }),
+      ];
+      const stream = createMockStream(tokens);
+      (stream as { getHiddenTokensToLeft: unknown }).getHiddenTokensToLeft =
+        vi.fn(() => null);
+      const extractor = new CommentExtractor(stream);
+
+      const comments = extractor.getCommentsBefore(0);
+
+      expect(comments).toHaveLength(0);
+    });
+  });
+
+  // ========================================================================
+  // getCommentsAfter (inline comments)
+  // ========================================================================
+
+  describe("getCommentsAfter", () => {
+    it("should get inline comments on same line", () => {
+      const tokens = [
+        createToken({
+          type: CNextLexer.IDENTIFIER,
+          text: "x",
+          line: 1,
+          column: 0,
+          tokenIndex: 0,
+          channel: Token.DEFAULT_CHANNEL,
+        }),
+        createToken({
+          type: CNextLexer.LINE_COMMENT,
+          text: "// inline",
+          line: 1,
+          column: 5,
+          tokenIndex: 1,
+        }),
+      ];
+      const stream = createMockStream(tokens);
+      const extractor = new CommentExtractor(stream);
+
+      const comments = extractor.getCommentsAfter(0);
+
+      expect(comments).toHaveLength(1);
+      expect(comments[0].content).toBe(" inline");
+    });
+
+    it("should not include comments on different lines", () => {
+      const tokens = [
+        createToken({
+          type: CNextLexer.IDENTIFIER,
+          text: "x",
+          line: 1,
+          column: 0,
+          tokenIndex: 0,
+          channel: Token.DEFAULT_CHANNEL,
+        }),
+        createToken({
+          type: CNextLexer.LINE_COMMENT,
+          text: "// next line",
+          line: 2, // Different line
+          column: 0,
+          tokenIndex: 1,
+        }),
+      ];
+      const stream = createMockStream(tokens);
+      const extractor = new CommentExtractor(stream);
+
+      const comments = extractor.getCommentsAfter(0);
+
+      expect(comments).toHaveLength(0);
+    });
+
+    it("should return empty array when no comments after", () => {
+      const tokens = [
+        createToken({
+          type: CNextLexer.IDENTIFIER,
+          text: "x",
+          line: 1,
+          column: 0,
+          tokenIndex: 0,
+          channel: Token.DEFAULT_CHANNEL,
+        }),
+      ];
+      const stream = createMockStream(tokens);
+      (stream as { getHiddenTokensToRight: unknown }).getHiddenTokensToRight =
+        vi.fn(() => null);
+      const extractor = new CommentExtractor(stream);
+
+      const comments = extractor.getCommentsAfter(0);
+
+      expect(comments).toHaveLength(0);
+    });
+  });
+
+  // ========================================================================
+  // validate - MISRA C:2012 Rules 3.1 and 3.2
+  // ========================================================================
+
+  describe("validate", () => {
+    describe("MISRA Rule 3.1 - nested comment markers", () => {
+      it("should detect nested /* in block comment", () => {
+        const tokens = [
+          createToken({
+            type: CNextLexer.BLOCK_COMMENT,
+            text: "/* outer /* nested */",
+            line: 1,
+            column: 0,
+            tokenIndex: 0,
+          }),
+        ];
+        const stream = createMockStream(tokens);
+        const extractor = new CommentExtractor(stream);
+
+        const errors = extractor.validate();
+
+        expect(errors).toHaveLength(1);
+        expect(errors[0].rule).toBe("3.1");
+        expect(errors[0].message).toContain("/*");
+      });
+
+      it("should detect nested // in block comment", () => {
+        const tokens = [
+          createToken({
+            type: CNextLexer.BLOCK_COMMENT,
+            text: "/* test // nested */",
+            line: 1,
+            column: 0,
+            tokenIndex: 0,
+          }),
+        ];
+        const stream = createMockStream(tokens);
+        const extractor = new CommentExtractor(stream);
+
+        const errors = extractor.validate();
+
+        expect(errors).toHaveLength(1);
+        expect(errors[0].rule).toBe("3.1");
+        expect(errors[0].message).toContain("//");
+      });
+
+      it("should allow :// (URI pattern) in comments", () => {
+        const tokens = [
+          createToken({
+            type: CNextLexer.LINE_COMMENT,
+            text: "// See https://example.com",
+            line: 1,
+            column: 0,
+            tokenIndex: 0,
+          }),
+        ];
+        const stream = createMockStream(tokens);
+        const extractor = new CommentExtractor(stream);
+
+        const errors = extractor.validate();
+
+        expect(errors).toHaveLength(0);
+      });
+
+      it("should detect nested /* in line comment", () => {
+        const tokens = [
+          createToken({
+            type: CNextLexer.LINE_COMMENT,
+            text: "// TODO /* fix this */",
+            line: 1,
+            column: 0,
+            tokenIndex: 0,
+          }),
+        ];
+        const stream = createMockStream(tokens);
+        const extractor = new CommentExtractor(stream);
+
+        const errors = extractor.validate();
+
+        expect(errors).toHaveLength(1);
+        expect(errors[0].rule).toBe("3.1");
+      });
+
+      it("should detect nested /* in doc comment", () => {
+        const tokens = [
+          createToken({
+            type: CNextLexer.DOC_COMMENT,
+            text: "/// /* documentation */",
+            line: 1,
+            column: 0,
+            tokenIndex: 0,
+          }),
+        ];
+        const stream = createMockStream(tokens);
+        const extractor = new CommentExtractor(stream);
+
+        const errors = extractor.validate();
+
+        expect(errors).toHaveLength(1);
+        expect(errors[0].rule).toBe("3.1");
+      });
+    });
+
+    describe("MISRA Rule 3.2 - line-splice in comments", () => {
+      it("should detect line ending with backslash in line comment", () => {
+        const tokens = [
+          createToken({
+            type: CNextLexer.LINE_COMMENT,
+            text: "// continued \\",
+            line: 1,
+            column: 0,
+            tokenIndex: 0,
+          }),
+        ];
+        const stream = createMockStream(tokens);
+        const extractor = new CommentExtractor(stream);
+
+        const errors = extractor.validate();
+
+        expect(errors).toHaveLength(1);
+        expect(errors[0].rule).toBe("3.2");
+        expect(errors[0].message).toContain("line-splice");
+      });
+
+      it("should detect line ending with backslash in doc comment", () => {
+        const tokens = [
+          createToken({
+            type: CNextLexer.DOC_COMMENT,
+            text: "/// docs \\",
+            line: 1,
+            column: 0,
+            tokenIndex: 0,
+          }),
+        ];
+        const stream = createMockStream(tokens);
+        const extractor = new CommentExtractor(stream);
+
+        const errors = extractor.validate();
+
+        expect(errors).toHaveLength(1);
+        expect(errors[0].rule).toBe("3.2");
+      });
+
+      it("should not flag block comments for Rule 3.2", () => {
+        const tokens = [
+          createToken({
+            type: CNextLexer.BLOCK_COMMENT,
+            text: "/* ends with backslash \\ */",
+            line: 1,
+            column: 0,
+            tokenIndex: 0,
+          }),
+        ];
+        const stream = createMockStream(tokens);
+        const extractor = new CommentExtractor(stream);
+
+        const errors = extractor.validate();
+
+        // Block comments can have backslash, Rule 3.2 only applies to line comments
+        expect(errors.filter((e) => e.rule === "3.2")).toHaveLength(0);
+      });
+
+      it("should allow backslash in middle of line comment", () => {
+        const tokens = [
+          createToken({
+            type: CNextLexer.LINE_COMMENT,
+            text: "// path\\to\\file is fine",
+            line: 1,
+            column: 0,
+            tokenIndex: 0,
+          }),
+        ];
+        const stream = createMockStream(tokens);
+        const extractor = new CommentExtractor(stream);
+
+        const errors = extractor.validate();
+
+        expect(errors).toHaveLength(0);
+      });
+    });
+
+    describe("multiple errors", () => {
+      it("should report multiple violations", () => {
+        const tokens = [
+          createToken({
+            type: CNextLexer.LINE_COMMENT,
+            text: "// /* nested */ \\",
+            line: 1,
+            column: 0,
+            tokenIndex: 0,
+          }),
+        ];
+        const stream = createMockStream(tokens);
+        const extractor = new CommentExtractor(stream);
+
+        const errors = extractor.validate();
+
+        expect(errors).toHaveLength(2);
+        expect(errors.map((e) => e.rule).sort()).toEqual(["3.1", "3.2"]);
+      });
+    });
+  });
+
+  // ========================================================================
+  // getErrors
+  // ========================================================================
+
+  describe("getErrors", () => {
+    it("should return empty array before validation", () => {
+      const stream = createMockStream([]);
+      const extractor = new CommentExtractor(stream);
+
+      expect(extractor.getErrors()).toEqual([]);
+    });
+
+    it("should return errors after validation", () => {
+      const tokens = [
+        createToken({
+          type: CNextLexer.LINE_COMMENT,
+          text: "// bad \\",
+          line: 1,
+          column: 0,
+          tokenIndex: 0,
+        }),
+      ];
+      const stream = createMockStream(tokens);
+      const extractor = new CommentExtractor(stream);
+
+      extractor.validate();
+
+      expect(extractor.getErrors()).toHaveLength(1);
+    });
+  });
+
+  // ========================================================================
+  // Edge cases
+  // ========================================================================
+
+  describe("edge cases", () => {
+    it("should handle empty token text", () => {
+      const tokens = [
+        {
+          type: CNextLexer.LINE_COMMENT,
+          text: null,
+          line: 1,
+          column: 0,
+          tokenIndex: 0,
+          channel: Token.HIDDEN_CHANNEL,
+        } as unknown as ReturnType<typeof createToken>,
+      ];
+      const stream = createMockStream(tokens);
+      const extractor = new CommentExtractor(stream);
+
+      const comments = extractor.extractAll();
+
+      expect(comments).toHaveLength(0);
+    });
+
+    it("should handle multiple comments", () => {
+      const tokens = [
+        createToken({
+          type: CNextLexer.DOC_COMMENT,
+          text: "/// Line 1",
+          line: 1,
+          column: 0,
+          tokenIndex: 0,
+        }),
+        createToken({
+          type: CNextLexer.DOC_COMMENT,
+          text: "/// Line 2",
+          line: 2,
+          column: 0,
+          tokenIndex: 1,
+        }),
+        createToken({
+          type: CNextLexer.LINE_COMMENT,
+          text: "// Regular",
+          line: 3,
+          column: 0,
+          tokenIndex: 2,
+        }),
+      ];
+      const stream = createMockStream(tokens);
+      const extractor = new CommentExtractor(stream);
+
+      const comments = extractor.extractAll();
+
+      expect(comments).toHaveLength(3);
+      expect(comments[0].type).toBe(ECommentType.Doc);
+      expect(comments[1].type).toBe(ECommentType.Doc);
+      expect(comments[2].type).toBe(ECommentType.Line);
+    });
+  });
+});

--- a/src/codegen/CommentFormatter.test.ts
+++ b/src/codegen/CommentFormatter.test.ts
@@ -1,0 +1,230 @@
+/**
+ * Unit tests for CommentFormatter
+ * ADR-043: Comment formatting for C output
+ */
+import { describe, it, expect, beforeEach } from "vitest";
+import CommentFormatter from "./CommentFormatter";
+import ECommentType from "./types/ECommentType";
+import IComment from "./types/IComment";
+
+describe("CommentFormatter", () => {
+  let formatter: CommentFormatter;
+
+  beforeEach(() => {
+    formatter = new CommentFormatter();
+  });
+
+  // Helper to create comment objects
+  const makeComment = (
+    type: ECommentType,
+    content: string,
+    line = 1,
+  ): IComment => ({
+    type,
+    raw:
+      type === ECommentType.Doc
+        ? `///${content}`
+        : type === ECommentType.Line
+          ? `//${content}`
+          : `/*${content}*/`,
+    content,
+    line,
+    column: 0,
+    tokenIndex: 0,
+  });
+
+  // ========================================================================
+  // format() - Single comment formatting
+  // ========================================================================
+
+  describe("format", () => {
+    describe("line comments", () => {
+      it("should format line comment without indent", () => {
+        const comment = makeComment(ECommentType.Line, " hello world");
+        expect(formatter.format(comment)).toBe("// hello world");
+      });
+
+      it("should format line comment with indent", () => {
+        const comment = makeComment(ECommentType.Line, " hello");
+        expect(formatter.format(comment, "    ")).toBe("    // hello");
+      });
+    });
+
+    describe("block comments", () => {
+      it("should format single-line block comment", () => {
+        const comment = makeComment(ECommentType.Block, " block ");
+        expect(formatter.format(comment)).toBe("/* block */");
+      });
+
+      it("should format single-line block comment with indent", () => {
+        const comment = makeComment(ECommentType.Block, " block ");
+        expect(formatter.format(comment, "  ")).toBe("  /* block */");
+      });
+
+      it("should format multi-line block comment", () => {
+        const comment = makeComment(ECommentType.Block, " line1\n * line2\n ");
+        const result = formatter.format(comment);
+        expect(result).toContain("/*");
+        expect(result).toContain("*/");
+        expect(result).toContain("line1");
+        expect(result).toContain("line2");
+      });
+
+      it("should preserve structure in multi-line block comment", () => {
+        const comment = makeComment(
+          ECommentType.Block,
+          "\n * Description\n * @param x\n ",
+        );
+        const result = formatter.format(comment, "    ");
+        expect(result).toContain("    /*");
+      });
+    });
+
+    describe("doc comments", () => {
+      it("should format doc comment as Doxygen", () => {
+        const comment = makeComment(ECommentType.Doc, " Brief description");
+        expect(formatter.format(comment)).toBe("/** Brief description */");
+      });
+
+      it("should format empty doc comment", () => {
+        const comment = makeComment(ECommentType.Doc, "   ");
+        expect(formatter.format(comment)).toBe("/** */");
+      });
+
+      it("should format doc comment with indent", () => {
+        const comment = makeComment(ECommentType.Doc, " Description");
+        expect(formatter.format(comment, "  ")).toBe("  /** Description */");
+      });
+    });
+  });
+
+  // ========================================================================
+  // formatDocCommentGroup() - Multiple doc comments as Doxygen block
+  // ========================================================================
+
+  describe("formatDocCommentGroup", () => {
+    it("should return empty string for empty array", () => {
+      expect(formatter.formatDocCommentGroup([])).toBe("");
+    });
+
+    it("should format single doc comment same as format()", () => {
+      const comments = [makeComment(ECommentType.Doc, " Single")];
+      expect(formatter.formatDocCommentGroup(comments)).toBe("/** Single */");
+    });
+
+    it("should format multiple doc comments as single Doxygen block", () => {
+      const comments = [
+        makeComment(ECommentType.Doc, " First line"),
+        makeComment(ECommentType.Doc, " Second line"),
+        makeComment(ECommentType.Doc, " Third line"),
+      ];
+      const result = formatter.formatDocCommentGroup(comments);
+      expect(result).toBe(
+        "/**\n * First line\n * Second line\n * Third line\n */",
+      );
+    });
+
+    it("should handle empty content in group", () => {
+      const comments = [
+        makeComment(ECommentType.Doc, " Description"),
+        makeComment(ECommentType.Doc, ""),
+        makeComment(ECommentType.Doc, " @param x"),
+      ];
+      const result = formatter.formatDocCommentGroup(comments);
+      expect(result).toContain(" * Description");
+      expect(result).toContain(" *\n"); // Empty line preserved
+      expect(result).toContain(" * @param x");
+    });
+
+    it("should apply indent to all lines", () => {
+      const comments = [
+        makeComment(ECommentType.Doc, " Line 1"),
+        makeComment(ECommentType.Doc, " Line 2"),
+      ];
+      const result = formatter.formatDocCommentGroup(comments, "    ");
+      expect(result).toBe("    /**\n     * Line 1\n     * Line 2\n     */");
+    });
+  });
+
+  // ========================================================================
+  // formatLeadingComments() - Comments before code
+  // ========================================================================
+
+  describe("formatLeadingComments", () => {
+    it("should return empty array for empty input", () => {
+      expect(formatter.formatLeadingComments([])).toEqual([]);
+    });
+
+    it("should format single line comment", () => {
+      const comments = [makeComment(ECommentType.Line, " TODO")];
+      expect(formatter.formatLeadingComments(comments)).toEqual(["// TODO"]);
+    });
+
+    it("should format single block comment", () => {
+      const comments = [makeComment(ECommentType.Block, " Note ")];
+      expect(formatter.formatLeadingComments(comments)).toEqual(["/* Note */"]);
+    });
+
+    it("should group consecutive doc comments", () => {
+      const comments = [
+        makeComment(ECommentType.Doc, " First"),
+        makeComment(ECommentType.Doc, " Second"),
+      ];
+      const result = formatter.formatLeadingComments(comments);
+      expect(result.length).toBe(1);
+      expect(result[0]).toContain("/**");
+      expect(result[0]).toContain("First");
+      expect(result[0]).toContain("Second");
+    });
+
+    it("should separate doc groups with other comment types", () => {
+      const comments = [
+        makeComment(ECommentType.Doc, " Doc 1"),
+        makeComment(ECommentType.Line, " separator"),
+        makeComment(ECommentType.Doc, " Doc 2"),
+      ];
+      const result = formatter.formatLeadingComments(comments);
+      expect(result.length).toBe(3);
+      expect(result[0]).toContain("Doc 1"); // First doc
+      expect(result[1]).toBe("// separator"); // Line comment
+      expect(result[2]).toContain("Doc 2"); // Second doc (separate)
+    });
+
+    it("should apply indent to all comments", () => {
+      const comments = [
+        makeComment(ECommentType.Line, " comment"),
+        makeComment(ECommentType.Doc, " doc"),
+      ];
+      const result = formatter.formatLeadingComments(comments, "  ");
+      expect(result[0]).toBe("  // comment");
+      expect(result[1]).toBe("  /** doc */");
+    });
+  });
+
+  // ========================================================================
+  // formatTrailingComment() - Inline comments after code
+  // ========================================================================
+
+  describe("formatTrailingComment", () => {
+    it("should format line comment with leading spaces", () => {
+      const comment = makeComment(ECommentType.Line, " inline note");
+      expect(formatter.formatTrailingComment(comment)).toBe("  // inline note");
+    });
+
+    it("should format doc comment as line comment style", () => {
+      const comment = makeComment(ECommentType.Doc, " documented");
+      expect(formatter.formatTrailingComment(comment)).toBe("  // documented");
+    });
+
+    it("should format single-line block comment", () => {
+      const comment = makeComment(ECommentType.Block, " block ");
+      expect(formatter.formatTrailingComment(comment)).toBe("  /* block */");
+    });
+
+    it("should format multi-line block comment (edge case)", () => {
+      const comment = makeComment(ECommentType.Block, " line1\nline2 ");
+      const result = formatter.formatTrailingComment(comment);
+      expect(result).toBe("  /* line1\nline2 */");
+    });
+  });
+});

--- a/src/codegen/TypeResolver.test.ts
+++ b/src/codegen/TypeResolver.test.ts
@@ -1,0 +1,941 @@
+/**
+ * Unit tests for TypeResolver
+ * Tests type classification, conversion validation, and literal validation
+ */
+import { describe, it, expect, beforeEach } from "vitest";
+import TypeResolver from "./TypeResolver";
+import SymbolTable from "../symbols/SymbolTable";
+import ITypeResolverDeps from "./types/ITypeResolverDeps";
+import TTypeInfo from "./types/TTypeInfo";
+
+describe("TypeResolver", () => {
+  let resolver: TypeResolver;
+  let symbolTable: SymbolTable;
+  let typeRegistry: Map<string, TTypeInfo>;
+
+  beforeEach(() => {
+    symbolTable = new SymbolTable();
+    typeRegistry = new Map();
+
+    const deps: ITypeResolverDeps = {
+      symbols: null,
+      symbolTable,
+      typeRegistry,
+      resolveIdentifier: (name: string) => name,
+    };
+
+    resolver = new TypeResolver(deps);
+  });
+
+  // ========================================================================
+  // Type Classification Methods
+  // ========================================================================
+
+  describe("isIntegerType", () => {
+    it("should return true for unsigned integer types", () => {
+      expect(resolver.isIntegerType("u8")).toBe(true);
+      expect(resolver.isIntegerType("u16")).toBe(true);
+      expect(resolver.isIntegerType("u32")).toBe(true);
+      expect(resolver.isIntegerType("u64")).toBe(true);
+    });
+
+    it("should return true for signed integer types", () => {
+      expect(resolver.isIntegerType("i8")).toBe(true);
+      expect(resolver.isIntegerType("i16")).toBe(true);
+      expect(resolver.isIntegerType("i32")).toBe(true);
+      expect(resolver.isIntegerType("i64")).toBe(true);
+    });
+
+    it("should return false for non-integer types", () => {
+      expect(resolver.isIntegerType("f32")).toBe(false);
+      expect(resolver.isIntegerType("f64")).toBe(false);
+      expect(resolver.isIntegerType("bool")).toBe(false);
+      expect(resolver.isIntegerType("void")).toBe(false);
+      expect(resolver.isIntegerType("MyStruct")).toBe(false);
+    });
+  });
+
+  describe("isFloatType", () => {
+    it("should return true for float types", () => {
+      expect(resolver.isFloatType("f32")).toBe(true);
+      expect(resolver.isFloatType("f64")).toBe(true);
+    });
+
+    it("should return false for non-float types", () => {
+      expect(resolver.isFloatType("u32")).toBe(false);
+      expect(resolver.isFloatType("i32")).toBe(false);
+      expect(resolver.isFloatType("bool")).toBe(false);
+    });
+  });
+
+  describe("isSignedType", () => {
+    it("should return true for signed integer types", () => {
+      expect(resolver.isSignedType("i8")).toBe(true);
+      expect(resolver.isSignedType("i16")).toBe(true);
+      expect(resolver.isSignedType("i32")).toBe(true);
+      expect(resolver.isSignedType("i64")).toBe(true);
+    });
+
+    it("should return false for unsigned types", () => {
+      expect(resolver.isSignedType("u8")).toBe(false);
+      expect(resolver.isSignedType("u16")).toBe(false);
+      expect(resolver.isSignedType("u32")).toBe(false);
+      expect(resolver.isSignedType("u64")).toBe(false);
+    });
+
+    it("should return false for non-integer types", () => {
+      expect(resolver.isSignedType("f32")).toBe(false);
+      expect(resolver.isSignedType("bool")).toBe(false);
+    });
+  });
+
+  describe("isUnsignedType", () => {
+    it("should return true for unsigned integer types", () => {
+      expect(resolver.isUnsignedType("u8")).toBe(true);
+      expect(resolver.isUnsignedType("u16")).toBe(true);
+      expect(resolver.isUnsignedType("u32")).toBe(true);
+      expect(resolver.isUnsignedType("u64")).toBe(true);
+    });
+
+    it("should return false for signed types", () => {
+      expect(resolver.isUnsignedType("i8")).toBe(false);
+      expect(resolver.isUnsignedType("i16")).toBe(false);
+      expect(resolver.isUnsignedType("i32")).toBe(false);
+      expect(resolver.isUnsignedType("i64")).toBe(false);
+    });
+
+    it("should return false for non-integer types", () => {
+      expect(resolver.isUnsignedType("f32")).toBe(false);
+      expect(resolver.isUnsignedType("bool")).toBe(false);
+    });
+  });
+
+  // ========================================================================
+  // Struct Type Detection
+  // ========================================================================
+
+  describe("isStructType", () => {
+    it("should return true for struct with fields in SymbolTable", () => {
+      symbolTable.addStructField("Point", "x", "i32");
+      symbolTable.addStructField("Point", "y", "i32");
+
+      expect(resolver.isStructType("Point")).toBe(true);
+    });
+
+    it("should return false for unknown type", () => {
+      expect(resolver.isStructType("UnknownStruct")).toBe(false);
+    });
+
+    it("should return false for primitive types", () => {
+      expect(resolver.isStructType("u32")).toBe(false);
+      expect(resolver.isStructType("f64")).toBe(false);
+    });
+  });
+
+  // ========================================================================
+  // Type Conversion Validation
+  // ========================================================================
+
+  describe("isNarrowingConversion", () => {
+    it("should return true when target is smaller than source", () => {
+      expect(resolver.isNarrowingConversion("u32", "u16")).toBe(true);
+      expect(resolver.isNarrowingConversion("u32", "u8")).toBe(true);
+      expect(resolver.isNarrowingConversion("u64", "u32")).toBe(true);
+      expect(resolver.isNarrowingConversion("i64", "i8")).toBe(true);
+    });
+
+    it("should return false when target is same size or larger", () => {
+      expect(resolver.isNarrowingConversion("u16", "u32")).toBe(false);
+      expect(resolver.isNarrowingConversion("u32", "u32")).toBe(false);
+      expect(resolver.isNarrowingConversion("u8", "u64")).toBe(false);
+    });
+
+    it("should return false for unknown types", () => {
+      expect(resolver.isNarrowingConversion("unknown", "u32")).toBe(false);
+      expect(resolver.isNarrowingConversion("u32", "unknown")).toBe(false);
+    });
+  });
+
+  describe("isSignConversion", () => {
+    it("should return true for signed to unsigned conversion", () => {
+      expect(resolver.isSignConversion("i32", "u32")).toBe(true);
+      expect(resolver.isSignConversion("i8", "u64")).toBe(true);
+    });
+
+    it("should return true for unsigned to signed conversion", () => {
+      expect(resolver.isSignConversion("u32", "i32")).toBe(true);
+      expect(resolver.isSignConversion("u8", "i64")).toBe(true);
+    });
+
+    it("should return false for same-sign conversion", () => {
+      expect(resolver.isSignConversion("i32", "i64")).toBe(false);
+      expect(resolver.isSignConversion("u32", "u64")).toBe(false);
+    });
+
+    it("should return false for non-integer types", () => {
+      expect(resolver.isSignConversion("f32", "f64")).toBe(false);
+      expect(resolver.isSignConversion("bool", "u8")).toBe(false);
+    });
+  });
+
+  describe("validateTypeConversion", () => {
+    it("should not throw for same type", () => {
+      expect(() => resolver.validateTypeConversion("u32", "u32")).not.toThrow();
+      expect(() => resolver.validateTypeConversion("i64", "i64")).not.toThrow();
+    });
+
+    it("should not throw for widening conversion", () => {
+      expect(() => resolver.validateTypeConversion("u32", "u16")).not.toThrow();
+      expect(() => resolver.validateTypeConversion("u64", "u8")).not.toThrow();
+      expect(() => resolver.validateTypeConversion("i64", "i32")).not.toThrow();
+    });
+
+    it("should throw for narrowing conversion", () => {
+      expect(() => resolver.validateTypeConversion("u8", "u32")).toThrow(
+        /narrowing/,
+      );
+      expect(() => resolver.validateTypeConversion("u16", "u64")).toThrow(
+        /narrowing/,
+      );
+    });
+
+    it("should throw for sign conversion", () => {
+      expect(() => resolver.validateTypeConversion("u32", "i32")).toThrow(
+        /sign change/,
+      );
+      expect(() => resolver.validateTypeConversion("i32", "u32")).toThrow(
+        /sign change/,
+      );
+    });
+
+    it("should not throw when source type is null", () => {
+      expect(() => resolver.validateTypeConversion("u32", null)).not.toThrow();
+    });
+
+    it("should not throw for non-integer types", () => {
+      expect(() => resolver.validateTypeConversion("f32", "f64")).not.toThrow();
+      expect(() => resolver.validateTypeConversion("bool", "u8")).not.toThrow();
+    });
+  });
+
+  // ========================================================================
+  // Literal Validation
+  // ========================================================================
+
+  describe("validateLiteralFitsType", () => {
+    describe("unsigned types", () => {
+      it("should accept valid u8 values", () => {
+        expect(() => resolver.validateLiteralFitsType("0", "u8")).not.toThrow();
+        expect(() =>
+          resolver.validateLiteralFitsType("255", "u8"),
+        ).not.toThrow();
+        expect(() =>
+          resolver.validateLiteralFitsType("0xFF", "u8"),
+        ).not.toThrow();
+      });
+
+      it("should reject out-of-range u8 values", () => {
+        expect(() => resolver.validateLiteralFitsType("256", "u8")).toThrow(
+          /exceeds u8 range/,
+        );
+        expect(() => resolver.validateLiteralFitsType("1000", "u8")).toThrow(
+          /exceeds u8 range/,
+        );
+      });
+
+      it("should reject negative values for unsigned types", () => {
+        expect(() => resolver.validateLiteralFitsType("-1", "u8")).toThrow(
+          /Negative value/,
+        );
+        expect(() => resolver.validateLiteralFitsType("-100", "u32")).toThrow(
+          /Negative value/,
+        );
+      });
+
+      it("should accept valid u16 values", () => {
+        expect(() =>
+          resolver.validateLiteralFitsType("65535", "u16"),
+        ).not.toThrow();
+        expect(() =>
+          resolver.validateLiteralFitsType("0xFFFF", "u16"),
+        ).not.toThrow();
+      });
+
+      it("should reject out-of-range u16 values", () => {
+        expect(() => resolver.validateLiteralFitsType("65536", "u16")).toThrow(
+          /exceeds u16 range/,
+        );
+      });
+
+      it("should accept valid u32 values", () => {
+        expect(() =>
+          resolver.validateLiteralFitsType("4294967295", "u32"),
+        ).not.toThrow();
+        expect(() =>
+          resolver.validateLiteralFitsType("0xFFFFFFFF", "u32"),
+        ).not.toThrow();
+      });
+
+      it("should reject out-of-range u32 values", () => {
+        expect(() =>
+          resolver.validateLiteralFitsType("4294967296", "u32"),
+        ).toThrow(/exceeds u32 range/);
+      });
+    });
+
+    describe("signed types", () => {
+      it("should accept valid i8 values", () => {
+        expect(() =>
+          resolver.validateLiteralFitsType("-128", "i8"),
+        ).not.toThrow();
+        expect(() =>
+          resolver.validateLiteralFitsType("127", "i8"),
+        ).not.toThrow();
+        expect(() => resolver.validateLiteralFitsType("0", "i8")).not.toThrow();
+      });
+
+      it("should reject out-of-range i8 values", () => {
+        expect(() => resolver.validateLiteralFitsType("128", "i8")).toThrow(
+          /exceeds i8 range/,
+        );
+        expect(() => resolver.validateLiteralFitsType("-129", "i8")).toThrow(
+          /exceeds i8 range/,
+        );
+      });
+
+      it("should accept valid i32 values", () => {
+        expect(() =>
+          resolver.validateLiteralFitsType("-2147483648", "i32"),
+        ).not.toThrow();
+        expect(() =>
+          resolver.validateLiteralFitsType("2147483647", "i32"),
+        ).not.toThrow();
+      });
+
+      it("should reject out-of-range i32 values", () => {
+        expect(() =>
+          resolver.validateLiteralFitsType("2147483648", "i32"),
+        ).toThrow(/exceeds i32 range/);
+        expect(() =>
+          resolver.validateLiteralFitsType("-2147483649", "i32"),
+        ).toThrow(/exceeds i32 range/);
+      });
+    });
+
+    describe("hex and binary literals", () => {
+      it("should validate hex literals", () => {
+        expect(() =>
+          resolver.validateLiteralFitsType("0xFF", "u8"),
+        ).not.toThrow();
+        expect(() => resolver.validateLiteralFitsType("0x100", "u8")).toThrow(
+          /exceeds u8 range/,
+        );
+      });
+
+      it("should validate binary literals", () => {
+        expect(() =>
+          resolver.validateLiteralFitsType("0b11111111", "u8"),
+        ).not.toThrow();
+        expect(() =>
+          resolver.validateLiteralFitsType("0b100000000", "u8"),
+        ).toThrow(/exceeds u8 range/);
+      });
+    });
+
+    describe("edge cases", () => {
+      it("should skip validation for unknown types", () => {
+        expect(() =>
+          resolver.validateLiteralFitsType("999999", "unknown"),
+        ).not.toThrow();
+        expect(() =>
+          resolver.validateLiteralFitsType("999999", "f32"),
+        ).not.toThrow();
+      });
+
+      it("should skip validation for non-integer literals", () => {
+        expect(() =>
+          resolver.validateLiteralFitsType("3.14", "u8"),
+        ).not.toThrow();
+        expect(() =>
+          resolver.validateLiteralFitsType("hello", "u8"),
+        ).not.toThrow();
+      });
+    });
+  });
+
+  // ========================================================================
+  // Primary Expression Type Detection
+  // ========================================================================
+
+  describe("getPrimaryExpressionType", () => {
+    // Helper to create mock primary expression context
+    const mockPrimary = (opts: {
+      identifier?: string;
+      literal?: string;
+      castType?: string;
+    }) => {
+      return {
+        IDENTIFIER: () =>
+          opts.identifier ? { getText: () => opts.identifier } : null,
+        literal: () => (opts.literal ? { getText: () => opts.literal } : null),
+        expression: () => null,
+        castExpression: () =>
+          opts.castType
+            ? { type: () => ({ getText: () => opts.castType }) }
+            : null,
+      } as Parameters<typeof resolver.getPrimaryExpressionType>[0];
+    };
+
+    it("should return type for identifier in registry", () => {
+      typeRegistry.set("myVar", {
+        baseType: "u32",
+        bitWidth: 32,
+        isArray: false,
+        isConst: false,
+      });
+      const ctx = mockPrimary({ identifier: "myVar" });
+      expect(resolver.getPrimaryExpressionType(ctx)).toBe("u32");
+    });
+
+    it("should return null for identifier not in registry", () => {
+      const ctx = mockPrimary({ identifier: "unknownVar" });
+      expect(resolver.getPrimaryExpressionType(ctx)).toBeNull();
+    });
+
+    it("should return type from literal suffix", () => {
+      const ctx = mockPrimary({ literal: "42u8" });
+      expect(resolver.getPrimaryExpressionType(ctx)).toBe("u8");
+    });
+
+    it("should return bool for boolean literal", () => {
+      const ctx = mockPrimary({ literal: "true" });
+      expect(resolver.getPrimaryExpressionType(ctx)).toBe("bool");
+    });
+
+    it("should return type from cast expression", () => {
+      const ctx = mockPrimary({ castType: "i16" });
+      expect(resolver.getPrimaryExpressionType(ctx)).toBe("i16");
+    });
+
+    it("should return null when no matching component", () => {
+      const ctx = mockPrimary({});
+      expect(resolver.getPrimaryExpressionType(ctx)).toBeNull();
+    });
+  });
+
+  // ========================================================================
+  // Expression Type Detection
+  // ========================================================================
+
+  describe("getExpressionType", () => {
+    // Helper to create mock expression context with nested structure
+    const mockExpressionWithOr = (orCount: number) => {
+      const orExprs = Array(orCount)
+        .fill(null)
+        .map(() => ({
+          andExpression: () => [
+            {
+              equalityExpression: () => [
+                {
+                  relationalExpression: () => [
+                    { bitwiseOrExpression: () => [] },
+                  ],
+                },
+              ],
+            },
+          ],
+        }));
+
+      return {
+        ternaryExpression: () => ({
+          orExpression: () => orExprs,
+        }),
+      } as unknown as Parameters<typeof resolver.getExpressionType>[0];
+    };
+
+    const mockExpressionWithAnd = (andCount: number) => {
+      const andExprs = Array(andCount)
+        .fill(null)
+        .map(() => ({
+          equalityExpression: () => [
+            { relationalExpression: () => [{ bitwiseOrExpression: () => [] }] },
+          ],
+        }));
+
+      return {
+        ternaryExpression: () => ({
+          orExpression: () => [{ andExpression: () => andExprs }],
+        }),
+      } as unknown as Parameters<typeof resolver.getExpressionType>[0];
+    };
+
+    const mockExpressionWithEquality = (eqCount: number) => {
+      const eqExprs = Array(eqCount)
+        .fill(null)
+        .map(() => ({
+          relationalExpression: () => [{ bitwiseOrExpression: () => [] }],
+        }));
+
+      return {
+        ternaryExpression: () => ({
+          orExpression: () => [
+            { andExpression: () => [{ equalityExpression: () => eqExprs }] },
+          ],
+        }),
+      } as unknown as Parameters<typeof resolver.getExpressionType>[0];
+    };
+
+    const mockExpressionWithRelational = (relCount: number) => {
+      const relExprs = Array(relCount)
+        .fill(null)
+        .map(() => ({
+          bitwiseOrExpression: () => [],
+        }));
+
+      return {
+        ternaryExpression: () => ({
+          orExpression: () => [
+            {
+              andExpression: () => [
+                {
+                  equalityExpression: () => [
+                    { relationalExpression: () => relExprs },
+                  ],
+                },
+              ],
+            },
+          ],
+        }),
+      } as unknown as Parameters<typeof resolver.getExpressionType>[0];
+    };
+
+    it("should return null for ternary expression (multiple or expressions)", () => {
+      const ctx = mockExpressionWithOr(3);
+      expect(resolver.getExpressionType(ctx)).toBeNull();
+    });
+
+    it("should return bool for logical OR expression", () => {
+      const ctx = mockExpressionWithAnd(2);
+      expect(resolver.getExpressionType(ctx)).toBe("bool");
+    });
+
+    it("should return bool for logical AND expression", () => {
+      const ctx = mockExpressionWithEquality(2);
+      expect(resolver.getExpressionType(ctx)).toBe("bool");
+    });
+
+    it("should return bool for equality expression", () => {
+      const ctx = mockExpressionWithRelational(2);
+      expect(resolver.getExpressionType(ctx)).toBe("bool");
+    });
+
+    it("should return null for simple arithmetic expression", () => {
+      // Expression with 1 of each - falls through to null (can't determine arithmetic type)
+      // Need to mock the full depth of the expression tree
+      const ctx = {
+        ternaryExpression: () => ({
+          orExpression: () => [
+            {
+              andExpression: () => [
+                {
+                  equalityExpression: () => [
+                    {
+                      relationalExpression: () => [
+                        {
+                          bitwiseOrExpression: () => [
+                            {
+                              bitwiseXorExpression: () => [
+                                {
+                                  bitwiseAndExpression: () => [
+                                    {
+                                      shiftExpression: () => [
+                                        {
+                                          additiveExpression: () => [
+                                            {
+                                              multiplicativeExpression: () => [
+                                                {
+                                                  // 2 unary expressions = binary operation, can't determine type
+                                                  unaryExpression: () => [
+                                                    {},
+                                                    {},
+                                                  ],
+                                                },
+                                              ],
+                                            },
+                                          ],
+                                        },
+                                      ],
+                                    },
+                                  ],
+                                },
+                              ],
+                            },
+                          ],
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        }),
+      } as unknown as Parameters<typeof resolver.getExpressionType>[0];
+
+      expect(resolver.getExpressionType(ctx)).toBeNull();
+    });
+  });
+
+  // ========================================================================
+  // Postfix Expression Type Detection
+  // ========================================================================
+
+  describe("getPostfixExpressionType", () => {
+    it("should return null when no primary expression", () => {
+      const ctx = {
+        primaryExpression: () => null,
+        children: [],
+      } as unknown as Parameters<typeof resolver.getPostfixExpressionType>[0];
+
+      expect(resolver.getPostfixExpressionType(ctx)).toBeNull();
+    });
+
+    it("should return type from simple identifier", () => {
+      typeRegistry.set("counter", {
+        baseType: "u32",
+        bitWidth: 32,
+        isArray: false,
+        isConst: false,
+      });
+
+      const ctx = {
+        primaryExpression: () => ({
+          IDENTIFIER: () => ({ getText: () => "counter" }),
+          literal: () => null,
+          expression: () => null,
+          castExpression: () => null,
+        }),
+        children: [{ getText: () => "counter" }],
+      } as unknown as Parameters<typeof resolver.getPostfixExpressionType>[0];
+
+      expect(resolver.getPostfixExpressionType(ctx)).toBe("u32");
+    });
+
+    it("should return null when primary type cannot be determined", () => {
+      const ctx = {
+        primaryExpression: () => ({
+          IDENTIFIER: () => ({ getText: () => "unknownVar" }),
+          literal: () => null,
+          expression: () => null,
+          castExpression: () => null,
+        }),
+        children: [{ getText: () => "unknownVar" }],
+      } as unknown as Parameters<typeof resolver.getPostfixExpressionType>[0];
+
+      expect(resolver.getPostfixExpressionType(ctx)).toBeNull();
+    });
+
+    it("should return member type for struct member access", () => {
+      typeRegistry.set("point", {
+        baseType: "Point",
+        bitWidth: 0,
+        isArray: false,
+        isConst: false,
+      });
+      symbolTable.addStructField("Point", "x", "i32");
+
+      const ctx = {
+        primaryExpression: () => ({
+          IDENTIFIER: () => ({ getText: () => "point" }),
+          literal: () => null,
+          expression: () => null,
+          castExpression: () => null,
+        }),
+        children: [{ getText: () => "point" }, { getText: () => ".x" }],
+      } as unknown as Parameters<typeof resolver.getPostfixExpressionType>[0];
+
+      expect(resolver.getPostfixExpressionType(ctx)).toBe("i32");
+    });
+
+    it("should return null for unknown member", () => {
+      typeRegistry.set("point", {
+        baseType: "Point",
+        bitWidth: 0,
+        isArray: false,
+        isConst: false,
+      });
+      symbolTable.addStructField("Point", "x", "i32");
+
+      const ctx = {
+        primaryExpression: () => ({
+          IDENTIFIER: () => ({ getText: () => "point" }),
+          literal: () => null,
+          expression: () => null,
+          castExpression: () => null,
+        }),
+        children: [{ getText: () => "point" }, { getText: () => ".unknown" }],
+      } as unknown as Parameters<typeof resolver.getPostfixExpressionType>[0];
+
+      expect(resolver.getPostfixExpressionType(ctx)).toBeNull();
+    });
+
+    it("should return null for range bit indexing", () => {
+      typeRegistry.set("flags", {
+        baseType: "u32",
+        bitWidth: 32,
+        isArray: false,
+        isConst: false,
+      });
+
+      const ctx = {
+        primaryExpression: () => ({
+          IDENTIFIER: () => ({ getText: () => "flags" }),
+          literal: () => null,
+          expression: () => null,
+          castExpression: () => null,
+        }),
+        children: [{ getText: () => "flags" }, { getText: () => "[0, 8]" }],
+      } as unknown as Parameters<typeof resolver.getPostfixExpressionType>[0];
+
+      expect(resolver.getPostfixExpressionType(ctx)).toBeNull();
+    });
+
+    it("should return bool for single bit indexing on integer", () => {
+      typeRegistry.set("flags", {
+        baseType: "u32",
+        bitWidth: 32,
+        isArray: false,
+        isConst: false,
+      });
+
+      const ctx = {
+        primaryExpression: () => ({
+          IDENTIFIER: () => ({ getText: () => "flags" }),
+          literal: () => null,
+          expression: () => null,
+          castExpression: () => null,
+        }),
+        children: [{ getText: () => "flags" }, { getText: () => "[7]" }],
+      } as unknown as Parameters<typeof resolver.getPostfixExpressionType>[0];
+
+      expect(resolver.getPostfixExpressionType(ctx)).toBe("bool");
+    });
+
+    it("should return element type for array indexing on non-integer", () => {
+      typeRegistry.set("data", {
+        baseType: "Data",
+        bitWidth: 0,
+        isArray: false,
+        isConst: false,
+      });
+      symbolTable.addStructField("Data", "values", "u8", [10]);
+
+      const ctx = {
+        primaryExpression: () => ({
+          IDENTIFIER: () => ({ getText: () => "data" }),
+          literal: () => null,
+          expression: () => null,
+          castExpression: () => null,
+        }),
+        children: [
+          { getText: () => "data" },
+          { getText: () => ".values" },
+          { getText: () => "[0]" },
+        ],
+      } as unknown as Parameters<typeof resolver.getPostfixExpressionType>[0];
+
+      // After .values, type is "u8" (array element type)
+      // Then [0] on "u8" - u8 is an integer, so it returns "bool" for bit access
+      expect(resolver.getPostfixExpressionType(ctx)).toBe("bool");
+    });
+  });
+
+  // ========================================================================
+  // Unary Expression Type Detection
+  // ========================================================================
+
+  describe("getUnaryExpressionType", () => {
+    it("should return type from postfix expression", () => {
+      typeRegistry.set("value", {
+        baseType: "i32",
+        bitWidth: 32,
+        isArray: false,
+        isConst: false,
+      });
+
+      const ctx = {
+        postfixExpression: () => ({
+          primaryExpression: () => ({
+            IDENTIFIER: () => ({ getText: () => "value" }),
+            literal: () => null,
+            expression: () => null,
+            castExpression: () => null,
+          }),
+          children: [{ getText: () => "value" }],
+        }),
+        unaryExpression: () => null,
+      } as unknown as Parameters<typeof resolver.getUnaryExpressionType>[0];
+
+      expect(resolver.getUnaryExpressionType(ctx)).toBe("i32");
+    });
+
+    it("should return null when no postfix or unary", () => {
+      const ctx = {
+        postfixExpression: () => null,
+        unaryExpression: () => null,
+      } as unknown as Parameters<typeof resolver.getUnaryExpressionType>[0];
+
+      expect(resolver.getUnaryExpressionType(ctx)).toBeNull();
+    });
+
+    it("should recurse through unary expression chain", () => {
+      typeRegistry.set("x", {
+        baseType: "i32",
+        bitWidth: 32,
+        isArray: false,
+        isConst: false,
+      });
+
+      // Represents: -x (unary minus with nested expression)
+      const ctx = {
+        postfixExpression: () => null,
+        unaryExpression: () => ({
+          postfixExpression: () => ({
+            primaryExpression: () => ({
+              IDENTIFIER: () => ({ getText: () => "x" }),
+              literal: () => null,
+              expression: () => null,
+              castExpression: () => null,
+            }),
+            children: [{ getText: () => "x" }],
+          }),
+          unaryExpression: () => null,
+        }),
+      } as unknown as Parameters<typeof resolver.getUnaryExpressionType>[0];
+
+      expect(resolver.getUnaryExpressionType(ctx)).toBe("i32");
+    });
+  });
+
+  // ========================================================================
+  // Literal Type Detection
+  // ========================================================================
+
+  describe("getLiteralType", () => {
+    // Helper to create mock literal context
+    const mockLiteral = (text: string) =>
+      ({ getText: () => text }) as Parameters<
+        typeof resolver.getLiteralType
+      >[0];
+
+    describe("boolean literals", () => {
+      it("should return bool for true", () => {
+        expect(resolver.getLiteralType(mockLiteral("true"))).toBe("bool");
+      });
+
+      it("should return bool for false", () => {
+        expect(resolver.getLiteralType(mockLiteral("false"))).toBe("bool");
+      });
+    });
+
+    describe("integer suffixes", () => {
+      it("should detect u8 suffix", () => {
+        expect(resolver.getLiteralType(mockLiteral("255u8"))).toBe("u8");
+        expect(resolver.getLiteralType(mockLiteral("0U8"))).toBe("u8");
+      });
+
+      it("should detect u16 suffix", () => {
+        expect(resolver.getLiteralType(mockLiteral("1000u16"))).toBe("u16");
+      });
+
+      it("should detect u32 suffix", () => {
+        expect(resolver.getLiteralType(mockLiteral("1000000u32"))).toBe("u32");
+      });
+
+      it("should detect u64 suffix", () => {
+        expect(resolver.getLiteralType(mockLiteral("1000000000u64"))).toBe(
+          "u64",
+        );
+      });
+
+      it("should detect i8 suffix", () => {
+        expect(resolver.getLiteralType(mockLiteral("-50i8"))).toBe("i8");
+        expect(resolver.getLiteralType(mockLiteral("50I8"))).toBe("i8");
+      });
+
+      it("should detect i16 suffix", () => {
+        expect(resolver.getLiteralType(mockLiteral("1000i16"))).toBe("i16");
+      });
+
+      it("should detect i32 suffix", () => {
+        expect(resolver.getLiteralType(mockLiteral("1000000i32"))).toBe("i32");
+      });
+
+      it("should detect i64 suffix", () => {
+        expect(resolver.getLiteralType(mockLiteral("1000000000i64"))).toBe(
+          "i64",
+        );
+      });
+    });
+
+    describe("float suffixes", () => {
+      it("should detect f32 suffix", () => {
+        expect(resolver.getLiteralType(mockLiteral("3.14f32"))).toBe("f32");
+        expect(resolver.getLiteralType(mockLiteral("3.14F32"))).toBe("f32");
+      });
+
+      it("should detect f64 suffix", () => {
+        expect(resolver.getLiteralType(mockLiteral("3.14159f64"))).toBe("f64");
+        expect(resolver.getLiteralType(mockLiteral("3.14159F64"))).toBe("f64");
+      });
+    });
+
+    describe("unsuffixed literals", () => {
+      it("should return null for unsuffixed integer", () => {
+        expect(resolver.getLiteralType(mockLiteral("42"))).toBeNull();
+      });
+
+      it("should return null for unsuffixed hex", () => {
+        expect(resolver.getLiteralType(mockLiteral("0xFF"))).toBeNull();
+      });
+
+      it("should return null for unsuffixed float", () => {
+        expect(resolver.getLiteralType(mockLiteral("3.14"))).toBeNull();
+      });
+    });
+  });
+
+  // ========================================================================
+  // Member Type Info
+  // ========================================================================
+
+  describe("getMemberTypeInfo", () => {
+    it("should return field info from SymbolTable", () => {
+      symbolTable.addStructField("Point", "x", "i32");
+      symbolTable.addStructField("Point", "y", "i32");
+
+      const xInfo = resolver.getMemberTypeInfo("Point", "x");
+      expect(xInfo).toBeDefined();
+      expect(xInfo?.baseType).toBe("i32");
+      expect(xInfo?.isArray).toBe(false);
+    });
+
+    it("should return array info for array fields", () => {
+      symbolTable.addStructField("Buffer", "data", "u8", [256]);
+
+      const dataInfo = resolver.getMemberTypeInfo("Buffer", "data");
+      expect(dataInfo).toBeDefined();
+      expect(dataInfo?.baseType).toBe("u8");
+      expect(dataInfo?.isArray).toBe(true);
+    });
+
+    it("should return undefined for unknown struct", () => {
+      expect(resolver.getMemberTypeInfo("Unknown", "field")).toBeUndefined();
+    });
+
+    it("should return undefined for unknown field", () => {
+      symbolTable.addStructField("Point", "x", "i32");
+      expect(resolver.getMemberTypeInfo("Point", "z")).toBeUndefined();
+    });
+  });
+});

--- a/src/codegen/TypeValidator.test.ts
+++ b/src/codegen/TypeValidator.test.ts
@@ -1,0 +1,2480 @@
+/**
+ * Unit tests for TypeValidator
+ * Tests include validation, identifier validation, and type checking
+ */
+import { describe, it, expect, beforeEach } from "vitest";
+import TypeValidator from "./TypeValidator";
+import TypeResolver from "./TypeResolver";
+import SymbolTable from "../symbols/SymbolTable";
+import ITypeValidatorDeps from "./types/ITypeValidatorDeps";
+import ITypeResolverDeps from "./types/ITypeResolverDeps";
+import TTypeInfo from "./types/TTypeInfo";
+
+describe("TypeValidator", () => {
+  let validator: TypeValidator;
+  let symbolTable: SymbolTable;
+  let typeRegistry: Map<string, TTypeInfo>;
+  let typeResolver: TypeResolver;
+
+  beforeEach(() => {
+    symbolTable = new SymbolTable();
+    typeRegistry = new Map();
+
+    const resolverDeps: ITypeResolverDeps = {
+      symbols: null,
+      symbolTable,
+      typeRegistry,
+      resolveIdentifier: (name: string) => name,
+    };
+    typeResolver = new TypeResolver(resolverDeps);
+
+    const validatorDeps: ITypeValidatorDeps = {
+      symbols: null,
+      symbolTable,
+      typeRegistry,
+      typeResolver,
+      callbackTypes: new Map(),
+      knownFunctions: new Set(),
+      knownGlobals: new Set(),
+      getCurrentScope: () => null,
+      getScopeMembers: () => new Map(),
+      getCurrentParameters: () => new Map(),
+      getLocalVariables: () => new Set(),
+      resolveIdentifier: (name: string) => name,
+      getExpressionType: () => null,
+    };
+
+    validator = new TypeValidator(validatorDeps);
+  });
+
+  // ========================================================================
+  // Include Validation (ADR-010)
+  // ========================================================================
+
+  describe("validateIncludeNotImplementationFile", () => {
+    describe("should allow header files", () => {
+      it("should allow .h files with angle brackets", () => {
+        expect(() =>
+          validator.validateIncludeNotImplementationFile(
+            "#include <stdio.h>",
+            1,
+          ),
+        ).not.toThrow();
+      });
+
+      it("should allow .h files with quotes", () => {
+        expect(() =>
+          validator.validateIncludeNotImplementationFile(
+            '#include "myheader.h"',
+            1,
+          ),
+        ).not.toThrow();
+      });
+
+      it("should allow .hpp files", () => {
+        expect(() =>
+          validator.validateIncludeNotImplementationFile(
+            "#include <vector.hpp>",
+            1,
+          ),
+        ).not.toThrow();
+      });
+
+      it("should allow .cnx files", () => {
+        expect(() =>
+          validator.validateIncludeNotImplementationFile(
+            '#include "module.cnx"',
+            1,
+          ),
+        ).not.toThrow();
+      });
+    });
+
+    describe("should reject implementation files", () => {
+      it("should reject .c files", () => {
+        expect(() =>
+          validator.validateIncludeNotImplementationFile(
+            '#include "impl.c"',
+            10,
+          ),
+        ).toThrow(/E0503.*Cannot #include implementation file.*impl\.c/);
+      });
+
+      it("should reject .cpp files", () => {
+        expect(() =>
+          validator.validateIncludeNotImplementationFile(
+            "#include <module.cpp>",
+            5,
+          ),
+        ).toThrow(/E0503.*Cannot #include implementation file.*module\.cpp/);
+      });
+
+      it("should reject .cc files", () => {
+        expect(() =>
+          validator.validateIncludeNotImplementationFile(
+            '#include "code.cc"',
+            1,
+          ),
+        ).toThrow(/E0503.*Cannot #include implementation file.*code\.cc/);
+      });
+
+      it("should reject .cxx files", () => {
+        expect(() =>
+          validator.validateIncludeNotImplementationFile(
+            '#include "code.cxx"',
+            1,
+          ),
+        ).toThrow(/E0503.*Cannot #include implementation file/);
+      });
+
+      it("should reject .c++ files", () => {
+        expect(() =>
+          validator.validateIncludeNotImplementationFile(
+            '#include "code.c++"',
+            1,
+          ),
+        ).toThrow(/E0503.*Cannot #include implementation file/);
+      });
+    });
+
+    describe("edge cases", () => {
+      it("should handle malformed includes gracefully", () => {
+        expect(() =>
+          validator.validateIncludeNotImplementationFile("#include", 1),
+        ).not.toThrow();
+
+        expect(() =>
+          validator.validateIncludeNotImplementationFile("#include broken", 1),
+        ).not.toThrow();
+      });
+
+      it("should be case-insensitive for extensions", () => {
+        expect(() =>
+          validator.validateIncludeNotImplementationFile(
+            '#include "file.C"',
+            1,
+          ),
+        ).toThrow(/E0503/);
+
+        expect(() =>
+          validator.validateIncludeNotImplementationFile(
+            '#include "file.CPP"',
+            1,
+          ),
+        ).toThrow(/E0503/);
+      });
+
+      it("should include line number in error message", () => {
+        expect(() =>
+          validator.validateIncludeNotImplementationFile(
+            '#include "impl.c"',
+            42,
+          ),
+        ).toThrow(/Line 42/);
+      });
+    });
+  });
+
+  // ========================================================================
+  // CNX Alternative Validation (E0504)
+  // ========================================================================
+
+  describe("validateIncludeNoCnxAlternative", () => {
+    describe("should skip non-header files", () => {
+      it("should skip .cnx includes", () => {
+        expect(() =>
+          validator.validateIncludeNoCnxAlternative(
+            '#include "module.cnx"',
+            1,
+            "/src/main.cnx",
+            [],
+            () => true, // Always return true - should still not throw
+          ),
+        ).not.toThrow();
+      });
+
+      it("should skip non-h/hpp files", () => {
+        expect(() =>
+          validator.validateIncludeNoCnxAlternative(
+            '#include "data.json"',
+            1,
+            "/src/main.cnx",
+            [],
+            () => true,
+          ),
+        ).not.toThrow();
+      });
+    });
+
+    describe("quoted includes (relative to source)", () => {
+      it("should throw when .cnx alternative exists", () => {
+        expect(() =>
+          validator.validateIncludeNoCnxAlternative(
+            '#include "driver.h"',
+            10,
+            "/project/src/main.cnx",
+            [],
+            (path: string) => path.endsWith("driver.cnx"),
+          ),
+        ).toThrow(/E0504.*driver\.cnx.*exists/);
+      });
+
+      it("should not throw when .cnx alternative does not exist", () => {
+        expect(() =>
+          validator.validateIncludeNoCnxAlternative(
+            '#include "driver.h"',
+            10,
+            "/project/src/main.cnx",
+            [],
+            () => false,
+          ),
+        ).not.toThrow();
+      });
+
+      it("should skip when sourcePath is null", () => {
+        expect(() =>
+          validator.validateIncludeNoCnxAlternative(
+            '#include "driver.h"',
+            10,
+            null,
+            [],
+            () => true,
+          ),
+        ).not.toThrow();
+      });
+    });
+
+    describe("angle bracket includes (search paths)", () => {
+      it("should throw when .cnx alternative exists in include path", () => {
+        expect(() =>
+          validator.validateIncludeNoCnxAlternative(
+            "#include <sensors/temp.h>",
+            5,
+            "/project/src/main.cnx",
+            ["/project/include"],
+            (path: string) => path === "/project/include/sensors/temp.cnx",
+          ),
+        ).toThrow(/E0504.*temp\.cnx.*exists/);
+      });
+
+      it("should not throw when .cnx alternative does not exist", () => {
+        expect(() =>
+          validator.validateIncludeNoCnxAlternative(
+            "#include <sensors/temp.h>",
+            5,
+            "/project/src/main.cnx",
+            ["/project/include"],
+            () => false,
+          ),
+        ).not.toThrow();
+      });
+
+      it("should search multiple include paths", () => {
+        const checkedPaths: string[] = [];
+        validator.validateIncludeNoCnxAlternative(
+          "#include <util.h>",
+          1,
+          "/src/main.cnx",
+          ["/include1", "/include2", "/include3"],
+          (path: string) => {
+            checkedPaths.push(path);
+            return false;
+          },
+        );
+
+        expect(checkedPaths).toContain("/include1/util.cnx");
+        expect(checkedPaths).toContain("/include2/util.cnx");
+        expect(checkedPaths).toContain("/include3/util.cnx");
+      });
+    });
+
+    describe("edge cases", () => {
+      it("should handle malformed includes gracefully", () => {
+        expect(() =>
+          validator.validateIncludeNoCnxAlternative(
+            "#include broken",
+            1,
+            "/src/main.cnx",
+            [],
+            () => true,
+          ),
+        ).not.toThrow();
+      });
+
+      it("should handle .hpp files", () => {
+        expect(() =>
+          validator.validateIncludeNoCnxAlternative(
+            '#include "module.hpp"',
+            1,
+            "/src/main.cnx",
+            [],
+            (path: string) => path.endsWith("module.cnx"),
+          ),
+        ).toThrow(/E0504.*module\.cnx/);
+      });
+    });
+  });
+
+  // ========================================================================
+  // Callback Signature Matching (ADR-029)
+  // ========================================================================
+
+  describe("callbackSignaturesMatch", () => {
+    it("should return true for matching signatures", () => {
+      const a = {
+        functionName: "fnA",
+        typedefName: "fnA_fp",
+        returnType: "void",
+        parameters: [
+          {
+            name: "p",
+            type: "u32",
+            isConst: false,
+            isPointer: false,
+            isArray: false,
+            arrayDims: "",
+          },
+        ],
+      };
+      const b = {
+        functionName: "fnB",
+        typedefName: "fnB_fp",
+        returnType: "void",
+        parameters: [
+          {
+            name: "p",
+            type: "u32",
+            isConst: false,
+            isPointer: false,
+            isArray: false,
+            arrayDims: "",
+          },
+        ],
+      };
+      expect(validator.callbackSignaturesMatch(a, b)).toBe(true);
+    });
+
+    it("should return false for different return types", () => {
+      const a = {
+        functionName: "fnA",
+        typedefName: "fnA_fp",
+        returnType: "void",
+        parameters: [],
+      };
+      const b = {
+        functionName: "fnB",
+        typedefName: "fnB_fp",
+        returnType: "u32",
+        parameters: [],
+      };
+      expect(validator.callbackSignaturesMatch(a, b)).toBe(false);
+    });
+
+    it("should return false for different parameter counts", () => {
+      const a = {
+        functionName: "fnA",
+        typedefName: "fnA_fp",
+        returnType: "void",
+        parameters: [
+          {
+            name: "p",
+            type: "u32",
+            isConst: false,
+            isPointer: false,
+            isArray: false,
+            arrayDims: "",
+          },
+        ],
+      };
+      const b = {
+        functionName: "fnB",
+        typedefName: "fnB_fp",
+        returnType: "void",
+        parameters: [],
+      };
+      expect(validator.callbackSignaturesMatch(a, b)).toBe(false);
+    });
+
+    it("should return false for different parameter types", () => {
+      const a = {
+        functionName: "fnA",
+        typedefName: "fnA_fp",
+        returnType: "void",
+        parameters: [
+          {
+            name: "p",
+            type: "u32",
+            isConst: false,
+            isPointer: false,
+            isArray: false,
+            arrayDims: "",
+          },
+        ],
+      };
+      const b = {
+        functionName: "fnB",
+        typedefName: "fnB_fp",
+        returnType: "void",
+        parameters: [
+          {
+            name: "p",
+            type: "i32",
+            isConst: false,
+            isPointer: false,
+            isArray: false,
+            arrayDims: "",
+          },
+        ],
+      };
+      expect(validator.callbackSignaturesMatch(a, b)).toBe(false);
+    });
+
+    it("should return false for different const qualifiers", () => {
+      const a = {
+        functionName: "fnA",
+        typedefName: "fnA_fp",
+        returnType: "void",
+        parameters: [
+          {
+            name: "p",
+            type: "u32",
+            isConst: true,
+            isPointer: false,
+            isArray: false,
+            arrayDims: "",
+          },
+        ],
+      };
+      const b = {
+        functionName: "fnB",
+        typedefName: "fnB_fp",
+        returnType: "void",
+        parameters: [
+          {
+            name: "p",
+            type: "u32",
+            isConst: false,
+            isPointer: false,
+            isArray: false,
+            arrayDims: "",
+          },
+        ],
+      };
+      expect(validator.callbackSignaturesMatch(a, b)).toBe(false);
+    });
+
+    it("should return false for different pointer qualifiers", () => {
+      const a = {
+        functionName: "fnA",
+        typedefName: "fnA_fp",
+        returnType: "void",
+        parameters: [
+          {
+            name: "p",
+            type: "u32",
+            isConst: false,
+            isPointer: true,
+            isArray: false,
+            arrayDims: "",
+          },
+        ],
+      };
+      const b = {
+        functionName: "fnB",
+        typedefName: "fnB_fp",
+        returnType: "void",
+        parameters: [
+          {
+            name: "p",
+            type: "u32",
+            isConst: false,
+            isPointer: false,
+            isArray: false,
+            arrayDims: "",
+          },
+        ],
+      };
+      expect(validator.callbackSignaturesMatch(a, b)).toBe(false);
+    });
+
+    it("should return false for different array qualifiers", () => {
+      const a = {
+        functionName: "fnA",
+        typedefName: "fnA_fp",
+        returnType: "void",
+        parameters: [
+          {
+            name: "p",
+            type: "u32",
+            isConst: false,
+            isPointer: false,
+            isArray: true,
+            arrayDims: "",
+          },
+        ],
+      };
+      const b = {
+        functionName: "fnB",
+        typedefName: "fnB_fp",
+        returnType: "void",
+        parameters: [
+          {
+            name: "p",
+            type: "u32",
+            isConst: false,
+            isPointer: false,
+            isArray: false,
+            arrayDims: "",
+          },
+        ],
+      };
+      expect(validator.callbackSignaturesMatch(a, b)).toBe(false);
+    });
+  });
+
+  // ========================================================================
+  // Const Assignment Validation (ADR-013)
+  // ========================================================================
+
+  describe("checkConstAssignment", () => {
+    it("should return error message for const parameter", () => {
+      const params = new Map();
+      params.set("x", { type: "u32", isConst: true });
+
+      const deps: ITypeValidatorDeps = {
+        symbols: null,
+        symbolTable,
+        typeRegistry,
+        typeResolver,
+        callbackTypes: new Map(),
+        knownFunctions: new Set(),
+        knownGlobals: new Set(),
+        getCurrentScope: () => null,
+        getScopeMembers: () => new Map(),
+        getCurrentParameters: () => params,
+        getLocalVariables: () => new Set(),
+        resolveIdentifier: (name: string) => name,
+        getExpressionType: () => null,
+      };
+
+      const v = new TypeValidator(deps);
+      expect(v.checkConstAssignment("x")).toContain("const parameter");
+    });
+
+    it("should return error message for const variable", () => {
+      typeRegistry.set("MAX_VALUE", {
+        baseType: "u32",
+        bitWidth: 32,
+        isConst: true,
+        isArray: false,
+      });
+
+      expect(validator.checkConstAssignment("MAX_VALUE")).toContain(
+        "const variable",
+      );
+    });
+
+    it("should return null for mutable variable", () => {
+      typeRegistry.set("counter", {
+        baseType: "u32",
+        bitWidth: 32,
+        isConst: false,
+        isArray: false,
+      });
+
+      expect(validator.checkConstAssignment("counter")).toBeNull();
+    });
+  });
+
+  describe("isConstValue", () => {
+    it("should return true for const parameter", () => {
+      const params = new Map();
+      params.set("x", { type: "u32", isConst: true });
+
+      const deps: ITypeValidatorDeps = {
+        symbols: null,
+        symbolTable,
+        typeRegistry,
+        typeResolver,
+        callbackTypes: new Map(),
+        knownFunctions: new Set(),
+        knownGlobals: new Set(),
+        getCurrentScope: () => null,
+        getScopeMembers: () => new Map(),
+        getCurrentParameters: () => params,
+        getLocalVariables: () => new Set(),
+        resolveIdentifier: (name: string) => name,
+        getExpressionType: () => null,
+      };
+
+      const v = new TypeValidator(deps);
+      expect(v.isConstValue("x")).toBe(true);
+    });
+
+    it("should return true for const variable", () => {
+      typeRegistry.set("MAX", {
+        baseType: "u32",
+        bitWidth: 32,
+        isConst: true,
+        isArray: false,
+      });
+
+      expect(validator.isConstValue("MAX")).toBe(true);
+    });
+
+    it("should return false for non-const values", () => {
+      typeRegistry.set("counter", {
+        baseType: "u32",
+        bitWidth: 32,
+        isConst: false,
+        isArray: false,
+      });
+
+      expect(validator.isConstValue("counter")).toBe(false);
+    });
+  });
+
+  // ========================================================================
+  // Bitmap Field Validation (ADR-034)
+  // ========================================================================
+
+  describe("validateBitmapFieldLiteral", () => {
+    // Helper to create mock expression context
+    const mockExpr = (text: string) =>
+      ({ getText: () => text }) as Parameters<
+        typeof validator.validateBitmapFieldLiteral
+      >[0];
+
+    it("should allow values within range", () => {
+      expect(() =>
+        validator.validateBitmapFieldLiteral(mockExpr("15"), 4, "nibble"),
+      ).not.toThrow();
+
+      expect(() =>
+        validator.validateBitmapFieldLiteral(mockExpr("255"), 8, "byte"),
+      ).not.toThrow();
+    });
+
+    it("should reject decimal values exceeding bit width", () => {
+      expect(() =>
+        validator.validateBitmapFieldLiteral(mockExpr("16"), 4, "nibble"),
+      ).toThrow(/Value 16 exceeds 4-bit field 'nibble' maximum of 15/);
+
+      expect(() =>
+        validator.validateBitmapFieldLiteral(mockExpr("256"), 8, "byte"),
+      ).toThrow(/Value 256 exceeds 8-bit field 'byte' maximum of 255/);
+    });
+
+    it("should validate hex literals", () => {
+      expect(() =>
+        validator.validateBitmapFieldLiteral(mockExpr("0xFF"), 8, "byte"),
+      ).not.toThrow();
+
+      expect(() =>
+        validator.validateBitmapFieldLiteral(mockExpr("0x100"), 8, "byte"),
+      ).toThrow(/Value 256 exceeds 8-bit field 'byte' maximum of 255/);
+    });
+
+    it("should validate binary literals", () => {
+      expect(() =>
+        validator.validateBitmapFieldLiteral(mockExpr("0b1111"), 4, "nibble"),
+      ).not.toThrow();
+
+      expect(() =>
+        validator.validateBitmapFieldLiteral(mockExpr("0b10000"), 4, "nibble"),
+      ).toThrow(/Value 16 exceeds 4-bit field 'nibble' maximum of 15/);
+    });
+
+    it("should skip non-literal expressions", () => {
+      // Variables/identifiers should be skipped (can't evaluate at compile time)
+      expect(() =>
+        validator.validateBitmapFieldLiteral(mockExpr("myVar"), 4, "field"),
+      ).not.toThrow();
+
+      expect(() =>
+        validator.validateBitmapFieldLiteral(mockExpr("a + b"), 4, "field"),
+      ).not.toThrow();
+    });
+  });
+
+  // ========================================================================
+  // Array Bounds Validation (ADR-036)
+  // ========================================================================
+
+  describe("checkArrayBounds", () => {
+    // Helper to create mock expression context
+    const mockExpr = (text: string) =>
+      ({ getText: () => text }) as Parameters<
+        typeof validator.checkArrayBounds
+      >[2][0];
+
+    it("should allow in-bounds indices", () => {
+      expect(() =>
+        validator.checkArrayBounds("arr", [10], [mockExpr("5")], 1, () => 5),
+      ).not.toThrow();
+    });
+
+    it("should reject negative indices", () => {
+      expect(() =>
+        validator.checkArrayBounds("arr", [10], [mockExpr("-1")], 1, () => -1),
+      ).toThrow(/Array index out of bounds: -1 is negative for 'arr'/);
+    });
+
+    it("should reject indices >= dimension", () => {
+      expect(() =>
+        validator.checkArrayBounds("arr", [10], [mockExpr("10")], 1, () => 10),
+      ).toThrow(/Array index out of bounds: 10 >= 10 for 'arr' dimension 1/);
+    });
+
+    it("should check multiple dimensions", () => {
+      expect(() =>
+        validator.checkArrayBounds(
+          "matrix",
+          [3, 4],
+          [mockExpr("1"), mockExpr("5")],
+          1,
+          (ctx) => {
+            const text = ctx.getText();
+            return text === "1" ? 1 : 5;
+          },
+        ),
+      ).toThrow(/Array index out of bounds: 5 >= 4 for 'matrix' dimension 2/);
+    });
+
+    it("should skip non-constant indices", () => {
+      expect(() =>
+        validator.checkArrayBounds(
+          "arr",
+          [10],
+          [mockExpr("i")],
+          1,
+          () => undefined, // Non-constant
+        ),
+      ).not.toThrow();
+    });
+  });
+
+  // ========================================================================
+  // Ternary Validation (ADR-022)
+  // ========================================================================
+
+  describe("validateNoNestedTernary", () => {
+    const mockOrExpr = (text: string) =>
+      ({ getText: () => text }) as Parameters<
+        typeof validator.validateNoNestedTernary
+      >[0];
+
+    it("should allow non-nested expressions", () => {
+      expect(() =>
+        validator.validateNoNestedTernary(mockOrExpr("a + b"), "true branch"),
+      ).not.toThrow();
+
+      expect(() =>
+        validator.validateNoNestedTernary(mockOrExpr("x > 5"), "false branch"),
+      ).not.toThrow();
+    });
+
+    it("should reject nested ternary", () => {
+      expect(() =>
+        validator.validateNoNestedTernary(
+          mockOrExpr("a > 0 ? b : c"),
+          "true branch",
+        ),
+      ).toThrow(/Nested ternary not allowed in true branch/);
+
+      expect(() =>
+        validator.validateNoNestedTernary(
+          mockOrExpr("x ? y : z"),
+          "false branch",
+        ),
+      ).toThrow(/Nested ternary not allowed in false branch/);
+    });
+  });
+
+  // ========================================================================
+  // getCaseLabelValue (switch validation helper)
+  // ========================================================================
+
+  describe("getCaseLabelValue", () => {
+    it("should return identifier text", () => {
+      const mockCtx = {
+        qualifiedType: () => null,
+        IDENTIFIER: () => ({ getText: () => "MyValue" }),
+        INTEGER_LITERAL: () => null,
+        HEX_LITERAL: () => null,
+        BINARY_LITERAL: () => null,
+        CHAR_LITERAL: () => null,
+        children: null,
+      } as unknown as Parameters<typeof validator.getCaseLabelValue>[0];
+
+      expect(validator.getCaseLabelValue(mockCtx)).toBe("MyValue");
+    });
+
+    it("should return integer literal", () => {
+      const mockCtx = {
+        qualifiedType: () => null,
+        IDENTIFIER: () => null,
+        INTEGER_LITERAL: () => ({ getText: () => "42" }),
+        HEX_LITERAL: () => null,
+        BINARY_LITERAL: () => null,
+        CHAR_LITERAL: () => null,
+        children: [{ getText: () => "42" }],
+      } as unknown as Parameters<typeof validator.getCaseLabelValue>[0];
+
+      expect(validator.getCaseLabelValue(mockCtx)).toBe("42");
+    });
+
+    it("should handle negative integer literal", () => {
+      const mockCtx = {
+        qualifiedType: () => null,
+        IDENTIFIER: () => null,
+        INTEGER_LITERAL: () => ({ getText: () => "5" }),
+        HEX_LITERAL: () => null,
+        BINARY_LITERAL: () => null,
+        CHAR_LITERAL: () => null,
+        children: [{ getText: () => "-" }, { getText: () => "5" }],
+      } as unknown as Parameters<typeof validator.getCaseLabelValue>[0];
+
+      expect(validator.getCaseLabelValue(mockCtx)).toBe("-5");
+    });
+
+    it("should normalize hex to decimal", () => {
+      const mockCtx = {
+        qualifiedType: () => null,
+        IDENTIFIER: () => null,
+        INTEGER_LITERAL: () => null,
+        HEX_LITERAL: () => ({ getText: () => "0xFF" }),
+        BINARY_LITERAL: () => null,
+        CHAR_LITERAL: () => null,
+        children: [{ getText: () => "0xFF" }],
+      } as unknown as Parameters<typeof validator.getCaseLabelValue>[0];
+
+      expect(validator.getCaseLabelValue(mockCtx)).toBe("255");
+    });
+
+    it("should normalize binary to decimal", () => {
+      const mockCtx = {
+        qualifiedType: () => null,
+        IDENTIFIER: () => null,
+        INTEGER_LITERAL: () => null,
+        HEX_LITERAL: () => null,
+        BINARY_LITERAL: () => ({ getText: () => "0b1010" }),
+        CHAR_LITERAL: () => null,
+        children: null,
+      } as unknown as Parameters<typeof validator.getCaseLabelValue>[0];
+
+      expect(validator.getCaseLabelValue(mockCtx)).toBe("10");
+    });
+
+    it("should return char literal as-is", () => {
+      const mockCtx = {
+        qualifiedType: () => null,
+        IDENTIFIER: () => null,
+        INTEGER_LITERAL: () => null,
+        HEX_LITERAL: () => null,
+        BINARY_LITERAL: () => null,
+        CHAR_LITERAL: () => ({ getText: () => "'a'" }),
+        children: null,
+      } as unknown as Parameters<typeof validator.getCaseLabelValue>[0];
+
+      expect(validator.getCaseLabelValue(mockCtx)).toBe("'a'");
+    });
+
+    it("should handle qualified type (enum member)", () => {
+      const mockCtx = {
+        qualifiedType: () => ({
+          IDENTIFIER: () => [
+            { getText: () => "Color" },
+            { getText: () => "Red" },
+          ],
+        }),
+        IDENTIFIER: () => null,
+        INTEGER_LITERAL: () => null,
+        HEX_LITERAL: () => null,
+        BINARY_LITERAL: () => null,
+        CHAR_LITERAL: () => null,
+        children: null,
+      } as unknown as Parameters<typeof validator.getCaseLabelValue>[0];
+
+      expect(validator.getCaseLabelValue(mockCtx)).toBe("Color.Red");
+    });
+
+    it("should return empty string for unrecognized format", () => {
+      const mockCtx = {
+        qualifiedType: () => null,
+        IDENTIFIER: () => null,
+        INTEGER_LITERAL: () => null,
+        HEX_LITERAL: () => null,
+        BINARY_LITERAL: () => null,
+        CHAR_LITERAL: () => null,
+        children: null,
+      } as unknown as Parameters<typeof validator.getCaseLabelValue>[0];
+
+      expect(validator.getCaseLabelValue(mockCtx)).toBe("");
+    });
+  });
+
+  // ========================================================================
+  // getDefaultCount (switch validation helper)
+  // ========================================================================
+
+  describe("getDefaultCount", () => {
+    it("should return count for default(n) syntax", () => {
+      const mockCtx = {
+        INTEGER_LITERAL: () => ({ getText: () => "3" }),
+      } as unknown as Parameters<typeof validator.getDefaultCount>[0];
+
+      expect(validator.getDefaultCount(mockCtx)).toBe(3);
+    });
+
+    it("should return null for plain default", () => {
+      const mockCtx = {
+        INTEGER_LITERAL: () => null,
+      } as unknown as Parameters<typeof validator.getDefaultCount>[0];
+
+      expect(validator.getDefaultCount(mockCtx)).toBeNull();
+    });
+  });
+
+  // ========================================================================
+  // Shift Amount Validation (MISRA C:2012 Rule 12.2)
+  // ========================================================================
+
+  describe("validateShiftAmount", () => {
+    // Helper to create mock AdditiveExpressionContext with a literal
+    const mockShiftExpr = (literalText: string) => {
+      return {
+        multiplicativeExpression: () => [
+          {
+            unaryExpression: () => [
+              {
+                getText: () => literalText,
+                postfixExpression: () => ({
+                  primaryExpression: () => ({
+                    literal: () => ({ getText: () => literalText }),
+                  }),
+                }),
+                unaryExpression: () => null,
+              },
+            ],
+          },
+        ],
+      } as unknown as Parameters<typeof validator.validateShiftAmount>[1];
+    };
+
+    const mockShiftCtx = (text: string) =>
+      ({ getText: () => text }) as Parameters<
+        typeof validator.validateShiftAmount
+      >[3];
+
+    it("should allow valid shift amounts", () => {
+      expect(() =>
+        validator.validateShiftAmount(
+          "u8",
+          mockShiftExpr("7"),
+          "<<",
+          mockShiftCtx("x << 7"),
+        ),
+      ).not.toThrow();
+
+      expect(() =>
+        validator.validateShiftAmount(
+          "u32",
+          mockShiftExpr("31"),
+          ">>",
+          mockShiftCtx("x >> 31"),
+        ),
+      ).not.toThrow();
+    });
+
+    it("should reject shift amount >= type width", () => {
+      expect(() =>
+        validator.validateShiftAmount(
+          "u8",
+          mockShiftExpr("8"),
+          "<<",
+          mockShiftCtx("x << 8"),
+        ),
+      ).toThrow(/Shift amount \(8\) exceeds type width \(8 bits\)/);
+
+      expect(() =>
+        validator.validateShiftAmount(
+          "u16",
+          mockShiftExpr("16"),
+          "<<",
+          mockShiftCtx("x << 16"),
+        ),
+      ).toThrow(/Shift amount \(16\) exceeds type width \(16 bits\)/);
+
+      expect(() =>
+        validator.validateShiftAmount(
+          "i32",
+          mockShiftExpr("32"),
+          "<<",
+          mockShiftCtx("x << 32"),
+        ),
+      ).toThrow(/Shift amount \(32\) exceeds type width \(32 bits\)/);
+    });
+
+    it("should reject negative shift amounts", () => {
+      // Mock a negative literal with unary minus
+      const mockNegativeExpr = {
+        multiplicativeExpression: () => [
+          {
+            unaryExpression: () => [
+              {
+                getText: () => "-1",
+                postfixExpression: () => ({
+                  primaryExpression: () => ({
+                    literal: () => ({ getText: () => "1" }),
+                  }),
+                }),
+                unaryExpression: () => null,
+              },
+            ],
+          },
+        ],
+      } as unknown as Parameters<typeof validator.validateShiftAmount>[1];
+
+      expect(() =>
+        validator.validateShiftAmount(
+          "u32",
+          mockNegativeExpr,
+          "<<",
+          mockShiftCtx("x << -1"),
+        ),
+      ).toThrow(/Negative shift amount \(-1\) is undefined behavior/);
+    });
+
+    it("should validate hex literals", () => {
+      expect(() =>
+        validator.validateShiftAmount(
+          "u8",
+          mockShiftExpr("0x08"),
+          "<<",
+          mockShiftCtx("x << 0x08"),
+        ),
+      ).toThrow(/Shift amount \(8\) exceeds type width \(8 bits\)/);
+    });
+
+    it("should validate binary literals", () => {
+      expect(() =>
+        validator.validateShiftAmount(
+          "u8",
+          mockShiftExpr("0b1000"),
+          "<<",
+          mockShiftCtx("x << 0b1000"),
+        ),
+      ).toThrow(/Shift amount \(8\) exceeds type width \(8 bits\)/);
+    });
+
+    it("should skip unknown types", () => {
+      expect(() =>
+        validator.validateShiftAmount(
+          "MyCustomType",
+          mockShiftExpr("100"),
+          "<<",
+          mockShiftCtx("x << 100"),
+        ),
+      ).not.toThrow();
+    });
+
+    it("should skip non-constant expressions", () => {
+      const mockNonConstant = {
+        multiplicativeExpression: () => [
+          {
+            unaryExpression: () => [
+              {
+                getText: () => "i",
+                postfixExpression: () => ({
+                  primaryExpression: () => ({
+                    literal: () => null, // Not a literal
+                  }),
+                }),
+                unaryExpression: () => null,
+              },
+            ],
+          },
+        ],
+      } as unknown as Parameters<typeof validator.validateShiftAmount>[1];
+
+      expect(() =>
+        validator.validateShiftAmount(
+          "u8",
+          mockNonConstant,
+          "<<",
+          mockShiftCtx("x << i"),
+        ),
+      ).not.toThrow();
+    });
+
+    it("should handle all integer types", () => {
+      // Test each type boundary
+      const types = [
+        { type: "u8", width: 8 },
+        { type: "i8", width: 8 },
+        { type: "u16", width: 16 },
+        { type: "i16", width: 16 },
+        { type: "u32", width: 32 },
+        { type: "i32", width: 32 },
+        { type: "u64", width: 64 },
+        { type: "i64", width: 64 },
+      ];
+
+      for (const { type, width } of types) {
+        // Max valid shift
+        expect(() =>
+          validator.validateShiftAmount(
+            type,
+            mockShiftExpr(String(width - 1)),
+            "<<",
+            mockShiftCtx(`x << ${width - 1}`),
+          ),
+        ).not.toThrow();
+
+        // Invalid shift (equals width)
+        expect(() =>
+          validator.validateShiftAmount(
+            type,
+            mockShiftExpr(String(width)),
+            "<<",
+            mockShiftCtx(`x << ${width}`),
+          ),
+        ).toThrow(/exceeds type width/);
+      }
+    });
+  });
+
+  // ========================================================================
+  // Callback Assignment Validation (ADR-029)
+  // ========================================================================
+
+  describe("validateCallbackAssignment", () => {
+    it("should skip unknown functions", () => {
+      const mockExpr = { getText: () => "unknownFunc" } as Parameters<
+        typeof validator.validateCallbackAssignment
+      >[1];
+
+      expect(() =>
+        validator.validateCallbackAssignment(
+          "CallbackType",
+          mockExpr,
+          "handler",
+          () => false,
+        ),
+      ).not.toThrow();
+    });
+
+    it("should throw on signature mismatch", () => {
+      // Set up known functions and callback types
+      const knownFunctions = new Set(["myFunc", "CallbackType"]);
+      const callbackTypes = new Map([
+        [
+          "CallbackType",
+          {
+            functionName: "CallbackType",
+            typedefName: "CallbackType_fp",
+            returnType: "void",
+            parameters: [
+              {
+                name: "p",
+                type: "u32",
+                isConst: false,
+                isPointer: false,
+                isArray: false,
+                arrayDims: "",
+              },
+            ],
+          },
+        ],
+        [
+          "myFunc",
+          {
+            functionName: "myFunc",
+            typedefName: "myFunc_fp",
+            returnType: "void",
+            parameters: [
+              {
+                name: "p",
+                type: "i32",
+                isConst: false,
+                isPointer: false,
+                isArray: false,
+                arrayDims: "",
+              },
+            ],
+          },
+        ],
+      ]);
+
+      const deps: ITypeValidatorDeps = {
+        symbols: null,
+        symbolTable,
+        typeRegistry,
+        typeResolver,
+        callbackTypes,
+        knownFunctions,
+        knownGlobals: new Set(),
+        getCurrentScope: () => null,
+        getScopeMembers: () => new Map(),
+        getCurrentParameters: () => new Map(),
+        getLocalVariables: () => new Set(),
+        resolveIdentifier: (name: string) => name,
+        getExpressionType: () => null,
+      };
+
+      const v = new TypeValidator(deps);
+      const mockExpr = { getText: () => "myFunc" } as Parameters<
+        typeof validator.validateCallbackAssignment
+      >[1];
+
+      expect(() =>
+        v.validateCallbackAssignment(
+          "CallbackType",
+          mockExpr,
+          "handler",
+          () => false,
+        ),
+      ).toThrow(/signature does not match/);
+    });
+
+    it("should throw on nominal type mismatch", () => {
+      const knownFunctions = new Set(["funcA", "TypeA"]);
+      const callbackTypes = new Map([
+        [
+          "TypeA",
+          {
+            functionName: "TypeA",
+            typedefName: "TypeA_fp",
+            returnType: "void",
+            parameters: [],
+          },
+        ],
+        [
+          "funcA",
+          {
+            functionName: "funcA",
+            typedefName: "funcA_fp",
+            returnType: "void",
+            parameters: [],
+          },
+        ],
+      ]);
+
+      const deps: ITypeValidatorDeps = {
+        symbols: null,
+        symbolTable,
+        typeRegistry,
+        typeResolver,
+        callbackTypes,
+        knownFunctions,
+        knownGlobals: new Set(),
+        getCurrentScope: () => null,
+        getScopeMembers: () => new Map(),
+        getCurrentParameters: () => new Map(),
+        getLocalVariables: () => new Set(),
+        resolveIdentifier: (name: string) => name,
+        getExpressionType: () => null,
+      };
+
+      const v = new TypeValidator(deps);
+      const mockExpr = { getText: () => "funcA" } as Parameters<
+        typeof validator.validateCallbackAssignment
+      >[1];
+
+      // funcA is used as a field type somewhere
+      expect(() =>
+        v.validateCallbackAssignment(
+          "TypeA",
+          mockExpr,
+          "handler",
+          (fn) => fn === "funcA",
+        ),
+      ).toThrow(/nominal typing/);
+    });
+
+    it("should allow matching signature and type", () => {
+      const knownFunctions = new Set(["myHandler", "HandlerType"]);
+      const callbackTypes = new Map([
+        [
+          "HandlerType",
+          {
+            functionName: "HandlerType",
+            typedefName: "HandlerType_fp",
+            returnType: "void",
+            parameters: [
+              {
+                name: "p",
+                type: "u32",
+                isConst: false,
+                isPointer: false,
+                isArray: false,
+                arrayDims: "",
+              },
+            ],
+          },
+        ],
+        [
+          "myHandler",
+          {
+            functionName: "myHandler",
+            typedefName: "myHandler_fp",
+            returnType: "void",
+            parameters: [
+              {
+                name: "p",
+                type: "u32",
+                isConst: false,
+                isPointer: false,
+                isArray: false,
+                arrayDims: "",
+              },
+            ],
+          },
+        ],
+      ]);
+
+      const deps: ITypeValidatorDeps = {
+        symbols: null,
+        symbolTable,
+        typeRegistry,
+        typeResolver,
+        callbackTypes,
+        knownFunctions,
+        knownGlobals: new Set(),
+        getCurrentScope: () => null,
+        getScopeMembers: () => new Map(),
+        getCurrentParameters: () => new Map(),
+        getLocalVariables: () => new Set(),
+        resolveIdentifier: (name: string) => name,
+        getExpressionType: () => null,
+      };
+
+      const v = new TypeValidator(deps);
+      const mockExpr = { getText: () => "myHandler" } as Parameters<
+        typeof validator.validateCallbackAssignment
+      >[1];
+
+      expect(() =>
+        v.validateCallbackAssignment(
+          "HandlerType",
+          mockExpr,
+          "handler",
+          () => false,
+        ),
+      ).not.toThrow();
+    });
+  });
+
+  // ========================================================================
+  // Ternary Condition Validation (ADR-022)
+  // ========================================================================
+
+  describe("validateTernaryCondition", () => {
+    // Helper to create properly structured mock OrExpressionContext
+    const createMockRelational = (hasBitwiseOr: boolean) => ({
+      bitwiseOrExpression: () => (hasBitwiseOr ? [{}, {}] : [{}]),
+    });
+
+    const createMockEquality = (hasRelational: boolean) => ({
+      relationalExpression: () =>
+        hasRelational ? [{}, {}] : [createMockRelational(false)],
+    });
+
+    const createMockAnd = (hasEquality: boolean, hasRelational: boolean) => ({
+      equalityExpression: () =>
+        hasEquality ? [{}, {}] : [createMockEquality(hasRelational)],
+    });
+
+    const mockOrExprWithComparison = (text: string, hasOperator: string) => {
+      const hasLogicalOr = hasOperator === "||";
+      const hasLogicalAnd = hasOperator === "&&";
+      const hasEquality = hasOperator === "=" || hasOperator === "!=";
+      const hasRelational = ["<", ">", "<=", ">="].includes(hasOperator);
+
+      return {
+        getText: () => text,
+        andExpression: (idx?: number) => {
+          if (hasLogicalOr) {
+            const items = [
+              createMockAnd(false, false),
+              createMockAnd(false, false),
+            ];
+            return idx !== undefined ? items[idx] : items;
+          }
+          const items = [
+            createMockAnd(hasLogicalAnd, hasEquality || hasRelational),
+          ];
+          if (hasEquality) {
+            // For equality, we need relationalExpression to return multiple items
+            items[0] = {
+              equalityExpression: () => [
+                {
+                  relationalExpression: () => [{}, {}],
+                },
+              ],
+            };
+          } else if (hasRelational) {
+            items[0] = {
+              equalityExpression: () => [
+                {
+                  relationalExpression: () => [
+                    {
+                      bitwiseOrExpression: () => [{}, {}],
+                    },
+                  ],
+                },
+              ],
+            };
+          }
+          return idx !== undefined ? items[idx] : items;
+        },
+      } as unknown as Parameters<typeof validator.validateTernaryCondition>[0];
+    };
+
+    it("should allow conditions with || operator", () => {
+      expect(() =>
+        validator.validateTernaryCondition(
+          mockOrExprWithComparison("a || b", "||"),
+        ),
+      ).not.toThrow();
+    });
+
+    it("should allow conditions with && operator", () => {
+      const mockAnd = {
+        getText: () => "a && b",
+        andExpression: (idx?: number) => {
+          const items = [
+            { equalityExpression: () => [{}] },
+            { equalityExpression: () => [{}] },
+          ];
+          return idx !== undefined ? items[idx] : items;
+        },
+      } as unknown as Parameters<typeof validator.validateTernaryCondition>[0];
+
+      expect(() => validator.validateTernaryCondition(mockAnd)).not.toThrow();
+    });
+
+    it("should allow conditions with equality operator", () => {
+      const mockEq = {
+        getText: () => "a = b",
+        andExpression: (idx?: number) => {
+          const items = [
+            {
+              equalityExpression: (i?: number) => {
+                const eqs = [{}, {}];
+                return i !== undefined ? eqs[i] : eqs;
+              },
+            },
+          ];
+          return idx !== undefined ? items[idx] : items;
+        },
+      } as unknown as Parameters<typeof validator.validateTernaryCondition>[0];
+
+      expect(() => validator.validateTernaryCondition(mockEq)).not.toThrow();
+    });
+
+    it("should allow conditions with relational operator", () => {
+      const mockRel = {
+        getText: () => "a > b",
+        andExpression: (idx?: number) => {
+          const items = [
+            {
+              equalityExpression: (i?: number) => {
+                const eqs = [
+                  {
+                    relationalExpression: (j?: number) => {
+                      const rels = [{}, {}];
+                      return j !== undefined ? rels[j] : rels;
+                    },
+                  },
+                ];
+                return i !== undefined ? eqs[i] : eqs;
+              },
+            },
+          ];
+          return idx !== undefined ? items[idx] : items;
+        },
+      } as unknown as Parameters<typeof validator.validateTernaryCondition>[0];
+
+      expect(() => validator.validateTernaryCondition(mockRel)).not.toThrow();
+    });
+
+    it("should reject plain value conditions", () => {
+      const mockValue = {
+        getText: () => "value",
+        andExpression: (idx?: number) => {
+          const items = [
+            {
+              equalityExpression: (i?: number) => {
+                const eqs = [
+                  {
+                    relationalExpression: (j?: number) => {
+                      const rels = [
+                        {
+                          bitwiseOrExpression: () => [{}],
+                        },
+                      ];
+                      return j !== undefined ? rels[j] : rels;
+                    },
+                  },
+                ];
+                return i !== undefined ? eqs[i] : eqs;
+              },
+            },
+          ];
+          return idx !== undefined ? items[idx] : items;
+        },
+      } as unknown as Parameters<typeof validator.validateTernaryCondition>[0];
+
+      expect(() => validator.validateTernaryCondition(mockValue)).toThrow(
+        /Ternary condition must be a boolean expression/,
+      );
+    });
+
+    it("should reject missing andExpression", () => {
+      const mockEmpty = {
+        getText: () => "value",
+        andExpression: (idx?: number) => {
+          const items: object[] = [];
+          return idx !== undefined ? items[idx] : items;
+        },
+      } as unknown as Parameters<typeof validator.validateTernaryCondition>[0];
+
+      expect(() => validator.validateTernaryCondition(mockEmpty)).toThrow(
+        /Ternary condition must be a boolean expression/,
+      );
+    });
+  });
+
+  // ========================================================================
+  // Do-While Condition Validation (ADR-027)
+  // ========================================================================
+
+  describe("validateDoWhileCondition", () => {
+    // Helper to create mock ExpressionContext with proper index-aware methods
+    const mockDoWhileExpr = (text: string, hasOperator: string) => {
+      const hasLogicalOr = hasOperator === "||";
+      const hasLogicalAnd = hasOperator === "&&";
+      const hasEquality = hasOperator === "=" || hasOperator === "!=";
+      const hasRelational = ["<", ">", "<=", ">="].includes(hasOperator);
+
+      const createOrExpr = () => ({
+        getText: () => text,
+        andExpression: (idx?: number) => {
+          if (hasLogicalOr) {
+            const items = [{}, {}];
+            return idx !== undefined ? items[idx] : items;
+          }
+          const items = [
+            {
+              equalityExpression: (i?: number) => {
+                if (hasLogicalAnd) {
+                  const eqs = [{}, {}];
+                  return i !== undefined ? eqs[i] : eqs;
+                }
+                const eqs = [
+                  {
+                    relationalExpression: (j?: number) => {
+                      if (hasEquality) {
+                        const rels = [{}, {}];
+                        return j !== undefined ? rels[j] : rels;
+                      }
+                      const rels = [
+                        {
+                          bitwiseOrExpression: (k?: number) => {
+                            if (hasRelational) {
+                              const bors = [{}, {}];
+                              return k !== undefined ? bors[k] : bors;
+                            }
+                            const bors = [{ getText: () => text }];
+                            return k !== undefined ? bors[k] : bors;
+                          },
+                        },
+                      ];
+                      return j !== undefined ? rels[j] : rels;
+                    },
+                  },
+                ];
+                return i !== undefined ? eqs[i] : eqs;
+              },
+            },
+          ];
+          return idx !== undefined ? items[idx] : items;
+        },
+      });
+
+      return {
+        ternaryExpression: () => ({
+          orExpression: () => [createOrExpr()],
+        }),
+      } as unknown as Parameters<typeof validator.validateDoWhileCondition>[0];
+    };
+
+    it("should allow conditions with || operator", () => {
+      expect(() =>
+        validator.validateDoWhileCondition(mockDoWhileExpr("a || b", "||")),
+      ).not.toThrow();
+    });
+
+    it("should allow conditions with && operator", () => {
+      expect(() =>
+        validator.validateDoWhileCondition(mockDoWhileExpr("a && b", "&&")),
+      ).not.toThrow();
+    });
+
+    it("should allow conditions with equality operator", () => {
+      expect(() =>
+        validator.validateDoWhileCondition(mockDoWhileExpr("count != 0", "!=")),
+      ).not.toThrow();
+    });
+
+    it("should allow conditions with relational operator", () => {
+      expect(() =>
+        validator.validateDoWhileCondition(mockDoWhileExpr("i < 10", "<")),
+      ).not.toThrow();
+    });
+
+    it("should reject plain value conditions", () => {
+      expect(() =>
+        validator.validateDoWhileCondition(mockDoWhileExpr("count", "none")),
+      ).toThrow(/E0701.*do-while condition must be a boolean expression/);
+    });
+
+    it("should reject ternary in do-while condition", () => {
+      const mockTernaryCondition = {
+        ternaryExpression: () => ({
+          orExpression: () => [{}, {}], // Multiple orExpression = ternary
+        }),
+      } as unknown as Parameters<typeof validator.validateDoWhileCondition>[0];
+
+      expect(() =>
+        validator.validateDoWhileCondition(mockTernaryCondition),
+      ).toThrow(/E0701.*not a ternary/);
+    });
+
+    it("should allow boolean literals", () => {
+      const mockBoolLiteral = {
+        ternaryExpression: () => ({
+          orExpression: () => [
+            {
+              getText: () => "true",
+              andExpression: (idx?: number) => {
+                const items = [
+                  {
+                    equalityExpression: (i?: number) => {
+                      const eqs = [
+                        {
+                          relationalExpression: (j?: number) => {
+                            const rels = [
+                              {
+                                bitwiseOrExpression: (k?: number) => {
+                                  const bors = [{ getText: () => "true" }];
+                                  return k !== undefined ? bors[k] : bors;
+                                },
+                              },
+                            ];
+                            return j !== undefined ? rels[j] : rels;
+                          },
+                        },
+                      ];
+                      return i !== undefined ? eqs[i] : eqs;
+                    },
+                  },
+                ];
+                return idx !== undefined ? items[idx] : items;
+              },
+            },
+          ],
+        }),
+      } as unknown as Parameters<typeof validator.validateDoWhileCondition>[0];
+
+      expect(() =>
+        validator.validateDoWhileCondition(mockBoolLiteral),
+      ).not.toThrow();
+    });
+
+    it("should allow negation operator", () => {
+      const mockNegation = {
+        ternaryExpression: () => ({
+          orExpression: () => [
+            {
+              getText: () => "!done",
+              andExpression: (idx?: number) => {
+                const items = [
+                  {
+                    equalityExpression: (i?: number) => {
+                      const eqs = [
+                        {
+                          relationalExpression: (j?: number) => {
+                            const rels = [
+                              {
+                                bitwiseOrExpression: (k?: number) => {
+                                  const bors = [{ getText: () => "!done" }];
+                                  return k !== undefined ? bors[k] : bors;
+                                },
+                              },
+                            ];
+                            return j !== undefined ? rels[j] : rels;
+                          },
+                        },
+                      ];
+                      return i !== undefined ? eqs[i] : eqs;
+                    },
+                  },
+                ];
+                return idx !== undefined ? items[idx] : items;
+              },
+            },
+          ],
+        }),
+      } as unknown as Parameters<typeof validator.validateDoWhileCondition>[0];
+
+      expect(() =>
+        validator.validateDoWhileCondition(mockNegation),
+      ).not.toThrow();
+    });
+
+    it("should allow boolean variable from type registry", () => {
+      typeRegistry.set("isReady", {
+        baseType: "bool",
+        bitWidth: 1,
+        isConst: false,
+        isArray: false,
+      });
+
+      const mockBoolVar = {
+        ternaryExpression: () => ({
+          orExpression: () => [
+            {
+              getText: () => "isReady",
+              andExpression: (idx?: number) => {
+                const items = [
+                  {
+                    equalityExpression: (i?: number) => {
+                      const eqs = [
+                        {
+                          relationalExpression: (j?: number) => {
+                            const rels = [
+                              {
+                                bitwiseOrExpression: (k?: number) => {
+                                  const bors = [{ getText: () => "isReady" }];
+                                  return k !== undefined ? bors[k] : bors;
+                                },
+                              },
+                            ];
+                            return j !== undefined ? rels[j] : rels;
+                          },
+                        },
+                      ];
+                      return i !== undefined ? eqs[i] : eqs;
+                    },
+                  },
+                ];
+                return idx !== undefined ? items[idx] : items;
+              },
+            },
+          ],
+        }),
+      } as unknown as Parameters<typeof validator.validateDoWhileCondition>[0];
+
+      expect(() =>
+        validator.validateDoWhileCondition(mockBoolVar),
+      ).not.toThrow();
+    });
+  });
+
+  // ========================================================================
+  // Function Call in Condition Validation (Issue #254)
+  // ========================================================================
+
+  describe("validateConditionNoFunctionCall", () => {
+    // Helper to create expression with or without function call
+    const mockExprWithFunctionCall = (text: string, hasFuncCall: boolean) => {
+      const postfixOps = hasFuncCall
+        ? [{ argumentList: () => ({}), getText: () => "()" }]
+        : [];
+
+      return {
+        getText: () => text,
+        ternaryExpression: () => ({
+          orExpression: () => [
+            {
+              andExpression: () => [
+                {
+                  equalityExpression: () => [
+                    {
+                      relationalExpression: () => [
+                        {
+                          bitwiseOrExpression: () => [
+                            {
+                              bitwiseXorExpression: () => [
+                                {
+                                  bitwiseAndExpression: () => [
+                                    {
+                                      shiftExpression: () => [
+                                        {
+                                          additiveExpression: () => [
+                                            {
+                                              multiplicativeExpression: () => [
+                                                {
+                                                  unaryExpression: () => [
+                                                    {
+                                                      postfixExpression:
+                                                        () => ({
+                                                          postfixOp: () =>
+                                                            postfixOps,
+                                                        }),
+                                                      unaryExpression: () =>
+                                                        null,
+                                                    },
+                                                  ],
+                                                },
+                                              ],
+                                            },
+                                          ],
+                                        },
+                                      ],
+                                    },
+                                  ],
+                                },
+                              ],
+                            },
+                          ],
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        }),
+      } as unknown as Parameters<
+        typeof validator.validateConditionNoFunctionCall
+      >[0];
+    };
+
+    it("should allow conditions without function calls", () => {
+      expect(() =>
+        validator.validateConditionNoFunctionCall(
+          mockExprWithFunctionCall("a > b", false),
+          "if",
+        ),
+      ).not.toThrow();
+    });
+
+    it("should reject conditions with function calls", () => {
+      expect(() =>
+        validator.validateConditionNoFunctionCall(
+          mockExprWithFunctionCall("isReady()", true),
+          "if",
+        ),
+      ).toThrow(/E0702.*Function call in 'if' condition is not allowed/);
+    });
+
+    it("should specify condition type in error message", () => {
+      expect(() =>
+        validator.validateConditionNoFunctionCall(
+          mockExprWithFunctionCall("getValue()", true),
+          "while",
+        ),
+      ).toThrow(/Function call in 'while' condition/);
+
+      expect(() =>
+        validator.validateConditionNoFunctionCall(
+          mockExprWithFunctionCall("check()", true),
+          "for",
+        ),
+      ).toThrow(/Function call in 'for' condition/);
+    });
+  });
+
+  describe("validateTernaryConditionNoFunctionCall", () => {
+    const mockOrExprWithFunctionCall = (text: string, hasFuncCall: boolean) => {
+      const postfixOps = hasFuncCall
+        ? [{ argumentList: () => ({}), getText: () => "()" }]
+        : [];
+
+      return {
+        getText: () => text,
+        andExpression: () => [
+          {
+            equalityExpression: () => [
+              {
+                relationalExpression: () => [
+                  {
+                    bitwiseOrExpression: () => [
+                      {
+                        bitwiseXorExpression: () => [
+                          {
+                            bitwiseAndExpression: () => [
+                              {
+                                shiftExpression: () => [
+                                  {
+                                    additiveExpression: () => [
+                                      {
+                                        multiplicativeExpression: () => [
+                                          {
+                                            unaryExpression: () => [
+                                              {
+                                                postfixExpression: () => ({
+                                                  postfixOp: () => postfixOps,
+                                                }),
+                                                unaryExpression: () => null,
+                                              },
+                                            ],
+                                          },
+                                        ],
+                                      },
+                                    ],
+                                  },
+                                ],
+                              },
+                            ],
+                          },
+                        ],
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      } as unknown as Parameters<
+        typeof validator.validateTernaryConditionNoFunctionCall
+      >[0];
+    };
+
+    it("should allow ternary conditions without function calls", () => {
+      expect(() =>
+        validator.validateTernaryConditionNoFunctionCall(
+          mockOrExprWithFunctionCall("x > 0", false),
+        ),
+      ).not.toThrow();
+    });
+
+    it("should reject ternary conditions with function calls", () => {
+      expect(() =>
+        validator.validateTernaryConditionNoFunctionCall(
+          mockOrExprWithFunctionCall("isValid()", true),
+        ),
+      ).toThrow(/E0702.*Function call in 'ternary' condition/);
+    });
+  });
+
+  // ========================================================================
+  // Switch Statement Validation (ADR-025)
+  // ========================================================================
+
+  describe("validateSwitchStatement", () => {
+    // Helper to create mock switch context
+    const createMockSwitchCtx = (
+      cases: { labels: string[] }[],
+      hasDefault: boolean,
+      defaultCount?: number,
+    ) => ({
+      switchCase: () =>
+        cases.map((c) => ({
+          caseLabel: () =>
+            c.labels.map((label) => ({
+              qualifiedType: () => null,
+              IDENTIFIER: () => ({ getText: () => label }),
+              INTEGER_LITERAL: () => null,
+              HEX_LITERAL: () => null,
+              BINARY_LITERAL: () => null,
+              CHAR_LITERAL: () => null,
+              children: null,
+            })),
+        })),
+      defaultCase: () =>
+        hasDefault
+          ? {
+              INTEGER_LITERAL: () =>
+                defaultCount !== undefined
+                  ? { getText: () => String(defaultCount) }
+                  : null,
+            }
+          : null,
+    });
+
+    const mockExpr = (_type: string | null) =>
+      ({}) as Parameters<typeof validator.validateSwitchStatement>[1];
+
+    it("should reject boolean switch expression (MISRA 16.7)", () => {
+      const deps: ITypeValidatorDeps = {
+        symbols: null,
+        symbolTable,
+        typeRegistry,
+        typeResolver,
+        callbackTypes: new Map(),
+        knownFunctions: new Set(),
+        knownGlobals: new Set(),
+        getCurrentScope: () => null,
+        getScopeMembers: () => new Map(),
+        getCurrentParameters: () => new Map(),
+        getLocalVariables: () => new Set(),
+        resolveIdentifier: (name: string) => name,
+        getExpressionType: () => "bool",
+      };
+
+      const v = new TypeValidator(deps);
+      const ctx = createMockSwitchCtx(
+        [{ labels: ["A"] }, { labels: ["B"] }],
+        false,
+      );
+
+      expect(() =>
+        v.validateSwitchStatement(
+          ctx as unknown as Parameters<typeof v.validateSwitchStatement>[0],
+          mockExpr("bool"),
+        ),
+      ).toThrow(/Cannot switch on boolean type.*MISRA 16\.7/);
+    });
+
+    it("should reject switch with less than 2 clauses (MISRA 16.6)", () => {
+      const deps: ITypeValidatorDeps = {
+        symbols: null,
+        symbolTable,
+        typeRegistry,
+        typeResolver,
+        callbackTypes: new Map(),
+        knownFunctions: new Set(),
+        knownGlobals: new Set(),
+        getCurrentScope: () => null,
+        getScopeMembers: () => new Map(),
+        getCurrentParameters: () => new Map(),
+        getLocalVariables: () => new Set(),
+        resolveIdentifier: (name: string) => name,
+        getExpressionType: () => "u32",
+      };
+
+      const v = new TypeValidator(deps);
+      const ctx = createMockSwitchCtx([{ labels: ["A"] }], false);
+
+      expect(() =>
+        v.validateSwitchStatement(
+          ctx as unknown as Parameters<typeof v.validateSwitchStatement>[0],
+          mockExpr("u32"),
+        ),
+      ).toThrow(/Switch requires at least 2 clauses.*MISRA 16\.6/);
+    });
+
+    it("should allow switch with 2+ clauses", () => {
+      const mockSymbols = {
+        knownEnums: new Set<string>(),
+      };
+
+      const deps: ITypeValidatorDeps = {
+        symbols: mockSymbols as unknown as ITypeValidatorDeps["symbols"],
+        symbolTable,
+        typeRegistry,
+        typeResolver,
+        callbackTypes: new Map(),
+        knownFunctions: new Set(),
+        knownGlobals: new Set(),
+        getCurrentScope: () => null,
+        getScopeMembers: () => new Map(),
+        getCurrentParameters: () => new Map(),
+        getLocalVariables: () => new Set(),
+        resolveIdentifier: (name: string) => name,
+        getExpressionType: () => "u32",
+      };
+
+      const v = new TypeValidator(deps);
+      const ctx = createMockSwitchCtx(
+        [{ labels: ["A"] }, { labels: ["B"] }],
+        false,
+      );
+
+      expect(() =>
+        v.validateSwitchStatement(
+          ctx as unknown as Parameters<typeof v.validateSwitchStatement>[0],
+          mockExpr("u32"),
+        ),
+      ).not.toThrow();
+    });
+
+    it("should count default as a clause", () => {
+      const mockSymbols = {
+        knownEnums: new Set<string>(),
+      };
+
+      const deps: ITypeValidatorDeps = {
+        symbols: mockSymbols as unknown as ITypeValidatorDeps["symbols"],
+        symbolTable,
+        typeRegistry,
+        typeResolver,
+        callbackTypes: new Map(),
+        knownFunctions: new Set(),
+        knownGlobals: new Set(),
+        getCurrentScope: () => null,
+        getScopeMembers: () => new Map(),
+        getCurrentParameters: () => new Map(),
+        getLocalVariables: () => new Set(),
+        resolveIdentifier: (name: string) => name,
+        getExpressionType: () => "u32",
+      };
+
+      const v = new TypeValidator(deps);
+      // One case + default = 2 clauses
+      const ctx = createMockSwitchCtx([{ labels: ["A"] }], true);
+
+      expect(() =>
+        v.validateSwitchStatement(
+          ctx as unknown as Parameters<typeof v.validateSwitchStatement>[0],
+          mockExpr("u32"),
+        ),
+      ).not.toThrow();
+    });
+
+    it("should reject duplicate case values", () => {
+      const deps: ITypeValidatorDeps = {
+        symbols: null,
+        symbolTable,
+        typeRegistry,
+        typeResolver,
+        callbackTypes: new Map(),
+        knownFunctions: new Set(),
+        knownGlobals: new Set(),
+        getCurrentScope: () => null,
+        getScopeMembers: () => new Map(),
+        getCurrentParameters: () => new Map(),
+        getLocalVariables: () => new Set(),
+        resolveIdentifier: (name: string) => name,
+        getExpressionType: () => "u32",
+      };
+
+      const v = new TypeValidator(deps);
+      const ctx = createMockSwitchCtx(
+        [{ labels: ["A"] }, { labels: ["A"] }], // Duplicate
+        false,
+      );
+
+      expect(() =>
+        v.validateSwitchStatement(
+          ctx as unknown as Parameters<typeof v.validateSwitchStatement>[0],
+          mockExpr("u32"),
+        ),
+      ).toThrow(/Duplicate case value 'A'/);
+    });
+  });
+
+  // ========================================================================
+  // Enum Exhaustiveness Validation (ADR-025)
+  // ========================================================================
+
+  describe("validateEnumExhaustiveness", () => {
+    // Helper for creating mock switch context for enum exhaustiveness
+    const createMockSwitchCtx = (
+      cases: { labels: string[] }[],
+      hasDefault: boolean,
+      defaultCount?: number,
+    ) => ({
+      switchCase: () =>
+        cases.map((c) => ({
+          caseLabel: () => c.labels.map(() => ({})),
+        })),
+      defaultCase: () =>
+        hasDefault
+          ? {
+              INTEGER_LITERAL: () =>
+                defaultCount !== undefined
+                  ? { getText: () => String(defaultCount) }
+                  : null,
+            }
+          : null,
+    });
+
+    it("should require all variants covered without default", () => {
+      // Create a mock symbols with enum members
+      const mockSymbols = {
+        enumMembers: new Map([
+          [
+            "Color",
+            new Map([
+              ["Red", 0],
+              ["Green", 1],
+              ["Blue", 2],
+            ]),
+          ],
+        ]),
+        knownEnums: new Set(["Color"]),
+        knownRegisters: new Set<string>(),
+      };
+
+      const deps: ITypeValidatorDeps = {
+        symbols: mockSymbols as unknown as ITypeValidatorDeps["symbols"],
+        symbolTable,
+        typeRegistry,
+        typeResolver,
+        callbackTypes: new Map(),
+        knownFunctions: new Set(),
+        knownGlobals: new Set(),
+        getCurrentScope: () => null,
+        getScopeMembers: () => new Map(),
+        getCurrentParameters: () => new Map(),
+        getLocalVariables: () => new Set(),
+        resolveIdentifier: (name: string) => name,
+        getExpressionType: () => "Color",
+      };
+
+      const v = new TypeValidator(deps);
+      const ctx = createMockSwitchCtx(
+        [{ labels: ["Red"] }, { labels: ["Green"] }], // Missing Blue
+        false,
+      );
+
+      expect(() =>
+        v.validateEnumExhaustiveness(
+          ctx as unknown as Parameters<typeof v.validateEnumExhaustiveness>[0],
+          "Color",
+          ctx.switchCase() as unknown as Parameters<
+            typeof v.validateEnumExhaustiveness
+          >[2],
+          null,
+        ),
+      ).toThrow(/Non-exhaustive switch on Color.*missing 1/);
+    });
+
+    it("should allow all variants covered", () => {
+      const mockSymbols = {
+        enumMembers: new Map([
+          [
+            "Color",
+            new Map([
+              ["Red", 0],
+              ["Green", 1],
+              ["Blue", 2],
+            ]),
+          ],
+        ]),
+      };
+
+      const deps: ITypeValidatorDeps = {
+        symbols: mockSymbols as unknown as ITypeValidatorDeps["symbols"],
+        symbolTable,
+        typeRegistry,
+        typeResolver,
+        callbackTypes: new Map(),
+        knownFunctions: new Set(),
+        knownGlobals: new Set(),
+        getCurrentScope: () => null,
+        getScopeMembers: () => new Map(),
+        getCurrentParameters: () => new Map(),
+        getLocalVariables: () => new Set(),
+        resolveIdentifier: (name: string) => name,
+        getExpressionType: () => "Color",
+      };
+
+      const v = new TypeValidator(deps);
+      const ctx = createMockSwitchCtx(
+        [{ labels: ["Red"] }, { labels: ["Green"] }, { labels: ["Blue"] }],
+        false,
+      );
+
+      expect(() =>
+        v.validateEnumExhaustiveness(
+          ctx as unknown as Parameters<typeof v.validateEnumExhaustiveness>[0],
+          "Color",
+          ctx.switchCase() as unknown as Parameters<
+            typeof v.validateEnumExhaustiveness
+          >[2],
+          null,
+        ),
+      ).not.toThrow();
+    });
+
+    it("should allow plain default without checking exhaustiveness", () => {
+      const mockSymbols = {
+        enumMembers: new Map([
+          [
+            "Color",
+            new Map([
+              ["Red", 0],
+              ["Green", 1],
+              ["Blue", 2],
+            ]),
+          ],
+        ]),
+      };
+
+      const deps: ITypeValidatorDeps = {
+        symbols: mockSymbols as unknown as ITypeValidatorDeps["symbols"],
+        symbolTable,
+        typeRegistry,
+        typeResolver,
+        callbackTypes: new Map(),
+        knownFunctions: new Set(),
+        knownGlobals: new Set(),
+        getCurrentScope: () => null,
+        getScopeMembers: () => new Map(),
+        getCurrentParameters: () => new Map(),
+        getLocalVariables: () => new Set(),
+        resolveIdentifier: (name: string) => name,
+        getExpressionType: () => "Color",
+      };
+
+      const v = new TypeValidator(deps);
+      const ctx = createMockSwitchCtx(
+        [{ labels: ["Red"] }], // Only one variant
+        true, // Has default
+      );
+
+      expect(() =>
+        v.validateEnumExhaustiveness(
+          ctx as unknown as Parameters<typeof v.validateEnumExhaustiveness>[0],
+          "Color",
+          ctx.switchCase() as unknown as Parameters<
+            typeof v.validateEnumExhaustiveness
+          >[2],
+          ctx.defaultCase() as unknown as Parameters<
+            typeof v.validateEnumExhaustiveness
+          >[3],
+        ),
+      ).not.toThrow();
+    });
+
+    it("should validate default(n) counts correctly", () => {
+      const mockSymbols = {
+        enumMembers: new Map([
+          [
+            "Color",
+            new Map([
+              ["Red", 0],
+              ["Green", 1],
+              ["Blue", 2],
+            ]),
+          ],
+        ]),
+      };
+
+      const deps: ITypeValidatorDeps = {
+        symbols: mockSymbols as unknown as ITypeValidatorDeps["symbols"],
+        symbolTable,
+        typeRegistry,
+        typeResolver,
+        callbackTypes: new Map(),
+        knownFunctions: new Set(),
+        knownGlobals: new Set(),
+        getCurrentScope: () => null,
+        getScopeMembers: () => new Map(),
+        getCurrentParameters: () => new Map(),
+        getLocalVariables: () => new Set(),
+        resolveIdentifier: (name: string) => name,
+        getExpressionType: () => "Color",
+      };
+
+      const v = new TypeValidator(deps);
+      // 1 explicit case + default(2) = 3 variants covered
+      const ctx = createMockSwitchCtx(
+        [{ labels: ["Red"] }],
+        true,
+        2, // default(2)
+      );
+
+      expect(() =>
+        v.validateEnumExhaustiveness(
+          ctx as unknown as Parameters<typeof v.validateEnumExhaustiveness>[0],
+          "Color",
+          ctx.switchCase() as unknown as Parameters<
+            typeof v.validateEnumExhaustiveness
+          >[2],
+          ctx.defaultCase() as unknown as Parameters<
+            typeof v.validateEnumExhaustiveness
+          >[3],
+        ),
+      ).not.toThrow();
+    });
+
+    it("should reject incorrect default(n) count", () => {
+      const mockSymbols = {
+        enumMembers: new Map([
+          [
+            "Color",
+            new Map([
+              ["Red", 0],
+              ["Green", 1],
+              ["Blue", 2],
+            ]),
+          ],
+        ]),
+      };
+
+      const deps: ITypeValidatorDeps = {
+        symbols: mockSymbols as unknown as ITypeValidatorDeps["symbols"],
+        symbolTable,
+        typeRegistry,
+        typeResolver,
+        callbackTypes: new Map(),
+        knownFunctions: new Set(),
+        knownGlobals: new Set(),
+        getCurrentScope: () => null,
+        getScopeMembers: () => new Map(),
+        getCurrentParameters: () => new Map(),
+        getLocalVariables: () => new Set(),
+        resolveIdentifier: (name: string) => name,
+        getExpressionType: () => "Color",
+      };
+
+      const v = new TypeValidator(deps);
+      // 1 explicit case + default(1) = 2, but need 3
+      const ctx = createMockSwitchCtx(
+        [{ labels: ["Red"] }],
+        true,
+        1, // default(1) - wrong, should be 2
+      );
+
+      expect(() =>
+        v.validateEnumExhaustiveness(
+          ctx as unknown as Parameters<typeof v.validateEnumExhaustiveness>[0],
+          "Color",
+          ctx.switchCase() as unknown as Parameters<
+            typeof v.validateEnumExhaustiveness
+          >[2],
+          ctx.defaultCase() as unknown as Parameters<
+            typeof v.validateEnumExhaustiveness
+          >[3],
+        ),
+      ).toThrow(/switch covers 2 of 3 Color variants/);
+    });
+
+    it("should handle unknown enum gracefully", () => {
+      const mockSymbols = {
+        enumMembers: new Map(), // No enums defined
+      };
+
+      const deps: ITypeValidatorDeps = {
+        symbols: mockSymbols as unknown as ITypeValidatorDeps["symbols"],
+        symbolTable,
+        typeRegistry,
+        typeResolver,
+        callbackTypes: new Map(),
+        knownFunctions: new Set(),
+        knownGlobals: new Set(),
+        getCurrentScope: () => null,
+        getScopeMembers: () => new Map(),
+        getCurrentParameters: () => new Map(),
+        getLocalVariables: () => new Set(),
+        resolveIdentifier: (name: string) => name,
+        getExpressionType: () => "UnknownEnum",
+      };
+
+      const v = new TypeValidator(deps);
+      const ctx = createMockSwitchCtx([{ labels: ["X"] }], false);
+
+      // Should return early without throwing
+      expect(() =>
+        v.validateEnumExhaustiveness(
+          ctx as unknown as Parameters<typeof v.validateEnumExhaustiveness>[0],
+          "UnknownEnum",
+          ctx.switchCase() as unknown as Parameters<
+            typeof v.validateEnumExhaustiveness
+          >[2],
+          null,
+        ),
+      ).not.toThrow();
+    });
+  });
+});

--- a/src/codegen/generators/support/CommentUtils.test.ts
+++ b/src/codegen/generators/support/CommentUtils.test.ts
@@ -1,0 +1,222 @@
+/**
+ * Unit tests for CommentUtils
+ * Tests the comment handling utility functions
+ */
+import { describe, it, expect, vi } from "vitest";
+import commentUtils from "./CommentUtils";
+import CommentExtractor from "../../CommentExtractor";
+import CommentFormatter from "../../CommentFormatter";
+import ECommentType from "../../types/ECommentType";
+import IComment from "../../types/IComment";
+
+const {
+  getLeadingComments,
+  getTrailingComments,
+  formatLeadingComments,
+  formatTrailingComment,
+} = commentUtils;
+
+describe("CommentUtils", () => {
+  // ========================================================================
+  // getLeadingComments
+  // ========================================================================
+
+  describe("getLeadingComments", () => {
+    it("should return empty array when extractor is null", () => {
+      const ctx = { start: { tokenIndex: 5 } };
+      const result = getLeadingComments(ctx, null);
+      expect(result).toEqual([]);
+    });
+
+    it("should return empty array when ctx.start is null", () => {
+      const extractor = {
+        getCommentsBefore: vi.fn(),
+      } as unknown as CommentExtractor;
+      const ctx = { start: null };
+
+      const result = getLeadingComments(ctx, extractor);
+
+      expect(result).toEqual([]);
+      expect(extractor.getCommentsBefore).not.toHaveBeenCalled();
+    });
+
+    it("should return empty array when ctx.start is undefined", () => {
+      const extractor = {
+        getCommentsBefore: vi.fn(),
+      } as unknown as CommentExtractor;
+      const ctx = {};
+
+      const result = getLeadingComments(ctx, extractor);
+
+      expect(result).toEqual([]);
+    });
+
+    it("should call extractor.getCommentsBefore with token index", () => {
+      const mockComments: IComment[] = [
+        {
+          type: ECommentType.Doc,
+          raw: "/// documentation",
+          content: "documentation",
+          line: 1,
+          column: 0,
+          tokenIndex: 0,
+        },
+      ];
+      const extractor = {
+        getCommentsBefore: vi.fn().mockReturnValue(mockComments),
+      } as unknown as CommentExtractor;
+      const ctx = { start: { tokenIndex: 10 } };
+
+      const result = getLeadingComments(ctx, extractor);
+
+      expect(extractor.getCommentsBefore).toHaveBeenCalledWith(10);
+      expect(result).toBe(mockComments);
+    });
+  });
+
+  // ========================================================================
+  // getTrailingComments
+  // ========================================================================
+
+  describe("getTrailingComments", () => {
+    it("should return empty array when extractor is null", () => {
+      const ctx = { stop: { tokenIndex: 5 } };
+      const result = getTrailingComments(ctx, null);
+      expect(result).toEqual([]);
+    });
+
+    it("should return empty array when ctx.stop is null", () => {
+      const extractor = {
+        getCommentsAfter: vi.fn(),
+      } as unknown as CommentExtractor;
+      const ctx = { stop: null };
+
+      const result = getTrailingComments(ctx, extractor);
+
+      expect(result).toEqual([]);
+      expect(extractor.getCommentsAfter).not.toHaveBeenCalled();
+    });
+
+    it("should return empty array when ctx.stop is undefined", () => {
+      const extractor = {
+        getCommentsAfter: vi.fn(),
+      } as unknown as CommentExtractor;
+      const ctx = {};
+
+      const result = getTrailingComments(ctx, extractor);
+
+      expect(result).toEqual([]);
+    });
+
+    it("should call extractor.getCommentsAfter with token index", () => {
+      const mockComments: IComment[] = [
+        {
+          type: ECommentType.Line,
+          raw: "// inline",
+          content: " inline",
+          line: 5,
+          column: 20,
+          tokenIndex: 15,
+        },
+      ];
+      const extractor = {
+        getCommentsAfter: vi.fn().mockReturnValue(mockComments),
+      } as unknown as CommentExtractor;
+      const ctx = { stop: { tokenIndex: 14 } };
+
+      const result = getTrailingComments(ctx, extractor);
+
+      expect(extractor.getCommentsAfter).toHaveBeenCalledWith(14);
+      expect(result).toBe(mockComments);
+    });
+  });
+
+  // ========================================================================
+  // formatLeadingComments
+  // ========================================================================
+
+  describe("formatLeadingComments", () => {
+    it("should return empty array when no comments", () => {
+      const formatter = {
+        formatLeadingComments: vi.fn(),
+      } as unknown as CommentFormatter;
+
+      const result = formatLeadingComments([], formatter, "  ");
+
+      expect(result).toEqual([]);
+      expect(formatter.formatLeadingComments).not.toHaveBeenCalled();
+    });
+
+    it("should call formatter.formatLeadingComments with comments and indent", () => {
+      const comments: IComment[] = [
+        {
+          type: ECommentType.Doc,
+          raw: "///docs",
+          content: "docs",
+          line: 1,
+          column: 0,
+          tokenIndex: 0,
+        },
+      ];
+      const formattedComments = ["    /** docs */"];
+      const formatter = {
+        formatLeadingComments: vi.fn().mockReturnValue(formattedComments),
+      } as unknown as CommentFormatter;
+
+      const result = formatLeadingComments(comments, formatter, "    ");
+
+      expect(formatter.formatLeadingComments).toHaveBeenCalledWith(
+        comments,
+        "    ",
+      );
+      expect(result).toBe(formattedComments);
+    });
+  });
+
+  // ========================================================================
+  // formatTrailingComment
+  // ========================================================================
+
+  describe("formatTrailingComment", () => {
+    it("should return empty string when no comments", () => {
+      const formatter = {
+        formatTrailingComment: vi.fn(),
+      } as unknown as CommentFormatter;
+
+      const result = formatTrailingComment([], formatter);
+
+      expect(result).toBe("");
+      expect(formatter.formatTrailingComment).not.toHaveBeenCalled();
+    });
+
+    it("should format only the first comment", () => {
+      const comments: IComment[] = [
+        {
+          type: ECommentType.Line,
+          raw: "// first",
+          content: " first",
+          line: 1,
+          column: 10,
+          tokenIndex: 5,
+        },
+        {
+          type: ECommentType.Line,
+          raw: "// second",
+          content: " second",
+          line: 1,
+          column: 20,
+          tokenIndex: 6,
+        },
+      ];
+      const formatter = {
+        formatTrailingComment: vi.fn().mockReturnValue("  // first"),
+      } as unknown as CommentFormatter;
+
+      const result = formatTrailingComment(comments, formatter);
+
+      expect(formatter.formatTrailingComment).toHaveBeenCalledTimes(1);
+      expect(formatter.formatTrailingComment).toHaveBeenCalledWith(comments[0]);
+      expect(result).toBe("  // first");
+    });
+  });
+});

--- a/src/pipeline/detectCppSyntax.test.ts
+++ b/src/pipeline/detectCppSyntax.test.ts
@@ -1,0 +1,151 @@
+/**
+ * Unit tests for detectCppSyntax
+ * Issue #208: Detect C++ syntax requiring C++14 parser
+ */
+import { describe, it, expect } from "vitest";
+import detectCppSyntax from "./detectCppSyntax";
+
+describe("detectCppSyntax", () => {
+  describe("C++ indicators - should return true", () => {
+    it("should detect typed enums (C++14)", () => {
+      expect(
+        detectCppSyntax("enum Color : uint8_t { RED, GREEN, BLUE };"),
+      ).toBe(true);
+      expect(detectCppSyntax("enum Status:int{OK,ERROR};")).toBe(true);
+      expect(
+        detectCppSyntax(`
+        enum EPressureType : uint8_t {
+          GAUGE = 0,
+          ABSOLUTE = 1
+        };
+      `),
+      ).toBe(true);
+    });
+
+    it("should detect class inheritance", () => {
+      expect(detectCppSyntax("class Derived : public Base {};")).toBe(true);
+      expect(detectCppSyntax("class Foo : private Bar {};")).toBe(true);
+      expect(detectCppSyntax("class Foo : protected Bar {};")).toBe(true);
+    });
+
+    it("should detect struct inheritance", () => {
+      expect(detectCppSyntax("struct Derived : public Base {};")).toBe(true);
+    });
+
+    it("should detect namespaces", () => {
+      expect(detectCppSyntax("namespace MyLib { int foo(); }")).toBe(true);
+      expect(
+        detectCppSyntax(`
+        namespace sensors {
+          void init();
+        }
+      `),
+      ).toBe(true);
+    });
+
+    it("should detect templates", () => {
+      expect(detectCppSyntax("template<typename T> class Container {};")).toBe(
+        true,
+      );
+      expect(detectCppSyntax("template <class T> T max(T a, T b);")).toBe(true);
+      expect(detectCppSyntax("template< int N > struct Array {};")).toBe(true);
+    });
+
+    it("should detect access specifiers", () => {
+      expect(
+        detectCppSyntax(`
+        class Foo {
+        public:
+          int x;
+        };
+      `),
+      ).toBe(true);
+      expect(
+        detectCppSyntax(`
+        class Bar {
+        private:
+          int y;
+        };
+      `),
+      ).toBe(true);
+      expect(
+        detectCppSyntax(`
+        class Baz {
+        protected:
+          int z;
+        };
+      `),
+      ).toBe(true);
+    });
+  });
+
+  describe("Pure C - should return false", () => {
+    it("should return false for simple C structs", () => {
+      expect(
+        detectCppSyntax(`
+        struct Point {
+          int x;
+          int y;
+        };
+      `),
+      ).toBe(false);
+    });
+
+    it("should return false for C enums without type annotation", () => {
+      expect(detectCppSyntax("enum Color { RED, GREEN, BLUE };")).toBe(false);
+      expect(
+        detectCppSyntax(`
+        typedef enum {
+          STATE_IDLE,
+          STATE_RUNNING
+        } State;
+      `),
+      ).toBe(false);
+    });
+
+    it("should return false for C functions", () => {
+      expect(detectCppSyntax("int add(int a, int b);")).toBe(false);
+      expect(detectCppSyntax("void* malloc(size_t size);")).toBe(false);
+    });
+
+    it("should return false for C typedefs", () => {
+      expect(detectCppSyntax("typedef unsigned char uint8_t;")).toBe(false);
+      expect(detectCppSyntax("typedef struct Node* NodePtr;")).toBe(false);
+    });
+
+    it("should return false for empty content", () => {
+      expect(detectCppSyntax("")).toBe(false);
+    });
+
+    it("should return false for C comments and preprocessor", () => {
+      expect(
+        detectCppSyntax(`
+        /* This is a C header */
+        #ifndef HEADER_H
+        #define HEADER_H
+
+        int value;
+
+        #endif
+      `),
+      ).toBe(false);
+    });
+  });
+
+  describe("edge cases", () => {
+    it("should not false-positive on 'public' in comments", () => {
+      // The regex requires 'public:' at line start with possible whitespace
+      expect(
+        detectCppSyntax(`
+        // This struct is public
+        struct Foo { int x; };
+      `),
+      ).toBe(false);
+    });
+
+    it("should not false-positive on variable names containing keywords", () => {
+      expect(detectCppSyntax("int namespace_count;")).toBe(false);
+      expect(detectCppSyntax("int template_id;")).toBe(false);
+    });
+  });
+});

--- a/src/symbols/SymbolTable.test.ts
+++ b/src/symbols/SymbolTable.test.ts
@@ -1,11 +1,12 @@
 /**
- * Unit tests for SymbolTable conflict detection
+ * Unit tests for SymbolTable
  * Issue #221: Function parameters should not cause conflicts
  */
 import { describe, it, expect, beforeEach } from "vitest";
 import SymbolTable from "./SymbolTable";
 import ESymbolKind from "../types/ESymbolKind";
 import ESourceLanguage from "../types/ESourceLanguage";
+import ISymbol from "../types/ISymbol";
 
 describe("SymbolTable", () => {
   let symbolTable: SymbolTable;
@@ -13,6 +14,593 @@ describe("SymbolTable", () => {
   beforeEach(() => {
     symbolTable = new SymbolTable();
   });
+
+  // ========================================================================
+  // Basic Symbol Operations
+  // ========================================================================
+
+  describe("addSymbol and getSymbol", () => {
+    it("should add and retrieve a symbol by name", () => {
+      const symbol: ISymbol = {
+        name: "myVar",
+        kind: ESymbolKind.Variable,
+        sourceFile: "test.cnx",
+        sourceLine: 1,
+        sourceLanguage: ESourceLanguage.CNext,
+        isExported: true,
+      };
+
+      symbolTable.addSymbol(symbol);
+      const retrieved = symbolTable.getSymbol("myVar");
+
+      expect(retrieved).toBeDefined();
+      expect(retrieved?.name).toBe("myVar");
+      expect(retrieved?.kind).toBe(ESymbolKind.Variable);
+    });
+
+    it("should return undefined for non-existent symbol", () => {
+      const retrieved = symbolTable.getSymbol("nonExistent");
+      expect(retrieved).toBeUndefined();
+    });
+
+    it("should return first symbol when multiple exist with same name", () => {
+      symbolTable.addSymbol({
+        name: "duplicate",
+        kind: ESymbolKind.Variable,
+        sourceFile: "first.cnx",
+        sourceLine: 1,
+        sourceLanguage: ESourceLanguage.CNext,
+        isExported: true,
+      });
+
+      symbolTable.addSymbol({
+        name: "duplicate",
+        kind: ESymbolKind.Variable,
+        sourceFile: "second.cnx",
+        sourceLine: 5,
+        sourceLanguage: ESourceLanguage.CNext,
+        isExported: true,
+      });
+
+      const retrieved = symbolTable.getSymbol("duplicate");
+      expect(retrieved?.sourceFile).toBe("first.cnx");
+    });
+  });
+
+  describe("addSymbols", () => {
+    it("should add multiple symbols at once", () => {
+      const symbols: ISymbol[] = [
+        {
+          name: "var1",
+          kind: ESymbolKind.Variable,
+          sourceFile: "test.cnx",
+          sourceLine: 1,
+          sourceLanguage: ESourceLanguage.CNext,
+          isExported: true,
+        },
+        {
+          name: "var2",
+          kind: ESymbolKind.Variable,
+          sourceFile: "test.cnx",
+          sourceLine: 2,
+          sourceLanguage: ESourceLanguage.CNext,
+          isExported: true,
+        },
+        {
+          name: "func1",
+          kind: ESymbolKind.Function,
+          sourceFile: "test.cnx",
+          sourceLine: 3,
+          sourceLanguage: ESourceLanguage.CNext,
+          isExported: true,
+        },
+      ];
+
+      symbolTable.addSymbols(symbols);
+
+      expect(symbolTable.getSymbol("var1")).toBeDefined();
+      expect(symbolTable.getSymbol("var2")).toBeDefined();
+      expect(symbolTable.getSymbol("func1")).toBeDefined();
+      expect(symbolTable.size).toBe(3);
+    });
+  });
+
+  describe("hasSymbol", () => {
+    it("should return true for existing symbol", () => {
+      symbolTable.addSymbol({
+        name: "exists",
+        kind: ESymbolKind.Variable,
+        sourceFile: "test.cnx",
+        sourceLine: 1,
+        sourceLanguage: ESourceLanguage.CNext,
+        isExported: true,
+      });
+
+      expect(symbolTable.hasSymbol("exists")).toBe(true);
+    });
+
+    it("should return false for non-existent symbol", () => {
+      expect(symbolTable.hasSymbol("notHere")).toBe(false);
+    });
+  });
+
+  describe("getOverloads", () => {
+    it("should return all symbols with same name", () => {
+      symbolTable.addSymbol({
+        name: "overloaded",
+        kind: ESymbolKind.Function,
+        signature: "int(int)",
+        sourceFile: "test.cpp",
+        sourceLine: 1,
+        sourceLanguage: ESourceLanguage.Cpp,
+        isExported: true,
+      });
+
+      symbolTable.addSymbol({
+        name: "overloaded",
+        kind: ESymbolKind.Function,
+        signature: "int(int, int)",
+        sourceFile: "test.cpp",
+        sourceLine: 5,
+        sourceLanguage: ESourceLanguage.Cpp,
+        isExported: true,
+      });
+
+      const overloads = symbolTable.getOverloads("overloaded");
+      expect(overloads.length).toBe(2);
+      expect(overloads[0].signature).toBe("int(int)");
+      expect(overloads[1].signature).toBe("int(int, int)");
+    });
+
+    it("should return empty array for non-existent symbol", () => {
+      const overloads = symbolTable.getOverloads("noSuchFunction");
+      expect(overloads).toEqual([]);
+    });
+  });
+
+  describe("getAllSymbols", () => {
+    it("should return all symbols in the table", () => {
+      symbolTable.addSymbol({
+        name: "a",
+        kind: ESymbolKind.Variable,
+        sourceFile: "test.cnx",
+        sourceLine: 1,
+        sourceLanguage: ESourceLanguage.CNext,
+        isExported: true,
+      });
+
+      symbolTable.addSymbol({
+        name: "b",
+        kind: ESymbolKind.Function,
+        sourceFile: "test.cnx",
+        sourceLine: 2,
+        sourceLanguage: ESourceLanguage.CNext,
+        isExported: true,
+      });
+
+      const all = symbolTable.getAllSymbols();
+      expect(all.length).toBe(2);
+      expect(all.map((s) => s.name).sort()).toEqual(["a", "b"]);
+    });
+
+    it("should return empty array for empty table", () => {
+      expect(symbolTable.getAllSymbols()).toEqual([]);
+    });
+  });
+
+  describe("size", () => {
+    it("should return 0 for empty table", () => {
+      expect(symbolTable.size).toBe(0);
+    });
+
+    it("should return correct count including duplicates", () => {
+      symbolTable.addSymbol({
+        name: "sym1",
+        kind: ESymbolKind.Variable,
+        sourceFile: "test.cnx",
+        sourceLine: 1,
+        sourceLanguage: ESourceLanguage.CNext,
+        isExported: true,
+      });
+
+      symbolTable.addSymbol({
+        name: "sym1",
+        kind: ESymbolKind.Variable,
+        sourceFile: "test2.cnx",
+        sourceLine: 1,
+        sourceLanguage: ESourceLanguage.CNext,
+        isExported: true,
+      });
+
+      symbolTable.addSymbol({
+        name: "sym2",
+        kind: ESymbolKind.Function,
+        sourceFile: "test.cnx",
+        sourceLine: 5,
+        sourceLanguage: ESourceLanguage.CNext,
+        isExported: true,
+      });
+
+      expect(symbolTable.size).toBe(3);
+    });
+  });
+
+  describe("clear", () => {
+    it("should remove all symbols", () => {
+      symbolTable.addSymbol({
+        name: "toBeCleared",
+        kind: ESymbolKind.Variable,
+        sourceFile: "test.cnx",
+        sourceLine: 1,
+        sourceLanguage: ESourceLanguage.CNext,
+        isExported: true,
+      });
+
+      symbolTable.addStructField("MyStruct", "field1", "uint32_t");
+      symbolTable.markNeedsStructKeyword("CStruct");
+      symbolTable.addEnumBitWidth("MyEnum", 8);
+
+      symbolTable.clear();
+
+      expect(symbolTable.size).toBe(0);
+      expect(symbolTable.getSymbol("toBeCleared")).toBeUndefined();
+      expect(
+        symbolTable.getStructFieldType("MyStruct", "field1"),
+      ).toBeUndefined();
+      expect(symbolTable.checkNeedsStructKeyword("CStruct")).toBe(false);
+      expect(symbolTable.getEnumBitWidth("MyEnum")).toBeUndefined();
+    });
+  });
+
+  // ========================================================================
+  // File-based and Language-based Queries
+  // ========================================================================
+
+  describe("getSymbolsByFile", () => {
+    it("should return symbols from a specific file", () => {
+      symbolTable.addSymbol({
+        name: "inFile1",
+        kind: ESymbolKind.Variable,
+        sourceFile: "file1.cnx",
+        sourceLine: 1,
+        sourceLanguage: ESourceLanguage.CNext,
+        isExported: true,
+      });
+
+      symbolTable.addSymbol({
+        name: "alsoInFile1",
+        kind: ESymbolKind.Function,
+        sourceFile: "file1.cnx",
+        sourceLine: 5,
+        sourceLanguage: ESourceLanguage.CNext,
+        isExported: true,
+      });
+
+      symbolTable.addSymbol({
+        name: "inFile2",
+        kind: ESymbolKind.Variable,
+        sourceFile: "file2.cnx",
+        sourceLine: 1,
+        sourceLanguage: ESourceLanguage.CNext,
+        isExported: true,
+      });
+
+      const file1Symbols = symbolTable.getSymbolsByFile("file1.cnx");
+      expect(file1Symbols.length).toBe(2);
+      expect(file1Symbols.map((s) => s.name).sort()).toEqual([
+        "alsoInFile1",
+        "inFile1",
+      ]);
+    });
+
+    it("should return empty array for unknown file", () => {
+      expect(symbolTable.getSymbolsByFile("unknown.cnx")).toEqual([]);
+    });
+  });
+
+  describe("getSymbolsByLanguage", () => {
+    it("should return symbols from a specific language", () => {
+      symbolTable.addSymbol({
+        name: "cnextVar",
+        kind: ESymbolKind.Variable,
+        sourceFile: "test.cnx",
+        sourceLine: 1,
+        sourceLanguage: ESourceLanguage.CNext,
+        isExported: true,
+      });
+
+      symbolTable.addSymbol({
+        name: "cVar",
+        kind: ESymbolKind.Variable,
+        sourceFile: "test.c",
+        sourceLine: 1,
+        sourceLanguage: ESourceLanguage.C,
+        isExported: true,
+      });
+
+      symbolTable.addSymbol({
+        name: "cppVar",
+        kind: ESymbolKind.Variable,
+        sourceFile: "test.cpp",
+        sourceLine: 1,
+        sourceLanguage: ESourceLanguage.Cpp,
+        isExported: true,
+      });
+
+      const cnextSymbols = symbolTable.getSymbolsByLanguage(
+        ESourceLanguage.CNext,
+      );
+      expect(cnextSymbols.length).toBe(1);
+      expect(cnextSymbols[0].name).toBe("cnextVar");
+
+      const cSymbols = symbolTable.getSymbolsByLanguage(ESourceLanguage.C);
+      expect(cSymbols.length).toBe(1);
+      expect(cSymbols[0].name).toBe("cVar");
+    });
+
+    it("should return empty array when no symbols match language", () => {
+      symbolTable.addSymbol({
+        name: "cnextOnly",
+        kind: ESymbolKind.Variable,
+        sourceFile: "test.cnx",
+        sourceLine: 1,
+        sourceLanguage: ESourceLanguage.CNext,
+        isExported: true,
+      });
+
+      expect(symbolTable.getSymbolsByLanguage(ESourceLanguage.C)).toEqual([]);
+    });
+  });
+
+  // ========================================================================
+  // Struct Field Operations
+  // ========================================================================
+
+  describe("struct field operations", () => {
+    it("should add and retrieve struct field type", () => {
+      symbolTable.addStructField("Point", "x", "int32_t");
+      symbolTable.addStructField("Point", "y", "int32_t");
+
+      expect(symbolTable.getStructFieldType("Point", "x")).toBe("int32_t");
+      expect(symbolTable.getStructFieldType("Point", "y")).toBe("int32_t");
+    });
+
+    it("should return undefined for unknown struct or field", () => {
+      symbolTable.addStructField("Point", "x", "int32_t");
+
+      expect(symbolTable.getStructFieldType("Unknown", "x")).toBeUndefined();
+      expect(symbolTable.getStructFieldType("Point", "z")).toBeUndefined();
+    });
+
+    it("should add struct field with array dimensions", () => {
+      symbolTable.addStructField("Buffer", "data", "uint8_t", [256]);
+      symbolTable.addStructField("Matrix", "values", "float", [4, 4]);
+
+      const bufferField = symbolTable.getStructFieldInfo("Buffer", "data");
+      expect(bufferField?.type).toBe("uint8_t");
+      expect(bufferField?.arrayDimensions).toEqual([256]);
+
+      const matrixField = symbolTable.getStructFieldInfo("Matrix", "values");
+      expect(matrixField?.type).toBe("float");
+      expect(matrixField?.arrayDimensions).toEqual([4, 4]);
+    });
+
+    it("should get all fields for a struct", () => {
+      symbolTable.addStructField("Person", "name", "char*");
+      symbolTable.addStructField("Person", "age", "uint8_t");
+      symbolTable.addStructField("Person", "id", "uint32_t");
+
+      const fields = symbolTable.getStructFields("Person");
+      expect(fields).toBeDefined();
+      expect(fields?.size).toBe(3);
+      expect(fields?.get("name")?.type).toBe("char*");
+      expect(fields?.get("age")?.type).toBe("uint8_t");
+    });
+
+    it("should return undefined for unknown struct in getStructFields", () => {
+      expect(symbolTable.getStructFields("Unknown")).toBeUndefined();
+    });
+
+    it("should get all struct fields for serialization", () => {
+      symbolTable.addStructField("A", "x", "int");
+      symbolTable.addStructField("B", "y", "float");
+
+      const allFields = symbolTable.getAllStructFields();
+      expect(allFields.size).toBe(2);
+      expect(allFields.has("A")).toBe(true);
+      expect(allFields.has("B")).toBe(true);
+    });
+
+    it("should restore struct fields from cache", () => {
+      const cached = new Map<
+        string,
+        Map<string, { type: string; arrayDimensions?: number[] }>
+      >();
+      const pointFields = new Map();
+      pointFields.set("x", { type: "int32_t" });
+      pointFields.set("y", { type: "int32_t" });
+      cached.set("Point", pointFields);
+
+      symbolTable.restoreStructFields(cached);
+
+      expect(symbolTable.getStructFieldType("Point", "x")).toBe("int32_t");
+      expect(symbolTable.getStructFieldType("Point", "y")).toBe("int32_t");
+    });
+
+    it("should merge restored struct fields with existing", () => {
+      symbolTable.addStructField("Point", "x", "int32_t");
+
+      const cached = new Map<
+        string,
+        Map<string, { type: string; arrayDimensions?: number[] }>
+      >();
+      const pointFields = new Map();
+      pointFields.set("z", { type: "int32_t" });
+      cached.set("Point", pointFields);
+
+      symbolTable.restoreStructFields(cached);
+
+      expect(symbolTable.getStructFieldType("Point", "x")).toBe("int32_t");
+      expect(symbolTable.getStructFieldType("Point", "z")).toBe("int32_t");
+    });
+  });
+
+  describe("getStructNamesByFile", () => {
+    it("should return struct names defined in a file", () => {
+      // Add a symbol for the struct
+      symbolTable.addSymbol({
+        name: "Point",
+        kind: ESymbolKind.Struct,
+        sourceFile: "geometry.h",
+        sourceLine: 1,
+        sourceLanguage: ESourceLanguage.C,
+        isExported: true,
+      });
+
+      // Register struct fields (which marks it as having struct data)
+      symbolTable.addStructField("Point", "x", "int");
+      symbolTable.addStructField("Point", "y", "int");
+
+      const structNames = symbolTable.getStructNamesByFile("geometry.h");
+      expect(structNames).toContain("Point");
+    });
+
+    it("should return empty array for file with no structs", () => {
+      symbolTable.addSymbol({
+        name: "someVar",
+        kind: ESymbolKind.Variable,
+        sourceFile: "vars.cnx",
+        sourceLine: 1,
+        sourceLanguage: ESourceLanguage.CNext,
+        isExported: true,
+      });
+
+      expect(symbolTable.getStructNamesByFile("vars.cnx")).toEqual([]);
+    });
+
+    it("should return empty array for unknown file", () => {
+      expect(symbolTable.getStructNamesByFile("nonexistent.cnx")).toEqual([]);
+    });
+  });
+
+  // ========================================================================
+  // Struct Keyword Tracking (Issue #196)
+  // ========================================================================
+
+  describe("struct keyword tracking", () => {
+    it("should mark and check if struct needs keyword", () => {
+      symbolTable.markNeedsStructKeyword("NamedPoint");
+
+      expect(symbolTable.checkNeedsStructKeyword("NamedPoint")).toBe(true);
+      expect(symbolTable.checkNeedsStructKeyword("OtherStruct")).toBe(false);
+    });
+
+    it("should get all structs needing keyword", () => {
+      symbolTable.markNeedsStructKeyword("Struct1");
+      symbolTable.markNeedsStructKeyword("Struct2");
+      symbolTable.markNeedsStructKeyword("Struct3");
+
+      const all = symbolTable.getAllNeedsStructKeyword();
+      expect(all.length).toBe(3);
+      expect(all.sort()).toEqual(["Struct1", "Struct2", "Struct3"]);
+    });
+
+    it("should restore struct keyword set from cache", () => {
+      symbolTable.restoreNeedsStructKeyword(["CachedStruct1", "CachedStruct2"]);
+
+      expect(symbolTable.checkNeedsStructKeyword("CachedStruct1")).toBe(true);
+      expect(symbolTable.checkNeedsStructKeyword("CachedStruct2")).toBe(true);
+      expect(symbolTable.checkNeedsStructKeyword("NotCached")).toBe(false);
+    });
+  });
+
+  // ========================================================================
+  // Enum Bit Width Tracking (Issue #208)
+  // ========================================================================
+
+  describe("enum bit width tracking", () => {
+    it("should add and get enum bit width", () => {
+      symbolTable.addEnumBitWidth("EPressureType", 8);
+      symbolTable.addEnumBitWidth("ELargeEnum", 32);
+
+      expect(symbolTable.getEnumBitWidth("EPressureType")).toBe(8);
+      expect(symbolTable.getEnumBitWidth("ELargeEnum")).toBe(32);
+    });
+
+    it("should return undefined for unknown enum", () => {
+      expect(symbolTable.getEnumBitWidth("UnknownEnum")).toBeUndefined();
+    });
+
+    it("should get all enum bit widths for serialization", () => {
+      symbolTable.addEnumBitWidth("Enum8", 8);
+      symbolTable.addEnumBitWidth("Enum16", 16);
+
+      const allWidths = symbolTable.getAllEnumBitWidths();
+      expect(allWidths.size).toBe(2);
+      expect(allWidths.get("Enum8")).toBe(8);
+      expect(allWidths.get("Enum16")).toBe(16);
+    });
+
+    it("should restore enum bit widths from cache", () => {
+      const cached = new Map<string, number>();
+      cached.set("CachedEnum1", 8);
+      cached.set("CachedEnum2", 16);
+
+      symbolTable.restoreEnumBitWidths(cached);
+
+      expect(symbolTable.getEnumBitWidth("CachedEnum1")).toBe(8);
+      expect(symbolTable.getEnumBitWidth("CachedEnum2")).toBe(16);
+    });
+  });
+
+  // ========================================================================
+  // hasConflict Method
+  // ========================================================================
+
+  describe("hasConflict", () => {
+    it("should return true when symbol has conflicts", () => {
+      symbolTable.addSymbol({
+        name: "conflicted",
+        kind: ESymbolKind.Variable,
+        sourceFile: "file1.cnx",
+        sourceLine: 1,
+        sourceLanguage: ESourceLanguage.CNext,
+        isExported: true,
+      });
+
+      symbolTable.addSymbol({
+        name: "conflicted",
+        kind: ESymbolKind.Variable,
+        sourceFile: "file2.cnx",
+        sourceLine: 1,
+        sourceLanguage: ESourceLanguage.CNext,
+        isExported: true,
+      });
+
+      expect(symbolTable.hasConflict("conflicted")).toBe(true);
+    });
+
+    it("should return false when symbol has no conflicts", () => {
+      symbolTable.addSymbol({
+        name: "unique",
+        kind: ESymbolKind.Variable,
+        sourceFile: "file1.cnx",
+        sourceLine: 1,
+        sourceLanguage: ESourceLanguage.CNext,
+        isExported: true,
+      });
+
+      expect(symbolTable.hasConflict("unique")).toBe(false);
+    });
+
+    it("should return false for non-existent symbol", () => {
+      expect(symbolTable.hasConflict("doesNotExist")).toBe(false);
+    });
+  });
+
+  // ========================================================================
+  // Conflict Detection (existing tests)
+  // ========================================================================
 
   describe("conflict detection", () => {
     it("should detect conflicts between two global variables with same name", () => {
@@ -194,6 +782,198 @@ describe("SymbolTable", () => {
       });
 
       // No conflicts - both 'x' are function parameters with different parents
+      const conflicts = symbolTable.getConflicts();
+      expect(conflicts.length).toBe(0);
+    });
+
+    it("should detect cross-language conflict between C-Next and C", () => {
+      // Same symbol in C-Next and C = ERROR
+      symbolTable.addSymbol({
+        name: "sharedVar",
+        kind: ESymbolKind.Variable,
+        sourceFile: "module.cnx",
+        sourceLine: 1,
+        sourceLanguage: ESourceLanguage.CNext,
+        isExported: true,
+      });
+
+      symbolTable.addSymbol({
+        name: "sharedVar",
+        kind: ESymbolKind.Variable,
+        sourceFile: "legacy.c",
+        sourceLine: 10,
+        sourceLanguage: ESourceLanguage.C,
+        isExported: true,
+      });
+
+      const conflicts = symbolTable.getConflicts();
+      expect(conflicts.length).toBe(1);
+      expect(conflicts[0].symbolName).toBe("sharedVar");
+      expect(conflicts[0].severity).toBe("error");
+      expect(conflicts[0].message).toContain("defined in multiple languages");
+    });
+
+    it("should detect cross-language conflict between C-Next and C++", () => {
+      // Same symbol in C-Next and C++ = ERROR
+      symbolTable.addSymbol({
+        name: "sharedFunc",
+        kind: ESymbolKind.Function,
+        sourceFile: "module.cnx",
+        sourceLine: 1,
+        sourceLanguage: ESourceLanguage.CNext,
+        isExported: true,
+      });
+
+      symbolTable.addSymbol({
+        name: "sharedFunc",
+        kind: ESymbolKind.Function,
+        sourceFile: "driver.cpp",
+        sourceLine: 20,
+        sourceLanguage: ESourceLanguage.Cpp,
+        isExported: true,
+      });
+
+      const conflicts = symbolTable.getConflicts();
+      expect(conflicts.length).toBe(1);
+      expect(conflicts[0].symbolName).toBe("sharedFunc");
+      expect(conflicts[0].severity).toBe("error");
+    });
+
+    it("should allow same symbol in C and C++ (common pattern)", () => {
+      // Same symbol in C and C++ is typically OK (e.g., header included by both)
+      symbolTable.addSymbol({
+        name: "commonSymbol",
+        kind: ESymbolKind.Variable,
+        sourceFile: "shared.c",
+        sourceLine: 1,
+        sourceLanguage: ESourceLanguage.C,
+        isExported: true,
+      });
+
+      symbolTable.addSymbol({
+        name: "commonSymbol",
+        kind: ESymbolKind.Variable,
+        sourceFile: "wrapper.cpp",
+        sourceLine: 5,
+        sourceLanguage: ESourceLanguage.Cpp,
+        isExported: true,
+      });
+
+      const conflicts = symbolTable.getConflicts();
+      expect(conflicts.length).toBe(0);
+    });
+
+    it("should allow C++ function overloads with different signatures", () => {
+      symbolTable.addSymbol({
+        name: "process",
+        kind: ESymbolKind.Function,
+        signature: "void(int)",
+        sourceFile: "utils.cpp",
+        sourceLine: 1,
+        sourceLanguage: ESourceLanguage.Cpp,
+        isExported: true,
+      });
+
+      symbolTable.addSymbol({
+        name: "process",
+        kind: ESymbolKind.Function,
+        signature: "void(int, int)",
+        sourceFile: "utils.cpp",
+        sourceLine: 10,
+        sourceLanguage: ESourceLanguage.Cpp,
+        isExported: true,
+      });
+
+      symbolTable.addSymbol({
+        name: "process",
+        kind: ESymbolKind.Function,
+        signature: "void(float)",
+        sourceFile: "utils.cpp",
+        sourceLine: 20,
+        sourceLanguage: ESourceLanguage.Cpp,
+        isExported: true,
+      });
+
+      const conflicts = symbolTable.getConflicts();
+      expect(conflicts.length).toBe(0);
+    });
+
+    it("should not count extern declarations as conflicts", () => {
+      // extern declarations are not definitions
+      symbolTable.addSymbol({
+        name: "externVar",
+        kind: ESymbolKind.Variable,
+        sourceFile: "header.h",
+        sourceLine: 1,
+        sourceLanguage: ESourceLanguage.C,
+        isExported: true,
+        isDeclaration: true, // extern declaration
+      });
+
+      symbolTable.addSymbol({
+        name: "externVar",
+        kind: ESymbolKind.Variable,
+        sourceFile: "impl.c",
+        sourceLine: 10,
+        sourceLanguage: ESourceLanguage.C,
+        isExported: true,
+        isDeclaration: false, // actual definition
+      });
+
+      const conflicts = symbolTable.getConflicts();
+      expect(conflicts.length).toBe(0);
+    });
+
+    it("should detect conflicts for scope functions with same qualified name", () => {
+      // Two scope functions (non-variable with parent) with same name = conflict
+      symbolTable.addSymbol({
+        name: "Math_calculate",
+        kind: ESymbolKind.Function,
+        type: "i32",
+        sourceFile: "math1.cnx",
+        sourceLine: 1,
+        sourceLanguage: ESourceLanguage.CNext,
+        isExported: true,
+        parent: "Math",
+      });
+
+      symbolTable.addSymbol({
+        name: "Math_calculate",
+        kind: ESymbolKind.Function,
+        type: "i32",
+        sourceFile: "math2.cnx",
+        sourceLine: 5,
+        sourceLanguage: ESourceLanguage.CNext,
+        isExported: true,
+        parent: "Math",
+      });
+
+      const conflicts = symbolTable.getConflicts();
+      expect(conflicts.length).toBe(1);
+      expect(conflicts[0].symbolName).toBe("Math_calculate");
+    });
+
+    it("should allow multiple C definitions (fallback case)", () => {
+      // Multiple C definitions - no conflict detection for C-only (handled by C compiler)
+      symbolTable.addSymbol({
+        name: "cOnlyVar",
+        kind: ESymbolKind.Variable,
+        sourceFile: "file1.c",
+        sourceLine: 1,
+        sourceLanguage: ESourceLanguage.C,
+        isExported: true,
+      });
+
+      symbolTable.addSymbol({
+        name: "cOnlyVar",
+        kind: ESymbolKind.Variable,
+        sourceFile: "file2.c",
+        sourceLine: 5,
+        sourceLanguage: ESourceLanguage.C,
+        isExported: true,
+      });
+
+      // C-only conflicts are left to the C compiler to detect
       const conflicts = symbolTable.getConflicts();
       expect(conflicts.length).toBe(0);
     });

--- a/src/symbols/SymbolUtils.test.ts
+++ b/src/symbols/SymbolUtils.test.ts
@@ -1,0 +1,137 @@
+/**
+ * Unit tests for SymbolUtils
+ * Tests utility functions for C/C++ symbol collection
+ */
+import { describe, it, expect } from "vitest";
+import SymbolUtils from "./SymbolUtils";
+
+describe("SymbolUtils", () => {
+  // ========================================================================
+  // parseArrayDimensions
+  // ========================================================================
+
+  describe("parseArrayDimensions", () => {
+    it("should parse single dimension", () => {
+      expect(SymbolUtils.parseArrayDimensions("data[8]")).toEqual([8]);
+      expect(SymbolUtils.parseArrayDimensions("buffer[256]")).toEqual([256]);
+      expect(SymbolUtils.parseArrayDimensions("[32]")).toEqual([32]);
+    });
+
+    it("should parse multiple dimensions", () => {
+      expect(SymbolUtils.parseArrayDimensions("matrix[4][4]")).toEqual([4, 4]);
+      expect(SymbolUtils.parseArrayDimensions("cube[2][3][4]")).toEqual([
+        2, 3, 4,
+      ]);
+    });
+
+    it("should return empty array for non-array", () => {
+      expect(SymbolUtils.parseArrayDimensions("value")).toEqual([]);
+      expect(SymbolUtils.parseArrayDimensions("int x")).toEqual([]);
+    });
+
+    it("should handle text with other content", () => {
+      expect(SymbolUtils.parseArrayDimensions("uint8_t data[10];")).toEqual([
+        10,
+      ]);
+      expect(
+        SymbolUtils.parseArrayDimensions("char buffer[BUFFER_SIZE]"),
+      ).toEqual([]);
+    });
+  });
+
+  // ========================================================================
+  // getTypeWidth
+  // ========================================================================
+
+  describe("getTypeWidth", () => {
+    describe("stdint.h types", () => {
+      it("should return 8 for 8-bit types", () => {
+        expect(SymbolUtils.getTypeWidth("uint8_t")).toBe(8);
+        expect(SymbolUtils.getTypeWidth("int8_t")).toBe(8);
+      });
+
+      it("should return 16 for 16-bit types", () => {
+        expect(SymbolUtils.getTypeWidth("uint16_t")).toBe(16);
+        expect(SymbolUtils.getTypeWidth("int16_t")).toBe(16);
+      });
+
+      it("should return 32 for 32-bit types", () => {
+        expect(SymbolUtils.getTypeWidth("uint32_t")).toBe(32);
+        expect(SymbolUtils.getTypeWidth("int32_t")).toBe(32);
+      });
+
+      it("should return 64 for 64-bit types", () => {
+        expect(SymbolUtils.getTypeWidth("uint64_t")).toBe(64);
+        expect(SymbolUtils.getTypeWidth("int64_t")).toBe(64);
+      });
+    });
+
+    describe("standard C types", () => {
+      it("should return correct width for char types", () => {
+        expect(SymbolUtils.getTypeWidth("char")).toBe(8);
+        expect(SymbolUtils.getTypeWidth("signed char")).toBe(8);
+        expect(SymbolUtils.getTypeWidth("unsigned char")).toBe(8);
+      });
+
+      it("should return correct width for short types", () => {
+        expect(SymbolUtils.getTypeWidth("short")).toBe(16);
+        expect(SymbolUtils.getTypeWidth("short int")).toBe(16);
+        expect(SymbolUtils.getTypeWidth("signed short")).toBe(16);
+        expect(SymbolUtils.getTypeWidth("unsigned short")).toBe(16);
+      });
+
+      it("should return correct width for int types", () => {
+        expect(SymbolUtils.getTypeWidth("int")).toBe(32);
+        expect(SymbolUtils.getTypeWidth("signed int")).toBe(32);
+        expect(SymbolUtils.getTypeWidth("unsigned")).toBe(32);
+        expect(SymbolUtils.getTypeWidth("unsigned int")).toBe(32);
+      });
+
+      it("should return correct width for long types", () => {
+        expect(SymbolUtils.getTypeWidth("long")).toBe(32);
+        expect(SymbolUtils.getTypeWidth("long int")).toBe(32);
+        expect(SymbolUtils.getTypeWidth("unsigned long")).toBe(32);
+      });
+
+      it("should return correct width for long long types", () => {
+        expect(SymbolUtils.getTypeWidth("long long")).toBe(64);
+        expect(SymbolUtils.getTypeWidth("long long int")).toBe(64);
+        expect(SymbolUtils.getTypeWidth("unsigned long long")).toBe(64);
+      });
+    });
+
+    describe("unknown types", () => {
+      it("should return 0 for unknown types", () => {
+        expect(SymbolUtils.getTypeWidth("MyStruct")).toBe(0);
+        expect(SymbolUtils.getTypeWidth("float")).toBe(0);
+        expect(SymbolUtils.getTypeWidth("double")).toBe(0);
+        expect(SymbolUtils.getTypeWidth("void")).toBe(0);
+      });
+    });
+  });
+
+  // ========================================================================
+  // Reserved Field Names
+  // ========================================================================
+
+  describe("isReservedFieldName", () => {
+    it("should return true for reserved names", () => {
+      expect(SymbolUtils.isReservedFieldName("length")).toBe(true);
+    });
+
+    it("should return false for non-reserved names", () => {
+      expect(SymbolUtils.isReservedFieldName("x")).toBe(false);
+      expect(SymbolUtils.isReservedFieldName("data")).toBe(false);
+      expect(SymbolUtils.isReservedFieldName("size")).toBe(false);
+      expect(SymbolUtils.isReservedFieldName("count")).toBe(false);
+    });
+  });
+
+  describe("getReservedFieldNames", () => {
+    it("should return array of reserved names", () => {
+      const reserved = SymbolUtils.getReservedFieldNames();
+      expect(Array.isArray(reserved)).toBe(true);
+      expect(reserved).toContain("length");
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add **428+ unit tests** for core TypeScript modules
- Coverage improved from **~2% to ~9%** overall
- Establishes solid testing foundation for the transpiler codebase

## New Test Files
| File | Tests | Coverage |
|------|-------|----------|
| `TypeValidator.test.ts` | 100 | 76.62% |
| `TypeResolver.test.ts` | 83 | 94.64% |
| `CommentExtractor.test.ts` | 25 | 100% |
| `CommentFormatter.test.ts` | 24 | 100% |
| `CommentUtils.test.ts` | 12 | 100% |
| `detectCppSyntax.test.ts` | 14 | 100% |
| `SymbolUtils.test.ts` | 17 | 100% |

## Extended Test Files
- `SymbolTable.test.ts` - Extended from ~10 to 49 tests (100% coverage)
- `memberAccessChain.test.ts` - Added type tracking edge cases (100% coverage)

## Coverage Highlights
Files at **100% statement coverage**:
- SymbolTable, SymbolUtils, detectCppSyntax
- memberAccessChain, CommentFormatter, CommentExtractor, CommentUtils

## Test Categories
- **Type validation**: MISRA compliance, switch statements, ternary/do-while conditions
- **Type resolution**: Literal types, expression types, narrowing/sign conversions
- **Comment handling**: ANTLR extraction, MISRA 3.1/3.2 validation, Doxygen formatting
- **Symbol management**: Cross-language conflicts, struct fields, enum bit widths

## Test plan
- [x] `npm run unit` passes (438 tests)
- [x] `npm run unit:coverage` shows improved coverage
- [x] Pre-commit hooks pass (prettier, oxlint)

🤖 Generated with [Claude Code](https://claude.com/claude-code)