### PR TITLE
fix: correct C++ class array initialization and header declarations (#379)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2953,6 +2953,7 @@
       "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/chai": "^5.2.2",
         "@vitest/expect": "3.2.4",

--- a/src/codegen/CodeGenerator.ts
+++ b/src/codegen/CodeGenerator.ts
@@ -5749,8 +5749,26 @@ export default class CodeGenerator implements IOrchestrator {
     typeCtx: Parser.TypeContext,
     isArray: boolean,
   ): string {
-    // Arrays and structs/classes use {0}
+    // Issue #379: Arrays need element type checking for C++ classes
+    // C++ class arrays must use {} instead of {0}
     if (isArray) {
+      // Check if element type is a C++ class or template type
+      if (typeCtx.userType()) {
+        const typeName = typeCtx.userType()!.getText();
+        // Use {} for C++ types (external libraries with constructors)
+        if (this.isCppType(typeName)) {
+          return "{}";
+        }
+        // In C++ mode, unknown user types may have non-trivial constructors
+        if (this.cppMode && !this._isKnownStruct(typeName)) {
+          return "{}";
+        }
+      }
+      // Template types are always C++ classes
+      if (typeCtx.templateType()) {
+        return "{}";
+      }
+      // Default: POD arrays use {0}
       return "{0}";
     }
 

--- a/src/codegen/HeaderGenerator.ts
+++ b/src/codegen/HeaderGenerator.ts
@@ -184,7 +184,12 @@ class HeaderGenerator {
         const cType = sym.type ? mapType(sym.type) : "int";
         // Issue #288: Include const qualifier for const variables
         const constPrefix = sym.isConst ? "const " : "";
-        lines.push(`extern ${constPrefix}${cType} ${sym.name};`);
+        // Issue #379: Include array dimensions for extern declarations
+        const arrayDims =
+          sym.isArray && sym.arrayDimensions
+            ? sym.arrayDimensions.map((d) => `[${d}]`).join("")
+            : "";
+        lines.push(`extern ${constPrefix}${cType} ${sym.name}${arrayDims};`);
       }
       lines.push("");
     }

--- a/src/symbols/CNextSymbolCollector.ts
+++ b/src/symbols/CNextSymbolCollector.ts
@@ -410,12 +410,24 @@ class CNextSymbolCollector {
     // Check for array (ADR-036: arrayDimension() now returns array for multi-dim)
     const arrayDims = varDecl.arrayDimension();
     let size: number | undefined;
+    let isArray = false;
+    const arrayDimensions: string[] = [];
+
     if (arrayDims.length > 0) {
-      // Get first dimension size for symbol tracking
-      const dimText = arrayDims[0].getText();
-      const match = dimText.match(/\[(\d+)\]/);
-      if (match) {
-        size = parseInt(match[1], 10);
+      isArray = true;
+      // Issue #379: Capture all array dimensions for header generation
+      for (const dim of arrayDims) {
+        const dimText = dim.getText();
+        // Extract dimension value (e.g., "[4]" -> "4", "[CONST]" -> "CONST")
+        const match = dimText.match(/\[([^\]]*)\]/);
+        if (match) {
+          arrayDimensions.push(match[1]);
+        }
+      }
+      // Get first dimension size for legacy size field
+      const firstMatch = arrayDims[0].getText().match(/\[(\d+)\]/);
+      if (firstMatch) {
+        size = parseInt(firstMatch[1], 10);
       }
     }
 
@@ -432,6 +444,8 @@ class CNextSymbolCollector {
       isExported: isPublic,
       parent,
       size,
+      isArray,
+      arrayDimensions: isArray ? arrayDimensions : undefined,
       isConst,
     });
   }

--- a/src/types/ISymbol.ts
+++ b/src/types/ISymbol.ts
@@ -51,6 +51,12 @@ interface ISymbol {
   /** For arrays: element count. For integers: bit width */
   size?: number;
 
+  /** Issue #379: Whether this variable is an array */
+  isArray?: boolean;
+
+  /** Issue #379: Array dimensions for extern declarations (e.g., ["4"] or ["4", "8"]) */
+  arrayDimensions?: string[];
+
   /** Issue #288: Whether this variable is const (for extern declarations) */
   isConst?: boolean;
 }

--- a/tests/functions/array-struct-member-cpp.expected.c
+++ b/tests/functions/array-struct-member-cpp.expected.c
@@ -14,7 +14,7 @@
 #include <stdbool.h>
 
 // Array of external C structs with bool/enum members
-SensorReading sensors[4] = {0};
+SensorReading sensors[4] = {};
 
 uint32_t process(uint32_t crc, uint8_t byte) {
     return crc ^ byte;


### PR DESCRIPTION
## Summary

- Fix C++ class arrays using `= {}` instead of invalid `= {0}` initialization
- Fix header extern declarations to include array dimensions
- Update `_getZeroInitializer()` to check element type for arrays
- Add `isArray` and `arrayDimensions` fields to ISymbol for header generation

Closes #379

## Test plan

- [x] All 699 existing tests pass
- [x] `tests/functions/array-struct-member-cpp.expected.c` updated to use `= {}`
- [x] Verified array extern declarations include dimensions in headers

🤖 Generated with [Claude Code](https://claude.com/claude-code)