### PR TITLE
test: add unit tests for semantic analyzers and extract ScopeStack

### DIFF
--- a/src/analysis/DivisionByZeroAnalyzer.test.ts
+++ b/src/analysis/DivisionByZeroAnalyzer.test.ts
@@ -1,0 +1,331 @@
+/**
+ * Unit tests for DivisionByZeroAnalyzer
+ * Tests detection of division and modulo by zero at compile time (ADR-051)
+ */
+import { describe, it, expect } from "vitest";
+import { CharStream, CommonTokenStream } from "antlr4ng";
+import { CNextLexer } from "../parser/grammar/CNextLexer";
+import { CNextParser } from "../parser/grammar/CNextParser";
+import DivisionByZeroAnalyzer from "./DivisionByZeroAnalyzer";
+
+/**
+ * Helper to parse C-Next code and return the AST
+ */
+function parse(source: string) {
+  const charStream = CharStream.fromString(source);
+  const lexer = new CNextLexer(charStream);
+  const tokenStream = new CommonTokenStream(lexer);
+  const parser = new CNextParser(tokenStream);
+  return parser.program();
+}
+
+describe("DivisionByZeroAnalyzer", () => {
+  // ========================================================================
+  // Phase 1: Literal Zero Detection
+  // ========================================================================
+
+  describe("literal zero detection", () => {
+    it("should detect division by literal zero", () => {
+      const code = `
+        void main() {
+          u32 x <- 10 / 0;
+        }
+      `;
+      const tree = parse(code);
+      const analyzer = new DivisionByZeroAnalyzer();
+      const errors = analyzer.analyze(tree);
+
+      expect(errors).toHaveLength(1);
+      expect(errors[0].code).toBe("E0800");
+      expect(errors[0].operator).toBe("/");
+      expect(errors[0].message).toBe("Division by zero");
+    });
+
+    it("should detect modulo by literal zero", () => {
+      const code = `
+        void main() {
+          u32 x <- 10 % 0;
+        }
+      `;
+      const tree = parse(code);
+      const analyzer = new DivisionByZeroAnalyzer();
+      const errors = analyzer.analyze(tree);
+
+      expect(errors).toHaveLength(1);
+      expect(errors[0].code).toBe("E0802");
+      expect(errors[0].operator).toBe("%");
+      expect(errors[0].message).toBe("Modulo by zero");
+    });
+
+    it("should detect hex zero (0x0)", () => {
+      const code = `
+        void main() {
+          u32 x <- 10 / 0x0;
+        }
+      `;
+      const tree = parse(code);
+      const analyzer = new DivisionByZeroAnalyzer();
+      const errors = analyzer.analyze(tree);
+
+      expect(errors).toHaveLength(1);
+      expect(errors[0].code).toBe("E0800");
+    });
+
+    it("should detect binary zero (0b0)", () => {
+      const code = `
+        void main() {
+          u32 x <- 10 / 0b0;
+        }
+      `;
+      const tree = parse(code);
+      const analyzer = new DivisionByZeroAnalyzer();
+      const errors = analyzer.analyze(tree);
+
+      expect(errors).toHaveLength(1);
+      expect(errors[0].code).toBe("E0800");
+    });
+
+    it("should not flag division by non-zero literal", () => {
+      const code = `
+        void main() {
+          u32 x <- 10 / 2;
+          u32 y <- 20 % 3;
+        }
+      `;
+      const tree = parse(code);
+      const analyzer = new DivisionByZeroAnalyzer();
+      const errors = analyzer.analyze(tree);
+
+      expect(errors).toHaveLength(0);
+    });
+
+    it("should not flag multiplication by zero", () => {
+      const code = `
+        void main() {
+          u32 x <- 10 * 0;
+        }
+      `;
+      const tree = parse(code);
+      const analyzer = new DivisionByZeroAnalyzer();
+      const errors = analyzer.analyze(tree);
+
+      expect(errors).toHaveLength(0);
+    });
+  });
+
+  // ========================================================================
+  // Phase 3: Const Zero Detection
+  // ========================================================================
+
+  describe("const zero detection", () => {
+    it("should detect division by const zero variable", () => {
+      const code = `
+        const u32 ZERO <- 0;
+        void main() {
+          u32 x <- 10 / ZERO;
+        }
+      `;
+      const tree = parse(code);
+      const analyzer = new DivisionByZeroAnalyzer();
+      const errors = analyzer.analyze(tree);
+
+      expect(errors).toHaveLength(1);
+      expect(errors[0].code).toBe("E0800");
+    });
+
+    it("should detect modulo by const zero variable", () => {
+      const code = `
+        const u32 ZERO <- 0;
+        void main() {
+          u32 x <- 10 % ZERO;
+        }
+      `;
+      const tree = parse(code);
+      const analyzer = new DivisionByZeroAnalyzer();
+      const errors = analyzer.analyze(tree);
+
+      expect(errors).toHaveLength(1);
+      expect(errors[0].code).toBe("E0802");
+    });
+
+    it("should not flag division by non-zero const", () => {
+      const code = `
+        const u32 DIVISOR <- 5;
+        void main() {
+          u32 x <- 10 / DIVISOR;
+        }
+      `;
+      const tree = parse(code);
+      const analyzer = new DivisionByZeroAnalyzer();
+      const errors = analyzer.analyze(tree);
+
+      expect(errors).toHaveLength(0);
+    });
+
+    it("should not flag division by non-const variable", () => {
+      const code = `
+        u32 divisor <- 0;
+        void main() {
+          u32 x <- 10 / divisor;
+        }
+      `;
+      const tree = parse(code);
+      const analyzer = new DivisionByZeroAnalyzer();
+      const errors = analyzer.analyze(tree);
+
+      // Non-const variables are not tracked (runtime value)
+      expect(errors).toHaveLength(0);
+    });
+  });
+
+  // ========================================================================
+  // Multiple Errors
+  // ========================================================================
+
+  describe("multiple errors", () => {
+    it("should detect multiple division by zero errors", () => {
+      const code = `
+        void main() {
+          u32 a <- 10 / 0;
+          u32 b <- 20 % 0;
+          u32 c <- 30 / 0;
+        }
+      `;
+      const tree = parse(code);
+      const analyzer = new DivisionByZeroAnalyzer();
+      const errors = analyzer.analyze(tree);
+
+      expect(errors).toHaveLength(3);
+      expect(errors[0].code).toBe("E0800"); // division
+      expect(errors[1].code).toBe("E0802"); // modulo
+      expect(errors[2].code).toBe("E0800"); // division
+    });
+  });
+
+  // ========================================================================
+  // Chained Expressions
+  // ========================================================================
+
+  describe("chained expressions", () => {
+    it("should detect zero in chained division", () => {
+      const code = `
+        void main() {
+          u32 x <- 10 / 2 / 0;
+        }
+      `;
+      const tree = parse(code);
+      const analyzer = new DivisionByZeroAnalyzer();
+      const errors = analyzer.analyze(tree);
+
+      expect(errors).toHaveLength(1);
+      expect(errors[0].code).toBe("E0800");
+    });
+  });
+
+  // ========================================================================
+  // Error Details
+  // ========================================================================
+
+  describe("error details", () => {
+    it("should provide helpful text for division by zero", () => {
+      const code = `
+        void main() {
+          u32 x <- 10 / 0;
+        }
+      `;
+      const tree = parse(code);
+      const analyzer = new DivisionByZeroAnalyzer();
+      const errors = analyzer.analyze(tree);
+
+      expect(errors[0].helpText).toContain("safe_div");
+    });
+
+    it("should provide helpful text for modulo by zero", () => {
+      const code = `
+        void main() {
+          u32 x <- 10 % 0;
+        }
+      `;
+      const tree = parse(code);
+      const analyzer = new DivisionByZeroAnalyzer();
+      const errors = analyzer.analyze(tree);
+
+      expect(errors[0].helpText).toContain("safe_mod");
+    });
+
+    it("should report correct line and column", () => {
+      const code = `void main() {
+  u32 x <- 10 / 0;
+}`;
+      const tree = parse(code);
+      const analyzer = new DivisionByZeroAnalyzer();
+      const errors = analyzer.analyze(tree);
+
+      expect(errors[0].line).toBe(2);
+      // Column should point to the zero operand
+      expect(errors[0].column).toBeGreaterThan(0);
+    });
+  });
+
+  // ========================================================================
+  // Suffixed Literals
+  // ========================================================================
+
+  describe("suffixed literals", () => {
+    it("should detect suffixed decimal zero (0u32)", () => {
+      const code = `
+        void main() {
+          u32 x <- 10 / 0u32;
+        }
+      `;
+      const tree = parse(code);
+      const analyzer = new DivisionByZeroAnalyzer();
+      const errors = analyzer.analyze(tree);
+
+      expect(errors).toHaveLength(1);
+      expect(errors[0].code).toBe("E0800");
+    });
+
+    it("should not flag suffixed non-zero (5u32)", () => {
+      const code = `
+        void main() {
+          u32 x <- 10 / 5u32;
+        }
+      `;
+      const tree = parse(code);
+      const analyzer = new DivisionByZeroAnalyzer();
+      const errors = analyzer.analyze(tree);
+
+      expect(errors).toHaveLength(0);
+    });
+  });
+
+  // ========================================================================
+  // Edge Cases
+  // ========================================================================
+
+  describe("edge cases", () => {
+    it("should handle empty program", () => {
+      const code = ``;
+      const tree = parse(code);
+      const analyzer = new DivisionByZeroAnalyzer();
+      const errors = analyzer.analyze(tree);
+
+      expect(errors).toHaveLength(0);
+    });
+
+    it("should handle program with no division operations", () => {
+      const code = `
+        void main() {
+          u32 x <- 5 + 3;
+          u32 y <- 10 - 2;
+        }
+      `;
+      const tree = parse(code);
+      const analyzer = new DivisionByZeroAnalyzer();
+      const errors = analyzer.analyze(tree);
+
+      expect(errors).toHaveLength(0);
+    });
+  });
+});

--- a/src/analysis/FloatModuloAnalyzer.test.ts
+++ b/src/analysis/FloatModuloAnalyzer.test.ts
@@ -1,0 +1,352 @@
+/**
+ * Unit tests for FloatModuloAnalyzer
+ * Tests detection of modulo operator with floating-point types
+ */
+import { describe, it, expect } from "vitest";
+import { CharStream, CommonTokenStream } from "antlr4ng";
+import { CNextLexer } from "../parser/grammar/CNextLexer";
+import { CNextParser } from "../parser/grammar/CNextParser";
+import FloatModuloAnalyzer from "./FloatModuloAnalyzer";
+
+/**
+ * Helper to parse C-Next code and return the AST
+ */
+function parse(source: string) {
+  const charStream = CharStream.fromString(source);
+  const lexer = new CNextLexer(charStream);
+  const tokenStream = new CommonTokenStream(lexer);
+  const parser = new CNextParser(tokenStream);
+  return parser.program();
+}
+
+describe("FloatModuloAnalyzer", () => {
+  // ========================================================================
+  // Float Variable Detection
+  // ========================================================================
+
+  describe("float variable modulo", () => {
+    it("should detect modulo with f32 left operand", () => {
+      const code = `
+        void main() {
+          f32 x <- 10.5;
+          f32 result <- x % 3;
+        }
+      `;
+      const tree = parse(code);
+      const analyzer = new FloatModuloAnalyzer();
+      const errors = analyzer.analyze(tree);
+
+      expect(errors).toHaveLength(1);
+      expect(errors[0].code).toBe("E0804");
+      expect(errors[0].message).toContain("Modulo operator not supported");
+    });
+
+    it("should detect modulo with f64 left operand", () => {
+      const code = `
+        void main() {
+          f64 x <- 10.5;
+          f64 result <- x % 3;
+        }
+      `;
+      const tree = parse(code);
+      const analyzer = new FloatModuloAnalyzer();
+      const errors = analyzer.analyze(tree);
+
+      expect(errors).toHaveLength(1);
+      expect(errors[0].code).toBe("E0804");
+    });
+
+    it("should detect modulo with float right operand", () => {
+      const code = `
+        void main() {
+          f32 y <- 3.0;
+          u32 result <- 10 % y;
+        }
+      `;
+      const tree = parse(code);
+      const analyzer = new FloatModuloAnalyzer();
+      const errors = analyzer.analyze(tree);
+
+      expect(errors).toHaveLength(1);
+      expect(errors[0].code).toBe("E0804");
+    });
+
+    it("should detect modulo with both float operands", () => {
+      const code = `
+        void main() {
+          f32 x <- 10.5;
+          f32 y <- 3.0;
+          f32 result <- x % y;
+        }
+      `;
+      const tree = parse(code);
+      const analyzer = new FloatModuloAnalyzer();
+      const errors = analyzer.analyze(tree);
+
+      expect(errors).toHaveLength(1);
+      expect(errors[0].code).toBe("E0804");
+    });
+  });
+
+  // ========================================================================
+  // Float Literal Detection
+  // ========================================================================
+
+  describe("float literal modulo", () => {
+    it("should detect modulo with float literal left operand", () => {
+      const code = `
+        void main() {
+          f32 result <- 10.5 % 3;
+        }
+      `;
+      const tree = parse(code);
+      const analyzer = new FloatModuloAnalyzer();
+      const errors = analyzer.analyze(tree);
+
+      expect(errors).toHaveLength(1);
+      expect(errors[0].code).toBe("E0804");
+    });
+
+    it("should detect modulo with float literal right operand", () => {
+      const code = `
+        void main() {
+          f32 result <- 10 % 3.5;
+        }
+      `;
+      const tree = parse(code);
+      const analyzer = new FloatModuloAnalyzer();
+      const errors = analyzer.analyze(tree);
+
+      expect(errors).toHaveLength(1);
+      expect(errors[0].code).toBe("E0804");
+    });
+  });
+
+  // ========================================================================
+  // Function Parameters
+  // ========================================================================
+
+  describe("function parameters", () => {
+    it("should detect modulo with f32 parameter", () => {
+      const code = `
+        void compute(f32 value) {
+          f32 result <- value % 2;
+        }
+      `;
+      const tree = parse(code);
+      const analyzer = new FloatModuloAnalyzer();
+      const errors = analyzer.analyze(tree);
+
+      expect(errors).toHaveLength(1);
+      expect(errors[0].code).toBe("E0804");
+    });
+
+    it("should detect modulo with f64 parameter", () => {
+      const code = `
+        void compute(f64 value) {
+          f64 result <- value % 2;
+        }
+      `;
+      const tree = parse(code);
+      const analyzer = new FloatModuloAnalyzer();
+      const errors = analyzer.analyze(tree);
+
+      expect(errors).toHaveLength(1);
+      expect(errors[0].code).toBe("E0804");
+    });
+  });
+
+  // ========================================================================
+  // Valid Integer Modulo
+  // ========================================================================
+
+  describe("valid integer modulo", () => {
+    it("should not flag modulo between integers", () => {
+      const code = `
+        void main() {
+          u32 x <- 10;
+          u32 y <- 3;
+          u32 result <- x % y;
+        }
+      `;
+      const tree = parse(code);
+      const analyzer = new FloatModuloAnalyzer();
+      const errors = analyzer.analyze(tree);
+
+      expect(errors).toHaveLength(0);
+    });
+
+    it("should not flag modulo with integer literals", () => {
+      const code = `
+        void main() {
+          u32 result <- 10 % 3;
+        }
+      `;
+      const tree = parse(code);
+      const analyzer = new FloatModuloAnalyzer();
+      const errors = analyzer.analyze(tree);
+
+      expect(errors).toHaveLength(0);
+    });
+
+    it("should not flag modulo with various integer types", () => {
+      const code = `
+        void main() {
+          i32 a <- 10;
+          u64 b <- 3;
+          i64 result <- a % b;
+        }
+      `;
+      const tree = parse(code);
+      const analyzer = new FloatModuloAnalyzer();
+      const errors = analyzer.analyze(tree);
+
+      expect(errors).toHaveLength(0);
+    });
+  });
+
+  // ========================================================================
+  // Other Float Operations (Should Not Flag)
+  // ========================================================================
+
+  describe("other float operations", () => {
+    it("should not flag float addition", () => {
+      const code = `
+        void main() {
+          f32 x <- 10.5;
+          f32 result <- x + 3.0;
+        }
+      `;
+      const tree = parse(code);
+      const analyzer = new FloatModuloAnalyzer();
+      const errors = analyzer.analyze(tree);
+
+      expect(errors).toHaveLength(0);
+    });
+
+    it("should not flag float subtraction", () => {
+      const code = `
+        void main() {
+          f32 x <- 10.5;
+          f32 result <- x - 3.0;
+        }
+      `;
+      const tree = parse(code);
+      const analyzer = new FloatModuloAnalyzer();
+      const errors = analyzer.analyze(tree);
+
+      expect(errors).toHaveLength(0);
+    });
+
+    it("should not flag float multiplication", () => {
+      const code = `
+        void main() {
+          f32 x <- 10.5;
+          f32 result <- x * 3.0;
+        }
+      `;
+      const tree = parse(code);
+      const analyzer = new FloatModuloAnalyzer();
+      const errors = analyzer.analyze(tree);
+
+      expect(errors).toHaveLength(0);
+    });
+
+    it("should not flag float division", () => {
+      const code = `
+        void main() {
+          f32 x <- 10.5;
+          f32 result <- x / 3.0;
+        }
+      `;
+      const tree = parse(code);
+      const analyzer = new FloatModuloAnalyzer();
+      const errors = analyzer.analyze(tree);
+
+      expect(errors).toHaveLength(0);
+    });
+  });
+
+  // ========================================================================
+  // Error Details
+  // ========================================================================
+
+  describe("error details", () => {
+    it("should provide fmod() help text", () => {
+      const code = `
+        void main() {
+          f32 x <- 10.5;
+          f32 result <- x % 3;
+        }
+      `;
+      const tree = parse(code);
+      const analyzer = new FloatModuloAnalyzer();
+      const errors = analyzer.analyze(tree);
+
+      expect(errors[0].helpText).toContain("fmod()");
+    });
+
+    it("should report correct line number", () => {
+      const code = `void main() {
+  f32 x <- 10.5;
+  f32 result <- x % 3;
+}`;
+      const tree = parse(code);
+      const analyzer = new FloatModuloAnalyzer();
+      const errors = analyzer.analyze(tree);
+
+      expect(errors[0].line).toBe(3);
+    });
+  });
+
+  // ========================================================================
+  // Multiple Errors
+  // ========================================================================
+
+  describe("multiple errors", () => {
+    it("should detect multiple float modulo operations", () => {
+      const code = `
+        void main() {
+          f32 a <- 10.5;
+          f32 b <- a % 3;
+          f64 c <- 20.5;
+          f64 d <- c % 4;
+        }
+      `;
+      const tree = parse(code);
+      const analyzer = new FloatModuloAnalyzer();
+      const errors = analyzer.analyze(tree);
+
+      expect(errors).toHaveLength(2);
+    });
+  });
+
+  // ========================================================================
+  // Edge Cases
+  // ========================================================================
+
+  describe("edge cases", () => {
+    it("should handle empty program", () => {
+      const code = ``;
+      const tree = parse(code);
+      const analyzer = new FloatModuloAnalyzer();
+      const errors = analyzer.analyze(tree);
+
+      expect(errors).toHaveLength(0);
+    });
+
+    it("should handle program with no modulo operations", () => {
+      const code = `
+        void main() {
+          f32 x <- 5.0 + 3.0;
+          f32 y <- 10.0 - 2.0;
+        }
+      `;
+      const tree = parse(code);
+      const analyzer = new FloatModuloAnalyzer();
+      const errors = analyzer.analyze(tree);
+
+      expect(errors).toHaveLength(0);
+    });
+  });
+});

--- a/src/analysis/FunctionCallAnalyzer.test.ts
+++ b/src/analysis/FunctionCallAnalyzer.test.ts
@@ -1,0 +1,416 @@
+/**
+ * Unit tests for FunctionCallAnalyzer
+ * Tests define-before-use enforcement for functions (ADR-030)
+ */
+import { describe, it, expect } from "vitest";
+import { CharStream, CommonTokenStream } from "antlr4ng";
+import { CNextLexer } from "../parser/grammar/CNextLexer";
+import { CNextParser } from "../parser/grammar/CNextParser";
+import FunctionCallAnalyzer from "./FunctionCallAnalyzer";
+import SymbolTable from "../symbols/SymbolTable";
+import ESourceLanguage from "../types/ESourceLanguage";
+import ESymbolKind from "../types/ESymbolKind";
+
+/**
+ * Helper to parse C-Next code and return the AST
+ */
+function parse(source: string) {
+  const charStream = CharStream.fromString(source);
+  const lexer = new CNextLexer(charStream);
+  const tokenStream = new CommonTokenStream(lexer);
+  const parser = new CNextParser(tokenStream);
+  return parser.program();
+}
+
+describe("FunctionCallAnalyzer", () => {
+  // ========================================================================
+  // Define Before Use
+  // ========================================================================
+
+  describe("define before use", () => {
+    it("should allow calling defined before use", () => {
+      const code = `
+        void helper() {
+          u32 x <- 5;
+        }
+        void main() {
+          helper();
+        }
+      `;
+      const tree = parse(code);
+      const analyzer = new FunctionCallAnalyzer();
+      const errors = analyzer.analyze(tree);
+
+      expect(errors).toHaveLength(0);
+    });
+
+    it("should detect called before definition", () => {
+      const code = `
+        void main() {
+          helper();
+        }
+        void helper() {
+          u32 x <- 5;
+        }
+      `;
+      const tree = parse(code);
+      const analyzer = new FunctionCallAnalyzer();
+      const errors = analyzer.analyze(tree);
+
+      expect(errors).toHaveLength(1);
+      expect(errors[0].code).toBe("E0422");
+      expect(errors[0].message).toContain("called before definition");
+    });
+
+    it("should detect undefined", () => {
+      const code = `
+        void main() {
+          unknownFunc();
+        }
+      `;
+      const tree = parse(code);
+      const analyzer = new FunctionCallAnalyzer();
+      const errors = analyzer.analyze(tree);
+
+      expect(errors).toHaveLength(1);
+      expect(errors[0].code).toBe("E0422");
+    });
+  });
+
+  // ========================================================================
+  // Self-Recursion Detection (MISRA C:2012 Rule 17.2)
+  // ========================================================================
+
+  describe("self-recursion detection", () => {
+    it("should detect direct self-recursion", () => {
+      const code = `
+        void factorial(u32 n) {
+          factorial(n - 1);
+        }
+      `;
+      const tree = parse(code);
+      const analyzer = new FunctionCallAnalyzer();
+      const errors = analyzer.analyze(tree);
+
+      expect(errors).toHaveLength(1);
+      expect(errors[0].code).toBe("E0423");
+      expect(errors[0].message).toContain("recursive call");
+      expect(errors[0].message).toContain("MISRA");
+    });
+
+    it("should allow calling other procedures with similar names", () => {
+      const code = `
+        void helper() {
+          u32 x <- 5;
+        }
+        void process() {
+          helper();
+        }
+      `;
+      const tree = parse(code);
+      const analyzer = new FunctionCallAnalyzer();
+      const errors = analyzer.analyze(tree);
+
+      expect(errors).toHaveLength(0);
+    });
+  });
+
+  // ========================================================================
+  // Scope Handling
+  // ========================================================================
+
+  describe("scope handling", () => {
+    it("should resolve scope member calls", () => {
+      const code = `
+        scope LED {
+          public void on() {
+            u32 x <- 1;
+          }
+        }
+        void main() {
+          LED.on();
+        }
+      `;
+      const tree = parse(code);
+      const analyzer = new FunctionCallAnalyzer();
+      const errors = analyzer.analyze(tree);
+
+      expect(errors).toHaveLength(0);
+    });
+
+    it("should detect undefined scope member", () => {
+      const code = `
+        scope LED {
+          public void on() {
+            u32 x <- 1;
+          }
+        }
+        void main() {
+          LED.off();
+        }
+      `;
+      const tree = parse(code);
+      const analyzer = new FunctionCallAnalyzer();
+      const errors = analyzer.analyze(tree);
+
+      expect(errors).toHaveLength(1);
+      expect(errors[0].code).toBe("E0422");
+    });
+  });
+
+  // ========================================================================
+  // Built-in Procedures
+  // ========================================================================
+
+  describe("built-in procedures", () => {
+    it("should allow safe_div built-in", () => {
+      const code = `
+        void main() {
+          u32 result;
+          safe_div(result, 10, 0, 0);
+        }
+      `;
+      const tree = parse(code);
+      const analyzer = new FunctionCallAnalyzer();
+      const errors = analyzer.analyze(tree);
+
+      expect(errors).toHaveLength(0);
+    });
+
+    it("should allow safe_mod built-in", () => {
+      const code = `
+        void main() {
+          u32 result;
+          safe_mod(result, 10, 0, 0);
+        }
+      `;
+      const tree = parse(code);
+      const analyzer = new FunctionCallAnalyzer();
+      const errors = analyzer.analyze(tree);
+
+      expect(errors).toHaveLength(0);
+    });
+  });
+
+  // ========================================================================
+  // Standard Library
+  // ========================================================================
+
+  describe("standard library", () => {
+    it("should allow printf with stdio.h included", () => {
+      const code = `
+        #include <stdio.h>
+        void main() {
+          printf("Hello");
+        }
+      `;
+      const tree = parse(code);
+      const analyzer = new FunctionCallAnalyzer();
+      const errors = analyzer.analyze(tree);
+
+      expect(errors).toHaveLength(0);
+    });
+
+    it("should detect printf without stdio.h", () => {
+      const code = `
+        void main() {
+          printf("Hello");
+        }
+      `;
+      const tree = parse(code);
+      const analyzer = new FunctionCallAnalyzer();
+      const errors = analyzer.analyze(tree);
+
+      expect(errors).toHaveLength(1);
+    });
+
+    it("should allow strlen with string.h included", () => {
+      const code = `
+        #include <string.h>
+        void main() {
+          u32 len <- strlen("test");
+        }
+      `;
+      const tree = parse(code);
+      const analyzer = new FunctionCallAnalyzer();
+      const errors = analyzer.analyze(tree);
+
+      expect(errors).toHaveLength(0);
+    });
+
+    it("should allow math operations with math.h included", () => {
+      const code = `
+        #include <math.h>
+        void main() {
+          f64 x <- sin(3.14);
+        }
+      `;
+      const tree = parse(code);
+      const analyzer = new FunctionCallAnalyzer();
+      const errors = analyzer.analyze(tree);
+
+      expect(errors).toHaveLength(0);
+    });
+  });
+
+  // ========================================================================
+  // External C/C++ (Symbol Table)
+  // ========================================================================
+
+  describe("external via symbol table", () => {
+    it("should allow external C from symbol table", () => {
+      const code = `
+        void main() {
+          myExternalFunc();
+        }
+      `;
+      const tree = parse(code);
+      const symbolTable = new SymbolTable();
+      symbolTable.addSymbol({
+        name: "myExternalFunc",
+        kind: ESymbolKind.Function,
+        sourceLanguage: ESourceLanguage.C,
+        sourceFile: "external.h",
+        sourceLine: 1,
+        isExported: true,
+        type: "void",
+      });
+
+      const analyzer = new FunctionCallAnalyzer();
+      const errors = analyzer.analyze(tree, symbolTable);
+
+      expect(errors).toHaveLength(0);
+    });
+
+    it("should allow external C++ from symbol table", () => {
+      const code = `
+        void main() {
+          cppHelper();
+        }
+      `;
+      const tree = parse(code);
+      const symbolTable = new SymbolTable();
+      symbolTable.addSymbol({
+        name: "cppHelper",
+        kind: ESymbolKind.Function,
+        sourceLanguage: ESourceLanguage.Cpp,
+        sourceFile: "helper.hpp",
+        sourceLine: 1,
+        isExported: true,
+        type: "void",
+      });
+
+      const analyzer = new FunctionCallAnalyzer();
+      const errors = analyzer.analyze(tree, symbolTable);
+
+      expect(errors).toHaveLength(0);
+    });
+  });
+
+  // ========================================================================
+  // ISR and Callback Variables (ADR-040)
+  // ========================================================================
+
+  describe("ISR and callback variables", () => {
+    it("should allow invoking ISR-typed variable", () => {
+      const code = `
+        void myHandler() {
+          u32 x <- 1;
+        }
+        void main() {
+          ISR handler <- myHandler;
+          handler();
+        }
+      `;
+      const tree = parse(code);
+      const analyzer = new FunctionCallAnalyzer();
+      const errors = analyzer.analyze(tree);
+
+      expect(errors).toHaveLength(0);
+    });
+
+    it("should allow invoking ISR-typed parameter", () => {
+      const code = `
+        void myHandler() {
+          u32 x <- 1;
+        }
+        void execute(ISR callback) {
+          callback();
+        }
+      `;
+      const tree = parse(code);
+      const analyzer = new FunctionCallAnalyzer();
+      const errors = analyzer.analyze(tree);
+
+      expect(errors).toHaveLength(0);
+    });
+  });
+
+  // ========================================================================
+  // Multiple Errors
+  // ========================================================================
+
+  describe("multiple errors", () => {
+    it("should detect multiple undefined", () => {
+      const code = `
+        void main() {
+          foo();
+          bar();
+          baz();
+        }
+      `;
+      const tree = parse(code);
+      const analyzer = new FunctionCallAnalyzer();
+      const errors = analyzer.analyze(tree);
+
+      expect(errors).toHaveLength(3);
+    });
+  });
+
+  // ========================================================================
+  // Error Details
+  // ========================================================================
+
+  describe("error details", () => {
+    it("should report correct line and column", () => {
+      const code = `void main() {
+  unknownFunc();
+}`;
+      const tree = parse(code);
+      const analyzer = new FunctionCallAnalyzer();
+      const errors = analyzer.analyze(tree);
+
+      expect(errors[0].line).toBe(2);
+      expect(errors[0].column).toBeGreaterThan(0);
+    });
+  });
+
+  // ========================================================================
+  // Edge Cases
+  // ========================================================================
+
+  describe("edge cases", () => {
+    it("should handle empty program", () => {
+      const code = ``;
+      const tree = parse(code);
+      const analyzer = new FunctionCallAnalyzer();
+      const errors = analyzer.analyze(tree);
+
+      expect(errors).toHaveLength(0);
+    });
+
+    it("should handle program with only declarations", () => {
+      const code = `
+        u32 globalVar <- 5;
+        void helper() {
+          u32 x <- globalVar;
+        }
+      `;
+      const tree = parse(code);
+      const analyzer = new FunctionCallAnalyzer();
+      const errors = analyzer.analyze(tree);
+
+      expect(errors).toHaveLength(0);
+    });
+  });
+});

--- a/src/analysis/ParameterNamingAnalyzer.test.ts
+++ b/src/analysis/ParameterNamingAnalyzer.test.ts
@@ -1,0 +1,274 @@
+/**
+ * Unit tests for ParameterNamingAnalyzer
+ * Tests validation of function parameter naming conventions (Issue #227)
+ */
+import { describe, it, expect } from "vitest";
+import { CharStream, CommonTokenStream } from "antlr4ng";
+import { CNextLexer } from "../parser/grammar/CNextLexer";
+import { CNextParser } from "../parser/grammar/CNextParser";
+import ParameterNamingAnalyzer from "./ParameterNamingAnalyzer";
+
+/**
+ * Helper to parse C-Next code and return the AST
+ */
+function parse(source: string) {
+  const charStream = CharStream.fromString(source);
+  const lexer = new CNextLexer(charStream);
+  const tokenStream = new CommonTokenStream(lexer);
+  const parser = new CNextParser(tokenStream);
+  return parser.program();
+}
+
+describe("ParameterNamingAnalyzer", () => {
+  // ========================================================================
+  // Reserved Parameter Names
+  // ========================================================================
+
+  describe("reserved parameter names", () => {
+    it("should detect parameter starting with function name prefix", () => {
+      const code = `
+        void process(u32 process_data) {
+          u32 x <- process_data;
+        }
+      `;
+      const tree = parse(code);
+      const analyzer = new ParameterNamingAnalyzer();
+      const errors = analyzer.analyze(tree);
+
+      expect(errors).toHaveLength(1);
+      expect(errors[0].code).toBe("E0227");
+      expect(errors[0].parameterName).toBe("process_data");
+      expect(errors[0].functionName).toBe("process");
+    });
+
+    it("should detect parameter exactly matching function name + underscore", () => {
+      const code = `
+        void init(u32 init_value, u32 init_size) {
+          u32 x <- init_value + init_size;
+        }
+      `;
+      const tree = parse(code);
+      const analyzer = new ParameterNamingAnalyzer();
+      const errors = analyzer.analyze(tree);
+
+      expect(errors).toHaveLength(2);
+      expect(errors[0].parameterName).toBe("init_value");
+      expect(errors[1].parameterName).toBe("init_size");
+    });
+  });
+
+  // ========================================================================
+  // Valid Parameter Names
+  // ========================================================================
+
+  describe("valid parameter names", () => {
+    it("should allow parameters not starting with function name prefix", () => {
+      const code = `
+        void process(u32 data, u32 size) {
+          u32 x <- data + size;
+        }
+      `;
+      const tree = parse(code);
+      const analyzer = new ParameterNamingAnalyzer();
+      const errors = analyzer.analyze(tree);
+
+      expect(errors).toHaveLength(0);
+    });
+
+    it("should allow parameter that contains but does not start with prefix", () => {
+      const code = `
+        void calc(u32 data_calc_value) {
+          u32 x <- data_calc_value;
+        }
+      `;
+      const tree = parse(code);
+      const analyzer = new ParameterNamingAnalyzer();
+      const errors = analyzer.analyze(tree);
+
+      // "data_calc_value" does not start with "calc_"
+      expect(errors).toHaveLength(0);
+    });
+
+    it("should allow parameter that is function name without underscore", () => {
+      const code = `
+        void test(u32 test) {
+          u32 x <- test;
+        }
+      `;
+      const tree = parse(code);
+      const analyzer = new ParameterNamingAnalyzer();
+      const errors = analyzer.analyze(tree);
+
+      // "test" does not start with "test_"
+      expect(errors).toHaveLength(0);
+    });
+
+    it("should allow similar prefix from different function", () => {
+      const code = `
+        void process(u32 init_value) {
+          u32 x <- init_value;
+        }
+      `;
+      const tree = parse(code);
+      const analyzer = new ParameterNamingAnalyzer();
+      const errors = analyzer.analyze(tree);
+
+      // "init_value" does not start with "process_"
+      expect(errors).toHaveLength(0);
+    });
+  });
+
+  // ========================================================================
+  // Multiple Functions
+  // ========================================================================
+
+  describe("multiple functions", () => {
+    it("should check each function independently", () => {
+      const code = `
+        void foo(u32 foo_x) {
+          u32 a <- foo_x;
+        }
+        void bar(u32 bar_y) {
+          u32 b <- bar_y;
+        }
+      `;
+      const tree = parse(code);
+      const analyzer = new ParameterNamingAnalyzer();
+      const errors = analyzer.analyze(tree);
+
+      expect(errors).toHaveLength(2);
+      expect(errors[0].functionName).toBe("foo");
+      expect(errors[1].functionName).toBe("bar");
+    });
+
+    it("should not cross-check between functions", () => {
+      const code = `
+        void foo(u32 bar_x) {
+          u32 a <- bar_x;
+        }
+        void bar(u32 foo_y) {
+          u32 b <- foo_y;
+        }
+      `;
+      const tree = parse(code);
+      const analyzer = new ParameterNamingAnalyzer();
+      const errors = analyzer.analyze(tree);
+
+      // "bar_x" does not start with "foo_", "foo_y" does not start with "bar_"
+      expect(errors).toHaveLength(0);
+    });
+  });
+
+  // ========================================================================
+  // Error Details
+  // ========================================================================
+
+  describe("error details", () => {
+    it("should provide correct error message", () => {
+      const code = `
+        void setup(u32 setup_config) {
+          u32 x <- setup_config;
+        }
+      `;
+      const tree = parse(code);
+      const analyzer = new ParameterNamingAnalyzer();
+      const errors = analyzer.analyze(tree);
+
+      expect(errors[0].message).toContain("Parameter 'setup_config'");
+      expect(errors[0].message).toContain(
+        "cannot start with function name prefix",
+      );
+      expect(errors[0].message).toContain("'setup_'");
+    });
+
+    it("should provide helpful suggestion", () => {
+      const code = `
+        void setup(u32 setup_config) {
+          u32 x <- setup_config;
+        }
+      `;
+      const tree = parse(code);
+      const analyzer = new ParameterNamingAnalyzer();
+      const errors = analyzer.analyze(tree);
+
+      expect(errors[0].helpText).toContain("Consider renaming");
+      expect(errors[0].helpText).toContain("setup_");
+    });
+
+    it("should report correct line and column", () => {
+      const code = `void setup(u32 setup_config) {
+  u32 x <- setup_config;
+}`;
+      const tree = parse(code);
+      const analyzer = new ParameterNamingAnalyzer();
+      const errors = analyzer.analyze(tree);
+
+      expect(errors[0].line).toBe(1);
+      // Column should point to parameter name
+      expect(errors[0].column).toBeGreaterThan(0);
+    });
+  });
+
+  // ========================================================================
+  // Functions Without Parameters
+  // ========================================================================
+
+  describe("functions without parameters", () => {
+    it("should handle functions with no parameters", () => {
+      const code = `
+        void noop() {
+          u32 x <- 5;
+        }
+      `;
+      const tree = parse(code);
+      const analyzer = new ParameterNamingAnalyzer();
+      const errors = analyzer.analyze(tree);
+
+      expect(errors).toHaveLength(0);
+    });
+  });
+
+  // ========================================================================
+  // Edge Cases
+  // ========================================================================
+
+  describe("edge cases", () => {
+    it("should handle empty program", () => {
+      const code = ``;
+      const tree = parse(code);
+      const analyzer = new ParameterNamingAnalyzer();
+      const errors = analyzer.analyze(tree);
+
+      expect(errors).toHaveLength(0);
+    });
+
+    it("should handle single character function name", () => {
+      const code = `
+        void f(u32 f_value) {
+          u32 x <- f_value;
+        }
+      `;
+      const tree = parse(code);
+      const analyzer = new ParameterNamingAnalyzer();
+      const errors = analyzer.analyze(tree);
+
+      expect(errors).toHaveLength(1);
+      expect(errors[0].functionName).toBe("f");
+    });
+
+    it("should handle underscore in function name", () => {
+      const code = `
+        void my_func(u32 my_func_data) {
+          u32 x <- my_func_data;
+        }
+      `;
+      const tree = parse(code);
+      const analyzer = new ParameterNamingAnalyzer();
+      const errors = analyzer.analyze(tree);
+
+      expect(errors).toHaveLength(1);
+      expect(errors[0].functionName).toBe("my_func");
+      expect(errors[0].parameterName).toBe("my_func_data");
+    });
+  });
+});

--- a/src/analysis/ScopeStack.test.ts
+++ b/src/analysis/ScopeStack.test.ts
@@ -1,0 +1,442 @@
+/**
+ * Unit tests for ScopeStack
+ * Tests the generic scope management data structure
+ */
+import { describe, it, expect, beforeEach } from "vitest";
+import ScopeStack from "./ScopeStack";
+
+/**
+ * Simple test state for variables
+ */
+interface ITestState {
+  initialized: boolean;
+  value: number;
+}
+
+describe("ScopeStack", () => {
+  let stack: ScopeStack<ITestState>;
+
+  beforeEach(() => {
+    stack = new ScopeStack<ITestState>();
+  });
+
+  // ========================================================================
+  // Basic Scope Operations
+  // ========================================================================
+
+  describe("scope management", () => {
+    it("should start with no active scope", () => {
+      expect(stack.hasActiveScope()).toBe(false);
+      expect(stack.getDepth()).toBe(0);
+    });
+
+    it("should create scope on enterScope", () => {
+      stack.enterScope();
+      expect(stack.hasActiveScope()).toBe(true);
+      expect(stack.getDepth()).toBe(1);
+    });
+
+    it("should nest scopes correctly", () => {
+      stack.enterScope();
+      stack.enterScope();
+      stack.enterScope();
+      expect(stack.getDepth()).toBe(3);
+    });
+
+    it("should exit scopes correctly", () => {
+      stack.enterScope();
+      stack.enterScope();
+      expect(stack.getDepth()).toBe(2);
+
+      stack.exitScope();
+      expect(stack.getDepth()).toBe(1);
+
+      stack.exitScope();
+      expect(stack.getDepth()).toBe(0);
+      expect(stack.hasActiveScope()).toBe(false);
+    });
+
+    it("should handle exitScope when no scope exists", () => {
+      const result = stack.exitScope();
+      expect(result).toBeNull();
+      expect(stack.getDepth()).toBe(0);
+    });
+
+    it("should return exited scope from exitScope", () => {
+      stack.enterScope();
+      stack.declare("x", { initialized: true, value: 42 });
+
+      const exited = stack.exitScope();
+      expect(exited).not.toBeNull();
+      expect(exited!.variables.get("x")?.value).toBe(42);
+    });
+  });
+
+  // ========================================================================
+  // Variable Declaration
+  // ========================================================================
+
+  describe("declare", () => {
+    it("should declare variable in current scope", () => {
+      stack.enterScope();
+      stack.declare("x", { initialized: false, value: 0 });
+
+      expect(stack.has("x")).toBe(true);
+      expect(stack.lookup("x")).toEqual({ initialized: false, value: 0 });
+    });
+
+    it("should throw when declaring without active scope", () => {
+      expect(() => {
+        stack.declare("x", { initialized: false, value: 0 });
+      }).toThrow("no active scope");
+    });
+
+    it("should allow same name in different scopes (shadowing)", () => {
+      stack.enterScope();
+      stack.declare("x", { initialized: true, value: 1 });
+
+      stack.enterScope();
+      stack.declare("x", { initialized: false, value: 2 });
+
+      // Inner scope shadows outer
+      expect(stack.lookup("x")?.value).toBe(2);
+
+      stack.exitScope();
+
+      // Back to outer scope
+      expect(stack.lookup("x")?.value).toBe(1);
+    });
+  });
+
+  // ========================================================================
+  // Variable Lookup
+  // ========================================================================
+
+  describe("lookup", () => {
+    it("should find variable in current scope", () => {
+      stack.enterScope();
+      stack.declare("x", { initialized: true, value: 10 });
+
+      expect(stack.lookup("x")?.value).toBe(10);
+    });
+
+    it("should find variable in parent scope", () => {
+      stack.enterScope();
+      stack.declare("outer", { initialized: true, value: 1 });
+
+      stack.enterScope();
+      stack.declare("inner", { initialized: true, value: 2 });
+
+      // Can find both
+      expect(stack.lookup("outer")?.value).toBe(1);
+      expect(stack.lookup("inner")?.value).toBe(2);
+    });
+
+    it("should find variable in grandparent scope", () => {
+      stack.enterScope();
+      stack.declare("global", { initialized: true, value: 100 });
+
+      stack.enterScope();
+      stack.enterScope();
+      stack.enterScope();
+
+      expect(stack.lookup("global")?.value).toBe(100);
+    });
+
+    it("should return null for undefined variable", () => {
+      stack.enterScope();
+      expect(stack.lookup("nonexistent")).toBeNull();
+    });
+
+    it("should return null when no scope exists", () => {
+      expect(stack.lookup("anything")).toBeNull();
+    });
+  });
+
+  // ========================================================================
+  // has / hasInCurrentScope
+  // ========================================================================
+
+  describe("has", () => {
+    it("should return true for existing variable", () => {
+      stack.enterScope();
+      stack.declare("x", { initialized: true, value: 0 });
+      expect(stack.has("x")).toBe(true);
+    });
+
+    it("should return false for non-existing variable", () => {
+      stack.enterScope();
+      expect(stack.has("x")).toBe(false);
+    });
+
+    it("should find variable in parent scope", () => {
+      stack.enterScope();
+      stack.declare("x", { initialized: true, value: 0 });
+      stack.enterScope();
+
+      expect(stack.has("x")).toBe(true);
+    });
+  });
+
+  describe("hasInCurrentScope", () => {
+    it("should return true for variable in current scope", () => {
+      stack.enterScope();
+      stack.declare("x", { initialized: true, value: 0 });
+      expect(stack.hasInCurrentScope("x")).toBe(true);
+    });
+
+    it("should return false for variable in parent scope", () => {
+      stack.enterScope();
+      stack.declare("x", { initialized: true, value: 0 });
+      stack.enterScope();
+
+      expect(stack.hasInCurrentScope("x")).toBe(false);
+      expect(stack.has("x")).toBe(true); // But has() finds it
+    });
+
+    it("should return false when no scope exists", () => {
+      expect(stack.hasInCurrentScope("x")).toBe(false);
+    });
+  });
+
+  // ========================================================================
+  // Update
+  // ========================================================================
+
+  describe("update", () => {
+    it("should update variable in current scope", () => {
+      stack.enterScope();
+      stack.declare("x", { initialized: false, value: 0 });
+
+      const updated = stack.update("x", (state) => ({
+        ...state,
+        initialized: true,
+        value: 42,
+      }));
+
+      expect(updated).toBe(true);
+      expect(stack.lookup("x")).toEqual({ initialized: true, value: 42 });
+    });
+
+    it("should update variable in parent scope", () => {
+      stack.enterScope();
+      stack.declare("x", { initialized: false, value: 0 });
+      stack.enterScope();
+
+      const updated = stack.update("x", (state) => ({
+        ...state,
+        initialized: true,
+      }));
+
+      expect(updated).toBe(true);
+      expect(stack.lookup("x")?.initialized).toBe(true);
+    });
+
+    it("should return false for non-existing variable", () => {
+      stack.enterScope();
+      const updated = stack.update("nonexistent", (state) => state);
+      expect(updated).toBe(false);
+    });
+
+    it("should update shadowed variable in inner scope only", () => {
+      stack.enterScope();
+      stack.declare("x", { initialized: true, value: 1 });
+
+      stack.enterScope();
+      stack.declare("x", { initialized: false, value: 2 });
+
+      stack.update("x", (state) => ({ ...state, value: 99 }));
+
+      // Inner was updated
+      expect(stack.lookup("x")?.value).toBe(99);
+
+      stack.exitScope();
+
+      // Outer unchanged
+      expect(stack.lookup("x")?.value).toBe(1);
+    });
+  });
+
+  // ========================================================================
+  // getAllVisible
+  // ========================================================================
+
+  describe("getAllVisible", () => {
+    it("should return all variables from all scopes", () => {
+      stack.enterScope();
+      stack.declare("a", { initialized: true, value: 1 });
+
+      stack.enterScope();
+      stack.declare("b", { initialized: true, value: 2 });
+
+      const visible = stack.getAllVisible();
+
+      expect(visible.size).toBe(2);
+      expect(visible.get("a")?.value).toBe(1);
+      expect(visible.get("b")?.value).toBe(2);
+    });
+
+    it("should respect shadowing (inner wins)", () => {
+      stack.enterScope();
+      stack.declare("x", { initialized: true, value: 1 });
+
+      stack.enterScope();
+      stack.declare("x", { initialized: false, value: 2 });
+
+      const visible = stack.getAllVisible();
+
+      expect(visible.size).toBe(1);
+      expect(visible.get("x")?.value).toBe(2); // Inner value
+    });
+
+    it("should return empty map when no scope", () => {
+      const visible = stack.getAllVisible();
+      expect(visible.size).toBe(0);
+    });
+  });
+
+  // ========================================================================
+  // cloneState / restoreState
+  // ========================================================================
+
+  describe("cloneState", () => {
+    it("should deep clone all variable states", () => {
+      stack.enterScope();
+      stack.declare("x", { initialized: false, value: 10 });
+
+      const cloned = stack.cloneState((s) => ({ ...s }));
+
+      // Modify original
+      stack.update("x", () => ({ initialized: true, value: 99 }));
+
+      // Clone unchanged
+      expect(cloned.get("x")).toEqual({ initialized: false, value: 10 });
+    });
+
+    it("should clone across multiple scopes", () => {
+      stack.enterScope();
+      stack.declare("a", { initialized: true, value: 1 });
+      stack.enterScope();
+      stack.declare("b", { initialized: false, value: 2 });
+
+      const cloned = stack.cloneState((s) => ({ ...s }));
+
+      expect(cloned.size).toBe(2);
+      expect(cloned.get("a")?.value).toBe(1);
+      expect(cloned.get("b")?.value).toBe(2);
+    });
+  });
+
+  describe("restoreState", () => {
+    it("should restore variable states from snapshot", () => {
+      stack.enterScope();
+      stack.declare("x", { initialized: false, value: 0 });
+
+      // Save state
+      const saved = stack.cloneState((s) => ({ ...s }));
+
+      // Modify
+      stack.update("x", () => ({ initialized: true, value: 42 }));
+      expect(stack.lookup("x")?.initialized).toBe(true);
+
+      // Restore
+      stack.restoreState(saved, (_current, saved) => ({ ...saved }));
+
+      expect(stack.lookup("x")).toEqual({ initialized: false, value: 0 });
+    });
+
+    it("should only restore variables that exist in both", () => {
+      stack.enterScope();
+      stack.declare("a", { initialized: false, value: 1 });
+
+      const saved = stack.cloneState((s) => ({ ...s }));
+
+      // Add new variable after snapshot
+      stack.declare("b", { initialized: true, value: 2 });
+
+      // Modify a
+      stack.update("a", () => ({ initialized: true, value: 99 }));
+
+      // Restore only affects 'a', not 'b'
+      stack.restoreState(saved, (_current, saved) => ({ ...saved }));
+
+      expect(stack.lookup("a")?.value).toBe(1); // Restored
+      expect(stack.lookup("b")?.value).toBe(2); // Unchanged
+    });
+  });
+
+  // ========================================================================
+  // currentScopeVariables iterator
+  // ========================================================================
+
+  describe("currentScopeVariables", () => {
+    it("should iterate over current scope only", () => {
+      stack.enterScope();
+      stack.declare("outer", { initialized: true, value: 1 });
+
+      stack.enterScope();
+      stack.declare("inner1", { initialized: true, value: 2 });
+      stack.declare("inner2", { initialized: true, value: 3 });
+
+      const names = [...stack.currentScopeVariables()].map(([name]) => name);
+
+      expect(names).toEqual(["inner1", "inner2"]);
+      expect(names).not.toContain("outer");
+    });
+
+    it("should yield nothing when no scope", () => {
+      const result = [...stack.currentScopeVariables()];
+      expect(result).toHaveLength(0);
+    });
+  });
+
+  // ========================================================================
+  // Real-world scenarios
+  // ========================================================================
+
+  describe("real-world scenarios", () => {
+    it("should handle function with nested blocks", () => {
+      // function foo() {
+      //   u32 x;
+      //   if (cond) {
+      //     u32 y;
+      //   }
+      //   // y not visible here
+      // }
+
+      stack.enterScope(); // function
+      stack.declare("x", { initialized: false, value: 0 });
+
+      stack.enterScope(); // if block
+      stack.declare("y", { initialized: false, value: 0 });
+      expect(stack.has("x")).toBe(true);
+      expect(stack.has("y")).toBe(true);
+
+      stack.exitScope(); // exit if block
+
+      expect(stack.has("x")).toBe(true);
+      expect(stack.has("y")).toBe(false); // y out of scope
+    });
+
+    it("should handle control flow state save/restore", () => {
+      // if (cond) {
+      //   x <- 1;  // initializes x in this branch
+      // }
+      // // x may or may not be initialized
+
+      stack.enterScope();
+      stack.declare("x", { initialized: false, value: 0 });
+
+      // Save state before if
+      const beforeIf = stack.cloneState((s) => ({ ...s }));
+
+      // Simulate if branch initializing x
+      stack.update("x", () => ({ initialized: true, value: 1 }));
+
+      // No else branch, so restore to "maybe uninitialized" state
+      stack.restoreState(beforeIf, (_current, saved) => ({ ...saved }));
+
+      expect(stack.lookup("x")?.initialized).toBe(false);
+    });
+  });
+});

--- a/src/analysis/ScopeStack.ts
+++ b/src/analysis/ScopeStack.ts
@@ -1,0 +1,206 @@
+/**
+ * ScopeStack - Generic scope management for variable tracking
+ *
+ * A linked-list stack of scopes where each scope contains variables.
+ * Supports lexical scoping: inner scopes can shadow outer variables,
+ * and lookups traverse from innermost to outermost scope.
+ *
+ * Used by InitializationAnalyzer, but generic enough for other analyses.
+ */
+
+/**
+ * A single scope in the stack
+ */
+interface IScope<T> {
+  /** Variables declared in this scope */
+  variables: Map<string, T>;
+  /** Parent scope (null for outermost/global scope) */
+  parent: IScope<T> | null;
+}
+
+/**
+ * Generic scope stack for tracking variables across nested scopes
+ *
+ * @typeParam T - The type of data stored for each variable
+ */
+class ScopeStack<T> {
+  private currentScope: IScope<T> | null = null;
+
+  /**
+   * Enter a new scope (e.g., function body, block)
+   * The new scope becomes the current scope, with the previous as parent.
+   */
+  enterScope(): void {
+    const newScope: IScope<T> = {
+      variables: new Map(),
+      parent: this.currentScope,
+    };
+    this.currentScope = newScope;
+  }
+
+  /**
+   * Exit the current scope and return to parent
+   * @returns The exited scope, or null if already at root
+   */
+  exitScope(): IScope<T> | null {
+    const exited = this.currentScope;
+    if (this.currentScope) {
+      this.currentScope = this.currentScope.parent;
+    }
+    return exited;
+  }
+
+  /**
+   * Declare a variable in the current scope
+   * @param name - Variable name
+   * @param state - Initial state for the variable
+   * @throws Error if no scope exists (call enterScope first)
+   */
+  declare(name: string, state: T): void {
+    if (!this.currentScope) {
+      throw new Error("Cannot declare variable: no active scope");
+    }
+    this.currentScope.variables.set(name, state);
+  }
+
+  /**
+   * Look up a variable by name, searching from innermost to outermost scope
+   * @param name - Variable name to find
+   * @returns The variable state, or null if not found in any scope
+   */
+  lookup(name: string): T | null {
+    let scope = this.currentScope;
+    while (scope) {
+      const state = scope.variables.get(name);
+      if (state !== undefined) {
+        return state;
+      }
+      scope = scope.parent;
+    }
+    return null;
+  }
+
+  /**
+   * Check if a variable exists in any scope
+   * @param name - Variable name to check
+   */
+  has(name: string): boolean {
+    return this.lookup(name) !== null;
+  }
+
+  /**
+   * Check if a variable is declared in the current (innermost) scope only
+   * Useful for detecting shadowing or redeclaration errors
+   * @param name - Variable name to check
+   */
+  hasInCurrentScope(name: string): boolean {
+    return this.currentScope?.variables.has(name) ?? false;
+  }
+
+  /**
+   * Update a variable's state in the scope where it's defined
+   * @param name - Variable name
+   * @param updater - Function that receives current state and returns new state
+   * @returns true if variable was found and updated, false otherwise
+   */
+  update(name: string, updater: (state: T) => T): boolean {
+    let scope = this.currentScope;
+    while (scope) {
+      if (scope.variables.has(name)) {
+        const current = scope.variables.get(name)!;
+        scope.variables.set(name, updater(current));
+        return true;
+      }
+      scope = scope.parent;
+    }
+    return false;
+  }
+
+  /**
+   * Get all variables visible from the current scope
+   * Variables in inner scopes shadow those in outer scopes.
+   * @returns Map of variable name to state
+   */
+  getAllVisible(): Map<string, T> {
+    const result = new Map<string, T>();
+    let scope = this.currentScope;
+    while (scope) {
+      for (const [name, state] of scope.variables) {
+        // Only add if not already shadowed by inner scope
+        if (!result.has(name)) {
+          result.set(name, state);
+        }
+      }
+      scope = scope.parent;
+    }
+    return result;
+  }
+
+  /**
+   * Clone the entire state of all visible variables
+   * Useful for control flow analysis (saving state before branches)
+   * @param cloner - Function to deep-clone individual variable states
+   * @returns Map of variable name to cloned state
+   */
+  cloneState(cloner: (state: T) => T): Map<string, T> {
+    const result = new Map<string, T>();
+    let scope = this.currentScope;
+    while (scope) {
+      for (const [name, state] of scope.variables) {
+        if (!result.has(name)) {
+          result.set(name, cloner(state));
+        }
+      }
+      scope = scope.parent;
+    }
+    return result;
+  }
+
+  /**
+   * Restore variable states from a saved snapshot
+   * Only updates variables that exist in both current scope chain and snapshot.
+   * @param savedState - Previously cloned state map
+   * @param restorer - Function to restore state (receives current and saved, returns new)
+   */
+  restoreState(
+    savedState: Map<string, T>,
+    restorer: (current: T, saved: T) => T,
+  ): void {
+    for (const [name, savedVarState] of savedState) {
+      this.update(name, (current) => restorer(current, savedVarState));
+    }
+  }
+
+  /**
+   * Get the current scope depth (0 = no scope, 1 = one scope, etc.)
+   * Useful for debugging and determining if we're at global level
+   */
+  getDepth(): number {
+    let depth = 0;
+    let scope = this.currentScope;
+    while (scope) {
+      depth++;
+      scope = scope.parent;
+    }
+    return depth;
+  }
+
+  /**
+   * Check if we're currently inside any scope
+   */
+  hasActiveScope(): boolean {
+    return this.currentScope !== null;
+  }
+
+  /**
+   * Iterate over all variables in the current scope only (not parents)
+   * @returns Iterator of [name, state] pairs
+   */
+  *currentScopeVariables(): IterableIterator<[string, T]> {
+    if (this.currentScope) {
+      yield* this.currentScope.variables;
+    }
+  }
+}
+
+export default ScopeStack;


### PR DESCRIPTION
## Summary

- Add comprehensive unit tests for 4 semantic analyzers (110 new tests)
- Extract `ScopeStack` as a reusable generic data structure
- Refactor `InitializationAnalyzer` to use the new `ScopeStack`

### New Test Coverage

| Analyzer | Tests | What It Tests |
|----------|-------|---------------|
| DivisionByZeroAnalyzer | 19 | Literal/const zero detection for `/` and `%` |
| FloatModuloAnalyzer | 20 | Float type modulo detection |
| ParameterNamingAnalyzer | 15 | Reserved parameter name validation |
| FunctionCallAnalyzer | 21 | Define-before-use, recursion, stdlib |
| ScopeStack | 35 | Generic scope management (pure unit tests) |

### ScopeStack Extraction

Extracted a generic `ScopeStack<T>` class from `InitializationAnalyzer`:
- Reusable for other analyzers (e.g., `NullCheckAnalyzer` has similar scope tracking)
- 35 pure unit tests with no parser dependency
- Supports lexical scoping, shadowing, and control flow state clone/restore

## Test plan

- [x] All 548 unit tests pass
- [x] All 704 integration tests pass
- [x] `npm run unit` passes
- [x] `npm test` passes

🤖 Generated with [Claude Code](https://claude.ai/code)