### PR TITLE
Release v0.1.33

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.33] - 2026-01-24
+
+### Added
+
+- C++ namespace types support for external library interop (Issue #388, PR #390)
+- FloatModuloAnalyzer and FunctionCallAnalyzer integration tests (PR #389)
+
+### Fixed
+
+- Unified assignment target grammar rules (Issue #387, PR #392)
+- Unified include resolution and pass symbol table to FunctionCallAnalyzer (PR #391)
+
 ## [0.1.32] - 2026-01-24
 
 ### Added
@@ -363,7 +375,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - 38 legacy ESLint errors (non-blocking, tracked for future cleanup)
 
-[Unreleased]: https://github.com/jlaustill/c-next/compare/v0.1.32...HEAD
+[Unreleased]: https://github.com/jlaustill/c-next/compare/v0.1.33...HEAD
+[0.1.33]: https://github.com/jlaustill/c-next/compare/v0.1.32...v0.1.33
 [0.1.32]: https://github.com/jlaustill/c-next/compare/v0.1.31...v0.1.32
 [0.1.31]: https://github.com/jlaustill/c-next/compare/v0.1.30...v0.1.31
 [0.1.30]: https://github.com/jlaustill/c-next/compare/v0.1.29...v0.1.30

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "c-next",
-  "version": "0.1.32",
+  "version": "0.1.33",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "c-next",
-      "version": "0.1.32",
+      "version": "0.1.33",
       "license": "MIT",
       "dependencies": {
         "antlr4ng": "^3.0.16",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "c-next",
-  "version": "0.1.32",
+  "version": "0.1.33",
   "description": "A safer C for embedded systems development. Transpiles to clean, readable C.",
   "main": "src/index.ts",
   "bin": {


### PR DESCRIPTION
## Summary

- Adds C++ namespace types support for external library interop (Issue #388)
- Adds FloatModuloAnalyzer and FunctionCallAnalyzer integration tests
- Fixes unified assignment target grammar rules (Issue #387)
- Fixes include resolution and symbol table passing to FunctionCallAnalyzer

## Test plan

- [x] All 730 tests passing
- [x] TypeScript typecheck clean
- [ ] Review CHANGELOG entries
- [ ] Merge and tag v0.1.33

🤖 Generated with [Claude Code](https://claude.ai/code)