### PR TITLE
fix: include macro-defining headers in generated .h files

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -161,6 +161,12 @@ u32 main() {
 }
 ```
 
+## Header Generation
+
+**Symbol collection timing in `transpileSource()`**: When generating headers, symbol collection MUST happen AFTER `codeGenerator.generate()`. Placing it before breaks type resolution (e.g., `strlen()` becomes placeholder comments).
+
+**Test `.expected.h` files**: The test framework validates `.expected.h` files when present. Create one alongside `.expected.c` for header generation tests.
+
 ## Task Completion Requirements
 
 **A task is NOT complete until all relevant documentation is updated:**


### PR DESCRIPTION
## Summary
- Fix generated `.h` files to include headers that define macros used in extern array declarations (closes #424)
- Add header generation guidance to CLAUDE.md documenting symbol collection timing and `.expected.h` test files

## Test plan
- [x] Existing tests pass
- [x] Header generation correctly includes macro-defining headers

🤖 Generated with [Claude Code](https://claude.com/claude-code)