### PR TITLE
docs: add Development Tips section to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -238,6 +238,10 @@ If implementing a feature, all documents must be current and memory must be upda
 - Use the `/commit-push-pr` skill or `git push` + `gh pr create` to push and create PRs
 - If the user says "commit this", only commit - ask before pushing
 
+## Development Tips
+
+**Testing local changes**: Use `npx tsx src/index.ts <file.cnx>` instead of the global `cnext` binary to test uncommitted transpiler changes.
+
 ## Release Checklist
 
 **See [`releasing.md`](releasing.md) for the complete release process.**


### PR DESCRIPTION
## Summary

- Adds a "Development Tips" section to CLAUDE.md
- Documents using `npx tsx src/index.ts` instead of global `cnext` binary when testing local transpiler changes

## Context

Learned during #427 fix that the globally installed `cnext` binary may be stale and won't reflect uncommitted changes. This tip helps future sessions avoid confusion.

## Test plan

- [x] Documentation only, no code changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)