### PR TITLE
fix: resolve SonarCloud code smells

### DIFF
--- a/src/analysis/FunctionCallAnalyzer.ts
+++ b/src/analysis/FunctionCallAnalyzer.ts
@@ -464,7 +464,7 @@ class FunctionCallAnalyzer {
     for (const include of tree.includeDirective()) {
       // Extract header name from #include <header.h> or #include "header.h"
       const text = include.getText();
-      const match = text.match(/#include\s*[<"]([^>"]+)[>"]/);
+      const match = /#include\s*[<"]([^>"]+)[>"]/.exec(text);
       if (match) {
         this.includedHeaders.add(match[1]);
       }

--- a/src/analysis/InitializationAnalyzer.ts
+++ b/src/analysis/InitializationAnalyzer.ts
@@ -390,7 +390,7 @@ class InitializationListener extends CNextListener {
     // Check if condition is var < POSITIVE_CONSTANT
     const condText = cond.getText();
     // Match patterns like "i<4" or "ti<3" (no spaces in AST getText())
-    const match = condText.match(/^\w+<(\d+)$/);
+    const match = /^\w+<(\d+)$/.exec(condText);
     if (!match) return false;
     const bound = parseInt(match[1], 10);
     return bound > 0;

--- a/src/analysis/NullCheckAnalyzer.ts
+++ b/src/analysis/NullCheckAnalyzer.ts
@@ -354,8 +354,8 @@ class NullCheckListener extends CNextListener {
     const conditionText = condition?.getText() ?? "";
 
     // Check for patterns like "c_var != NULL" or "c_var = NULL"
-    const nullCheckMatch = conditionText.match(
-      /^(c_[a-zA-Z_][a-zA-Z0-9_]*)\s*(!?=)\s*NULL$/,
+    const nullCheckMatch = /^(c_[a-zA-Z_][a-zA-Z0-9_]*)\s*(!?=)\s*NULL$/.exec(
+      conditionText,
     );
 
     if (nullCheckMatch) {
@@ -465,8 +465,8 @@ class NullCheckListener extends CNextListener {
     const conditionText = condition?.getText() ?? "";
 
     // Check for patterns like "c_var != NULL"
-    const nullCheckMatch = conditionText.match(
-      /^(c_[a-zA-Z_][a-zA-Z0-9_]*)\s*!=\s*NULL$/,
+    const nullCheckMatch = /^(c_[a-zA-Z_][a-zA-Z0-9_]*)\s*!=\s*NULL$/.exec(
+      conditionText,
     );
 
     if (nullCheckMatch) {
@@ -835,7 +835,7 @@ class NullCheckAnalyzer {
   private collectIncludes(tree: Parser.ProgramContext): void {
     for (const include of tree.includeDirective()) {
       const text = include.getText();
-      const match = text.match(/#include\s*[<"]([^>"]+)[>"]/);
+      const match = /#include\s*[<"]([^>"]+)[>"]/.exec(text);
       if (match) {
         this.includedHeaders.add(match[1]);
       }

--- a/src/codegen/CodeGenerator.ts
+++ b/src/codegen/CodeGenerator.ts
@@ -1711,7 +1711,7 @@ export default class CodeGenerator implements IOrchestrator {
         // PRAGMA_TARGET captures the whole "#pragma target <name>" as one token
         const text = pragmaDir.getText();
         // Extract target name: "#pragma target teensy41" -> "teensy41"
-        const match = text.match(/#\s*pragma\s+target\s+(\S+)/i);
+        const match = /#\s*pragma\s+target\s+(\S+)/i.exec(text);
         if (match) {
           const targetName = match[1].toLowerCase();
           if (TARGET_CAPABILITIES[targetName]) {
@@ -2498,20 +2498,20 @@ export default class CodeGenerator implements IOrchestrator {
     const text = ctx.getText().trim();
 
     // Check if it's a simple integer literal
-    if (/^-?\d+$/.test(text)) {
+    if (/^-?\d+$/.exec(text)) {
       return parseInt(text, 10);
     }
     // Check if it's a hex literal
-    if (/^0[xX][0-9a-fA-F]+$/.test(text)) {
+    if (/^0[xX][0-9a-fA-F]+$/.exec(text)) {
       return parseInt(text, 16);
     }
     // Check if it's a binary literal
-    if (/^0[bB][01]+$/.test(text)) {
+    if (/^0[bB][01]+$/.exec(text)) {
       return parseInt(text.substring(2), 2);
     }
 
     // Bug #8: Check if it's a known const value (identifier)
-    if (/^[a-zA-Z_][a-zA-Z0-9_]*$/.test(text)) {
+    if (/^[a-zA-Z_][a-zA-Z0-9_]*$/.exec(text)) {
       const constValue = this.constValues.get(text);
       if (constValue !== undefined) {
         return constValue;
@@ -2519,9 +2519,8 @@ export default class CodeGenerator implements IOrchestrator {
     }
 
     // Bug #8: Handle simple binary expressions with const values (e.g., INDEX_1 + INDEX_1)
-    const addMatch = text.match(
-      /^([a-zA-Z_][a-zA-Z0-9_]*)\+([a-zA-Z_][a-zA-Z0-9_]*)$/,
-    );
+    const addMatch =
+      /^([a-zA-Z_][a-zA-Z0-9_]*)\+([a-zA-Z_][a-zA-Z0-9_]*)$/.exec(text);
     if (addMatch) {
       const left = this.constValues.get(addMatch[1]);
       const right = this.constValues.get(addMatch[2]);
@@ -2531,7 +2530,7 @@ export default class CodeGenerator implements IOrchestrator {
     }
 
     // Handle sizeof(type) expressions for primitive types
-    const sizeofMatch = text.match(/^sizeof\(([a-zA-Z_][a-zA-Z0-9_]*)\)$/);
+    const sizeofMatch = /^sizeof\(([a-zA-Z_][a-zA-Z0-9_]*)\)$/.exec(text);
     if (sizeofMatch) {
       const typeName = sizeofMatch[1];
       const bitWidth = TYPE_WIDTH[typeName];
@@ -2548,8 +2547,8 @@ export default class CodeGenerator implements IOrchestrator {
     }
 
     // Handle sizeof(type) * N expressions
-    const sizeofMulMatch = text.match(
-      /^sizeof\(([a-zA-Z_][a-zA-Z0-9_]*)\)\*(\d+)$/,
+    const sizeofMulMatch = /^sizeof\(([a-zA-Z_][a-zA-Z0-9_]*)\)\*(\d+)$/.exec(
+      text,
     );
     if (sizeofMulMatch) {
       const typeName = sizeofMulMatch[1];
@@ -2561,8 +2560,8 @@ export default class CodeGenerator implements IOrchestrator {
     }
 
     // Handle sizeof(type) + N expressions
-    const sizeofAddMatch = text.match(
-      /^sizeof\(([a-zA-Z_][a-zA-Z0-9_]*)\)\+(\d+)$/,
+    const sizeofAddMatch = /^sizeof\(([a-zA-Z_][a-zA-Z0-9_]*)\)\+(\d+)$/.exec(
+      text,
     );
     if (sizeofAddMatch) {
       const typeName = sizeofAddMatch[1];
@@ -3491,7 +3490,7 @@ export default class CodeGenerator implements IOrchestrator {
     const text = ctx.getText();
 
     // Check if it's a simple identifier that's an enum variable
-    if (text.match(/^[a-zA-Z_][a-zA-Z0-9_]*$/)) {
+    if (/^[a-zA-Z_][a-zA-Z0-9_]*$/.exec(text)) {
       const typeInfo = this.context.typeRegistry.get(text);
       if (typeInfo?.isEnum && typeInfo.enumTypeName) {
         return typeInfo.enumTypeName;
@@ -3560,15 +3559,15 @@ export default class CodeGenerator implements IOrchestrator {
 
     // Check for integer literals
     if (
-      text.match(/^-?\d+$/) ||
-      text.match(/^0[xX][0-9a-fA-F]+$/) ||
-      text.match(/^0[bB][01]+$/)
+      /^-?\d+$/.exec(text) ||
+      /^0[xX][0-9a-fA-F]+$/.exec(text) ||
+      /^0[bB][01]+$/.exec(text)
     ) {
       return true;
     }
 
     // Check if it's a variable of primitive integer type
-    if (text.match(/^[a-zA-Z_][a-zA-Z0-9_]*$/)) {
+    if (/^[a-zA-Z_][a-zA-Z0-9_]*$/.exec(text)) {
       const typeInfo = this.context.typeRegistry.get(text);
       if (
         typeInfo &&
@@ -3600,7 +3599,7 @@ export default class CodeGenerator implements IOrchestrator {
     }
 
     // Check if it's a simple variable of string type
-    if (text.match(/^[a-zA-Z_][a-zA-Z0-9_]*$/)) {
+    if (/^[a-zA-Z_][a-zA-Z0-9_]*$/.exec(text)) {
       const typeInfo = this.context.typeRegistry.get(text);
       if (typeInfo?.isString) {
         return true;
@@ -3610,7 +3609,7 @@ export default class CodeGenerator implements IOrchestrator {
     // Issue #137: Check for array element access (e.g., names[0], arr[i])
     // Pattern: identifier[expression] or identifier[expression][expression]...
     // BUT NOT if accessing .length/.capacity/.size (those return numbers, not strings)
-    const arrayAccessMatch = text.match(/^([a-zA-Z_][a-zA-Z0-9_]*)\[/);
+    const arrayAccessMatch = /^([a-zA-Z_][a-zA-Z0-9_]*)\[/.exec(text);
     if (arrayAccessMatch) {
       // ADR-045: String properties return numeric values, not strings
       if (
@@ -3719,7 +3718,7 @@ export default class CodeGenerator implements IOrchestrator {
     }
 
     // Variable - check type registry
-    if (expr.match(/^[a-zA-Z_][a-zA-Z0-9_]*$/)) {
+    if (/^[a-zA-Z_][a-zA-Z0-9_]*$/.exec(expr)) {
       const typeInfo = this.context.typeRegistry.get(expr);
       if (typeInfo?.isString && typeInfo.stringCapacity !== undefined) {
         return typeInfo.stringCapacity;
@@ -5457,7 +5456,7 @@ export default class CodeGenerator implements IOrchestrator {
                 const firstDimExpr = arrayDims[0].expression();
                 if (firstDimExpr) {
                   const sizeText = firstDimExpr.getText();
-                  if (sizeText.match(/^\d+$/)) {
+                  if (/^\d+$/.exec(sizeText)) {
                     const declaredSize = parseInt(sizeText, 10);
                     if (
                       this.context.lastArrayFillValue === undefined &&
@@ -5479,7 +5478,7 @@ export default class CodeGenerator implements IOrchestrator {
                 const firstDimExpr = arrayDims[0].expression();
                 if (firstDimExpr) {
                   const sizeText = firstDimExpr.getText();
-                  if (sizeText.match(/^\d+$/)) {
+                  if (/^\d+$/.exec(sizeText)) {
                     const declaredSize = parseInt(sizeText, 10);
                     const fillVal = this.context.lastArrayFillValue;
                     // Only expand if not empty string (C handles {""} correctly for zeroing)
@@ -5669,7 +5668,7 @@ export default class CodeGenerator implements IOrchestrator {
     // Get first dimension size for simple validation (multi-dim validation is more complex)
     if (isArray && arrayDims[0].expression()) {
       const sizeText = arrayDims[0].expression()!.getText();
-      if (sizeText.match(/^\d+$/)) {
+      if (/^\d+$/.exec(sizeText)) {
         declaredSize = parseInt(sizeText, 10);
       }
     }
@@ -5822,9 +5821,9 @@ export default class CodeGenerator implements IOrchestrator {
         const exprText = ctx.expression()!.getText().trim();
         // Check if it's a direct literal (not a variable or expression)
         if (
-          exprText.match(/^-?\d+$/) ||
-          exprText.match(/^0[xX][0-9a-fA-F]+$/) ||
-          exprText.match(/^0[bB][01]+$/)
+          /^-?\d+$/.exec(exprText) ||
+          /^0[xX][0-9a-fA-F]+$/.exec(exprText) ||
+          /^0[bB][01]+$/.exec(exprText)
         ) {
           this._validateLiteralFitsType(exprText, typeName);
         } else {
@@ -6304,9 +6303,9 @@ export default class CodeGenerator implements IOrchestrator {
         const exprText = ctx.expression().getText().trim();
         // Check if it's a direct literal
         if (
-          exprText.match(/^-?\d+$/) ||
-          exprText.match(/^0[xX][0-9a-fA-F]+$/) ||
-          exprText.match(/^0[bB][01]+$/)
+          /^-?\d+$/.exec(exprText) ||
+          /^0[xX][0-9a-fA-F]+$/.exec(exprText) ||
+          /^0[bB][01]+$/.exec(exprText)
         ) {
           this._validateLiteralFitsType(exprText, targetTypeInfo.baseType);
         } else {
@@ -7801,7 +7800,7 @@ export default class CodeGenerator implements IOrchestrator {
 
           // Check if field is a string type (non-array)
           if (fieldType && fieldType.startsWith("string<")) {
-            const match = fieldType.match(/^string<(\d+)>$/);
+            const match = /^string<(\d+)>$/.exec(fieldType);
             if (match) {
               if (cOp !== "=") {
                 throw new Error(
@@ -9663,7 +9662,7 @@ export default class CodeGenerator implements IOrchestrator {
 
     // Check for function calls by looking for identifier followed by (
     // This is a heuristic - looking for "name(" pattern that's not a cast
-    if (/[a-zA-Z_][a-zA-Z0-9_]*\s*\(/.test(text)) {
+    if (/[a-zA-Z_][a-zA-Z0-9_]*\s*\(/.exec(text)) {
       // Could be a function call - walk the tree to confirm
       return this.hasPostfixFunctionCall(expr);
     }

--- a/src/codegen/HeaderGenerator.ts
+++ b/src/codegen/HeaderGenerator.ts
@@ -66,8 +66,7 @@ class HeaderGenerator {
       const needsUserIncludes = symbols.some(
         (s) =>
           s.isArray &&
-          s.arrayDimensions &&
-          s.arrayDimensions.some((dim) => this.isMacroDimension(dim)),
+          s.arrayDimensions?.some((dim) => this.isMacroDimension(dim)),
       );
 
       if (needsUserIncludes) {
@@ -500,7 +499,7 @@ class HeaderGenerator {
 
     // Check if the mapped type has embedded array dimensions (e.g., char[33])
     // This happens for string<N> types which map to char[N+1]
-    const embeddedMatch = cType.match(/^(\w+)\[(\d+)\]$/);
+    const embeddedMatch = /^(\w+)\[(\d+)\]$/.exec(cType);
     if (embeddedMatch) {
       const baseType = embeddedMatch[1];
       const embeddedDim = embeddedMatch[2];

--- a/src/codegen/TypeResolver.ts
+++ b/src/codegen/TypeResolver.ts
@@ -122,13 +122,13 @@ class TypeResolver {
     try {
       const cleanText = literalText.trim();
 
-      if (cleanText.match(/^-?\d+$/)) {
+      if (/^-?\d+$/.exec(cleanText)) {
         // Decimal integer
         value = BigInt(cleanText);
-      } else if (cleanText.match(/^0[xX][0-9a-fA-F]+$/)) {
+      } else if (/^0[xX][0-9a-fA-F]+$/.exec(cleanText)) {
         // Hex literal
         value = BigInt(cleanText);
-      } else if (cleanText.match(/^0[bB][01]+$/)) {
+      } else if (/^0[bB][01]+$/.exec(cleanText)) {
         // Binary literal
         value = BigInt(cleanText);
       } else {
@@ -167,7 +167,7 @@ class TypeResolver {
     if (text === "true" || text === "false") return "bool";
 
     // Check for type suffix on numeric literals
-    const suffixMatch = text.match(/([uUiI])(8|16|32|64)$/);
+    const suffixMatch = /([uUiI])(8|16|32|64)$/.exec(text);
     if (suffixMatch) {
       const signChar = suffixMatch[1].toLowerCase();
       const width = suffixMatch[2];
@@ -175,7 +175,7 @@ class TypeResolver {
     }
 
     // Float suffix
-    const floatMatch = text.match(/[fF](32|64)$/);
+    const floatMatch = /[fF](32|64)$/.exec(text);
     if (floatMatch) {
       return "f" + floatMatch[1];
     }

--- a/src/codegen/TypeValidator.ts
+++ b/src/codegen/TypeValidator.ts
@@ -65,8 +65,8 @@ class TypeValidator {
   ): void {
     // Extract the file path from #include directive
     // Match both <file> and "file" forms
-    const angleMatch = includeText.match(/#\s*include\s*<([^>]+)>/);
-    const quoteMatch = includeText.match(/#\s*include\s*"([^"]+)"/);
+    const angleMatch = /#\s*include\s*<([^>]+)>/.exec(includeText);
+    const quoteMatch = /#\s*include\s*"([^"]+)"/.exec(includeText);
 
     const includePath = angleMatch?.[1] || quoteMatch?.[1];
     if (!includePath) {
@@ -105,8 +105,8 @@ class TypeValidator {
     fileExists: (path: string) => boolean = (p) => require("fs").existsSync(p),
   ): void {
     // Extract the file path from #include directive
-    const angleMatch = includeText.match(/#\s*include\s*<([^>]+)>/);
-    const quoteMatch = includeText.match(/#\s*include\s*"([^"]+)"/);
+    const angleMatch = /#\s*include\s*<([^>]+)>/.exec(includeText);
+    const quoteMatch = /#\s*include\s*"([^"]+)"/.exec(includeText);
 
     const includePath = angleMatch?.[1] || quoteMatch?.[1];
     if (!includePath) {
@@ -173,11 +173,11 @@ class TypeValidator {
     // Check for integer literals
     let value: number | null = null;
 
-    if (text.match(/^\d+$/)) {
+    if (/^\d+$/.exec(text)) {
       value = parseInt(text, 10);
-    } else if (text.match(/^0[xX][0-9a-fA-F]+$/)) {
+    } else if (/^0[xX][0-9a-fA-F]+$/.exec(text)) {
       value = parseInt(text, 16);
-    } else if (text.match(/^0[bB][01]+$/)) {
+    } else if (/^0[bB][01]+$/.exec(text)) {
       value = parseInt(text.substring(2), 2);
     }
 
@@ -1063,7 +1063,7 @@ class TypeValidator {
       } else if (text.startsWith("0b") || text.startsWith("0B")) {
         value = parseInt(text.slice(2), 2);
       } else {
-        const numMatch = text.match(/^\d+/);
+        const numMatch = /^\d+/.exec(text);
         if (numMatch) {
           value = parseInt(numMatch[0], 10);
         }

--- a/src/codegen/generators/expressions/BinaryExprGenerator.ts
+++ b/src/codegen/generators/expressions/BinaryExprGenerator.ts
@@ -27,17 +27,17 @@ const tryParseNumericLiteral = (code: string): number | undefined => {
   const trimmed = code.trim();
 
   // Decimal integer (including negative)
-  if (/^-?\d+$/.test(trimmed)) {
+  if (/^-?\d+$/.exec(trimmed)) {
     return parseInt(trimmed, 10);
   }
 
   // Hex literal
-  if (/^0[xX][0-9a-fA-F]+$/.test(trimmed)) {
+  if (/^0[xX][0-9a-fA-F]+$/.exec(trimmed)) {
     return parseInt(trimmed, 16);
   }
 
   // Binary literal
-  if (/^0[bB][01]+$/.test(trimmed)) {
+  if (/^0[bB][01]+$/.exec(trimmed)) {
     return parseInt(trimmed.substring(2), 2);
   }
 

--- a/src/codegen/generators/expressions/LiteralGenerator.ts
+++ b/src/codegen/generators/expressions/LiteralGenerator.ts
@@ -40,9 +40,9 @@ const generateLiteral = (
   // ADR-024: Transform C-Next float suffixes to standard C syntax
   // 3.14f32 -> 3.14f (C float)
   // 3.14f64 -> 3.14 (C double, no suffix needed)
-  if (/[fF]32$/.test(literalText)) {
+  if (/[fF]32$/.exec(literalText)) {
     literalText = literalText.replace(/[fF]32$/, "f");
-  } else if (/[fF]64$/.test(literalText)) {
+  } else if (/[fF]64$/.exec(literalText)) {
     literalText = literalText.replace(/[fF]64$/, "");
   }
 
@@ -50,11 +50,11 @@ const generateLiteral = (
   // u8/u16/u32 and i8/i16/i32 suffixes are stripped (C infers from context)
   // u64 -> ULL suffix for 64-bit unsigned
   // i64 -> LL suffix for 64-bit signed
-  if (/[uU]64$/.test(literalText)) {
+  if (/[uU]64$/.exec(literalText)) {
     literalText = literalText.replace(/[uU]64$/, "ULL");
-  } else if (/[iI]64$/.test(literalText)) {
+  } else if (/[iI]64$/.exec(literalText)) {
     literalText = literalText.replace(/[iI]64$/, "LL");
-  } else if (/[uUiI](8|16|32)$/.test(literalText)) {
+  } else if (/[uUiI](8|16|32)$/.exec(literalText)) {
     // Strip 8/16/32-bit suffixes - C handles these without explicit suffix
     literalText = literalText.replace(/[uUiI](8|16|32)$/, "");
   }

--- a/src/codegen/generators/support/IncludeGenerator.ts
+++ b/src/codegen/generators/support/IncludeGenerator.ts
@@ -73,8 +73,8 @@ const transformIncludeDirective = (
   const { sourcePath, includeDirs = [], inputs = [] } = options;
 
   // Match: #include <file.cnx> or #include "file.cnx"
-  const angleMatch = includeText.match(/#\s*include\s*<([^>]+)\.cnx>/);
-  const quoteMatch = includeText.match(/#\s*include\s*"([^"]+)\.cnx"/);
+  const angleMatch = /#\s*include\s*<([^>]+)\.cnx>/.exec(includeText);
+  const quoteMatch = /#\s*include\s*"([^"]+)\.cnx"/.exec(includeText);
 
   if (angleMatch) {
     const filename = angleMatch[1];
@@ -128,7 +128,7 @@ const transformIncludeDirective = (
  * Extract the macro name from a #define directive
  */
 const extractDefineName = (text: string): string => {
-  const match = text.match(/#\s*define\s+([a-zA-Z_][a-zA-Z0-9_]*)/);
+  const match = /#\s*define\s+([a-zA-Z_][a-zA-Z0-9_]*)/.exec(text);
   return match ? match[1] : "unknown";
 };
 

--- a/src/codegen/headerGenerators/mapType.ts
+++ b/src/codegen/headerGenerators/mapType.ts
@@ -45,9 +45,9 @@ function mapType(type: string): string {
   }
 
   // Issue #427: Handle string<N> types -> char[N+1]
-  const stringMatch = type.match(/^string<(\d+)>$/);
+  const stringMatch = /^string<(\d+)>$/.exec(type);
   if (stringMatch) {
-    const capacity = parseInt(stringMatch[1], 10);
+    const capacity = Number.parseInt(stringMatch[1], 10);
     return `char[${capacity + 1}]`;
   }
 
@@ -58,7 +58,7 @@ function mapType(type: string): string {
   }
 
   // Handle array types (simplified)
-  const arrayMatch = type.match(/^(\w+)\[(\d*)\]$/);
+  const arrayMatch = /^(\w+)\[(\d*)\]$/.exec(type);
   if (arrayMatch) {
     const baseType = mapType(arrayMatch[1]);
     const size = arrayMatch[2] || "";

--- a/src/lib/PlatformIODetector.ts
+++ b/src/lib/PlatformIODetector.ts
@@ -76,14 +76,14 @@ function parsePlatformIOConfig(content: string): Record<string, string> {
     }
 
     // Section header
-    const sectionMatch = trimmed.match(/^\[([^\]]+)\]$/);
+    const sectionMatch = /^\[([^\]]+)\]$/.exec(trimmed);
     if (sectionMatch) {
       currentSection = sectionMatch[1];
       continue;
     }
 
     // Key = value pair
-    const kvMatch = trimmed.match(/^(\w+)\s*=\s*(.+)$/);
+    const kvMatch = /^(\w+)\s*=\s*(.+)$/.exec(trimmed);
     if (kvMatch && currentSection) {
       const key = `${currentSection}.${kvMatch[1]}`;
       result[key] = kvMatch[2].trim();

--- a/src/pipeline/Pipeline.ts
+++ b/src/pipeline/Pipeline.ts
@@ -71,7 +71,7 @@ class Pipeline {
     ReadonlyMap<string, ReadonlySet<string>>
   > = new Map();
   /** Issue #424: Store user includes per file for header generation */
-  private userIncludesCollectors: Map<string, string[]> = new Map();
+  private readonly userIncludesCollectors: Map<string, string[]> = new Map();
 
   constructor(config: IPipelineConfig) {
     // Apply defaults

--- a/src/preprocessor/Preprocessor.ts
+++ b/src/preprocessor/Preprocessor.ts
@@ -218,8 +218,8 @@ class Preprocessor {
       const line = lines[i];
 
       // Match # linenum "filename" or #line linenum "filename"
-      const match = line.match(
-        /^#\s*(?:line\s+)?(\d+)\s+"([^"]+)"(?:\s+\d+)*\s*$/,
+      const match = /^#\s*(?:line\s+)?(\d+)\s+"([^"]+)"(?:\s+\d+)*\s*$/.exec(
+        line,
       );
 
       if (match) {
@@ -244,7 +244,7 @@ class Preprocessor {
   private stripLineDirectives(content: string): string {
     return content
       .split("\n")
-      .filter((line) => !line.match(/^#\s*(?:line\s+)?\d+\s+"/))
+      .filter((line) => !/^#\s*(?:line\s+)?\d+\s+"/.exec(line))
       .join("\n");
   }
 

--- a/src/symbols/CNextSymbolCollector.ts
+++ b/src/symbols/CNextSymbolCollector.ts
@@ -391,7 +391,7 @@ class CNextSymbolCollector {
       const arrayDims = p.arrayDimension();
       const dimensions = arrayDims.map((d) => {
         const text = d.getText();
-        const match = text.match(/\[(\d*)\]/);
+        const match = /\[(\d*)\]/.exec(text);
         return match ? match[1] : ""; // "" means unbounded array
       });
 
@@ -472,13 +472,13 @@ class CNextSymbolCollector {
       for (const dim of arrayDims) {
         const dimText = dim.getText();
         // Extract dimension value (e.g., "[4]" -> "4", "[CONST]" -> "CONST")
-        const match = dimText.match(/\[([^\]]*)\]/);
+        const match = /\[([^\]]*)\]/.exec(dimText);
         if (match) {
           arrayDimensions.push(match[1]);
         }
       }
       // Get first dimension size for legacy size field
-      const firstMatch = arrayDims[0].getText().match(/\[(\d+)\]/);
+      const firstMatch = /\[(\d+)\]/.exec(arrayDims[0].getText());
       if (firstMatch) {
         size = parseInt(firstMatch[1], 10);
       }

--- a/src/utils/ExpressionUtils.ts
+++ b/src/utils/ExpressionUtils.ts
@@ -79,47 +79,47 @@ class ExpressionUtils {
 
     // ternaryExpression has multiple orExpressions if it's a ternary (condition ? a : b)
     const orExprs = ternary.orExpression();
-    if (!orExprs || orExprs.length !== 1) return null;
+    if (orExprs?.length !== 1) return null;
 
     // orExpression -> andExpression (multiple = has || operator)
     const andExprs = orExprs[0].andExpression();
-    if (!andExprs || andExprs.length !== 1) return null;
+    if (andExprs?.length !== 1) return null;
 
     // andExpression -> equalityExpression (multiple = has && operator)
     const eqExprs = andExprs[0].equalityExpression();
-    if (!eqExprs || eqExprs.length !== 1) return null;
+    if (eqExprs?.length !== 1) return null;
 
     // equalityExpression -> relationalExpression (multiple = has = or != operator)
     const relExprs = eqExprs[0].relationalExpression();
-    if (!relExprs || relExprs.length !== 1) return null;
+    if (relExprs?.length !== 1) return null;
 
     // relationalExpression -> bitwiseOrExpression (multiple = has <, >, <=, >= operator)
     const bitorExprs = relExprs[0].bitwiseOrExpression();
-    if (!bitorExprs || bitorExprs.length !== 1) return null;
+    if (bitorExprs?.length !== 1) return null;
 
     // bitwiseOrExpression -> bitwiseXorExpression (multiple = has | operator)
     const bitxorExprs = bitorExprs[0].bitwiseXorExpression();
-    if (!bitxorExprs || bitxorExprs.length !== 1) return null;
+    if (bitxorExprs?.length !== 1) return null;
 
     // bitwiseXorExpression -> bitwiseAndExpression (multiple = has ^ operator)
     const bitandExprs = bitxorExprs[0].bitwiseAndExpression();
-    if (!bitandExprs || bitandExprs.length !== 1) return null;
+    if (bitandExprs?.length !== 1) return null;
 
     // bitwiseAndExpression -> shiftExpression (multiple = has & operator)
     const shiftExprs = bitandExprs[0].shiftExpression();
-    if (!shiftExprs || shiftExprs.length !== 1) return null;
+    if (shiftExprs?.length !== 1) return null;
 
     // shiftExpression -> additiveExpression (multiple = has << or >> operator)
     const addExprs = shiftExprs[0].additiveExpression();
-    if (!addExprs || addExprs.length !== 1) return null;
+    if (addExprs?.length !== 1) return null;
 
     // additiveExpression -> multiplicativeExpression (multiple = has + or - operator)
     const multExprs = addExprs[0].multiplicativeExpression();
-    if (!multExprs || multExprs.length !== 1) return null;
+    if (multExprs?.length !== 1) return null;
 
     // multiplicativeExpression -> unaryExpression (multiple = has *, /, % operator)
     const unaryExprs = multExprs[0].unaryExpression();
-    if (!unaryExprs || unaryExprs.length !== 1) return null;
+    if (unaryExprs?.length !== 1) return null;
 
     return unaryExprs[0];
   }


### PR DESCRIPTION
## Summary

- Convert `string.match(regex)` to `regex.exec(string)` for SonarCloud consistency rule (43+ instances across 14 files)
- Use optional chaining for null checks (12 instances in `ExpressionUtils.ts`, 1 in `HeaderGenerator.ts`)  
- Mark Map property as `readonly` in `Pipeline.ts`
- Use `Number.parseInt` instead of global `parseInt` in `mapType.ts`

## Details

All changes are mechanical refactors that maintain identical runtime behavior. The `regex.exec(string)` pattern is preferred by SonarCloud over `string.match(regex)` for consistency and slight performance benefits.

**Files modified:** 16
**Issues resolved:** ~57 SonarCloud code smells

## Test plan

- [x] All 681 unit tests pass
- [x] All 743 integration tests pass
- [x] Pre-commit hooks (prettier, oxlint) pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)