### PR TITLE
docs: add status badges to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,12 @@
 # C-Next
 
+[![CI](https://github.com/jlaustill/c-next/actions/workflows/pr-checks.yml/badge.svg)](https://github.com/jlaustill/c-next/actions/workflows/pr-checks.yml)
+[![npm version](https://img.shields.io/npm/v/c-next)](https://www.npmjs.com/package/c-next)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
+[![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=jlaustill_c-next&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=jlaustill_c-next)
+[![Coverage](https://sonarcloud.io/api/project_badges/measure?project=jlaustill_c-next&metric=coverage)](https://sonarcloud.io/summary/new_code?id=jlaustill_c-next)
+[![Maintainability Rating](https://sonarcloud.io/api/project_badges/measure?project=jlaustill_c-next&metric=sqale_rating)](https://sonarcloud.io/summary/new_code?id=jlaustill_c-next)
+
 A safer C for embedded systems development. Transpiles to clean, readable C.
 
 **Status: Working Transpiler** — Verified on Teensy MicroMod hardware.


### PR DESCRIPTION
## Summary
- Add CI status badge from GitHub Actions
- Add npm version badge from Shields.io
- Add MIT license badge
- Add SonarCloud badges for quality gate, coverage, and maintainability

## Test plan
- [ ] View README on GitHub to confirm badges render correctly
- [ ] Click each badge to verify links work

🤖 Generated with [Claude Code](https://claude.com/claude-code)