### PR TITLE
Release v0.1.36

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.36] - 2026-01-25
+
+### Fixed
+
+- Unqualified enum member references now correctly prefixed in generated C with type-aware resolution (Issue #452, PR #453)
+
 ## [0.1.35] - 2026-01-25
 
 ### Fixed
@@ -417,6 +423,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - 38 legacy ESLint errors (non-blocking, tracked for future cleanup)
 
 [Unreleased]: https://github.com/jlaustill/c-next/compare/v0.1.35...HEAD
+[0.1.36]: https://github.com/jlaustill/c-next/compare/v0.1.35...v0.1.36
 [0.1.35]: https://github.com/jlaustill/c-next/compare/v0.1.34...v0.1.35
 [0.1.34]: https://github.com/jlaustill/c-next/compare/v0.1.33...v0.1.34
 [0.1.33]: https://github.com/jlaustill/c-next/compare/v0.1.32...v0.1.33

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "c-next",
-  "version": "0.1.35",
+  "version": "0.1.36",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "c-next",
-      "version": "0.1.35",
+      "version": "0.1.36",
       "license": "MIT",
       "dependencies": {
         "antlr4ng": "^3.0.16",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "c-next",
-  "version": "0.1.35",
+  "version": "0.1.36",
   "description": "A safer C for embedded systems development. Transpiles to clean, readable C.",
   "main": "src/index.ts",
   "bin": {


### PR DESCRIPTION
## Release v0.1.36

### Fixed

- Unqualified enum member references now correctly prefixed in generated C with type-aware resolution (Issue #452, PR #453)

### Checklist

- [x] Version bumped in package.json
- [x] CHANGELOG.md updated
- [x] All tests pass (777)

After merge, tag with:
```bash
git checkout main && git pull
git tag v0.1.36
git push origin v0.1.36
```