### PR TITLE
Release v0.1.37

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.37] - 2026-01-25
+
+### Fixed
+
+- Preserve const-based array dimensions in struct field declarations (Issue #455, PR #457)
+- Support C macro dimensions in array declarations for header interop (PR #456)
+- Handle hex and binary constants in array dimension expressions (PR #456)
+- Preserve const-based array dimensions in extern header declarations (PR #456)
+- Preserve tracked .test.h files and clean up stale test artifacts (PR #458)
+
 ## [0.1.36] - 2026-01-25
 
 ### Fixed
@@ -423,6 +433,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - 38 legacy ESLint errors (non-blocking, tracked for future cleanup)
 
 [Unreleased]: https://github.com/jlaustill/c-next/compare/v0.1.35...HEAD
+[0.1.37]: https://github.com/jlaustill/c-next/compare/v0.1.36...v0.1.37
 [0.1.36]: https://github.com/jlaustill/c-next/compare/v0.1.35...v0.1.36
 [0.1.35]: https://github.com/jlaustill/c-next/compare/v0.1.34...v0.1.35
 [0.1.34]: https://github.com/jlaustill/c-next/compare/v0.1.33...v0.1.34

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "c-next",
-  "version": "0.1.36",
+  "version": "0.1.37",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "c-next",
-      "version": "0.1.36",
+      "version": "0.1.37",
       "license": "MIT",
       "dependencies": {
         "antlr4ng": "^3.0.16",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "c-next",
-  "version": "0.1.36",
+  "version": "0.1.37",
   "description": "A safer C for embedded systems development. Transpiles to clean, readable C.",
   "main": "src/index.ts",
   "bin": {

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "c-next",
   "displayName": "C-Next",
   "description": "Syntax highlighting and live C preview for C-Next, a safer C for embedded systems",
-  "version": "0.1.34",
+  "version": "0.1.37",
   "publisher": "jlaustill",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
## Summary
- Bump version to 0.1.37
- Update CHANGELOG with fixes since v0.1.36

## Changes Since v0.1.36
- Preserve const-based array dimensions in struct field declarations (Issue #455, PR #457)
- Support C macro dimensions in array declarations for header interop (PR #456)
- Handle hex and binary constants in array dimension expressions (PR #456)
- Preserve const-based array dimensions in extern header declarations (PR #456)
- Preserve tracked .test.h files and clean up stale test artifacts (PR #458)

## Test plan
- [x] All 780 integration tests pass
- [x] TypeScript type checking passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)