### PR TITLE
chore: release v0.1.39

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.39] - 2026-01-26
+
+### Fixed
+
+- Enum values from external (included) .cnx files now correctly get type prefix in generated C code (Issue #465, PR #466)
+
 ## [0.1.38] - 2026-01-26
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "c-next",
-  "version": "0.1.38",
+  "version": "0.1.39",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "c-next",
-      "version": "0.1.38",
+      "version": "0.1.39",
       "license": "MIT",
       "dependencies": {
         "antlr4ng": "^3.0.16",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "c-next",
-  "version": "0.1.38",
+  "version": "0.1.39",
   "description": "A safer C for embedded systems development. Transpiles to clean, readable C.",
   "main": "src/index.ts",
   "bin": {


### PR DESCRIPTION
## Release v0.1.39

### Fixed

- Enum values from external (included) .cnx files now correctly get type prefix in generated C code (Issue #465, PR #466)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)