### PR TITLE
Release v0.1.40

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.40] - 2026-01-26
+
+### Fixed
+
+- Add `volatile` qualifier to extern declarations for atomic variables (Issue #468, PR #469)
+
 ## [0.1.39] - 2026-01-26
 
 ### Fixed
@@ -449,7 +455,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - 38 legacy ESLint errors (non-blocking, tracked for future cleanup)
 
-[Unreleased]: https://github.com/jlaustill/c-next/compare/v0.1.38...HEAD
+[Unreleased]: https://github.com/jlaustill/c-next/compare/v0.1.40...HEAD
+[0.1.40]: https://github.com/jlaustill/c-next/compare/v0.1.39...v0.1.40
+[0.1.39]: https://github.com/jlaustill/c-next/compare/v0.1.38...v0.1.39
 [0.1.38]: https://github.com/jlaustill/c-next/compare/v0.1.37...v0.1.38
 [0.1.37]: https://github.com/jlaustill/c-next/compare/v0.1.36...v0.1.37
 [0.1.36]: https://github.com/jlaustill/c-next/compare/v0.1.35...v0.1.36

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "c-next",
-  "version": "0.1.39",
+  "version": "0.1.40",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "c-next",
-      "version": "0.1.39",
+      "version": "0.1.40",
       "license": "MIT",
       "dependencies": {
         "antlr4ng": "^3.0.16",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "c-next",
-  "version": "0.1.39",
+  "version": "0.1.40",
   "description": "A safer C for embedded systems development. Transpiles to clean, readable C.",
   "main": "src/index.ts",
   "bin": {

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "c-next",
   "displayName": "C-Next",
   "description": "Syntax highlighting and live C preview for C-Next, a safer C for embedded systems",
-  "version": "0.1.37",
+  "version": "0.1.40",
   "publisher": "jlaustill",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
## Summary

- Bump version to 0.1.40
- Sync VS Code extension version (0.1.37 → 0.1.40)
- Add CHANGELOG entry for volatile qualifier fix in extern atomic declarations

### Changes in this release

- **Fixed**: Add `volatile` qualifier to extern declarations for atomic variables (Issue #468, PR #469)

## Test plan

- [x] All 787 tests pass
- [x] TypeScript typecheck passes
- [x] All pre-push quality checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)