### PR TITLE
Release v0.1.45

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.45] - 2026-01-26
+
+### Fixed
+
+- Cross-scope method calls returning enum types now correctly resolved (Issue #483)
+
+### Note
+
+- Re-release of 0.1.44 content due to npm publish issue
+
 ## [0.1.43] - 2026-01-26
 
 ### Fixed
@@ -489,15 +499,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - 38 legacy ESLint errors (non-blocking, tracked for future cleanup)
 
-[Unreleased]: https://github.com/jlaustill/c-next/compare/v0.1.40...HEAD
-[0.1.40]: https://github.com/jlaustill/c-next/compare/v0.1.39...v0.1.40
-[0.1.39]: https://github.com/jlaustill/c-next/compare/v0.1.38...v0.1.39
-[0.1.38]: https://github.com/jlaustill/c-next/compare/v0.1.37...v0.1.38
-[0.1.37]: https://github.com/jlaustill/c-next/compare/v0.1.36...v0.1.37
-[0.1.36]: https://github.com/jlaustill/c-next/compare/v0.1.35...v0.1.36
-[0.1.35]: https://github.com/jlaustill/c-next/compare/v0.1.34...v0.1.35
-[0.1.34]: https://github.com/jlaustill/c-next/compare/v0.1.33...v0.1.34
-[0.1.33]: https://github.com/jlaustill/c-next/compare/v0.1.32...v0.1.33
+[Unreleased]: https://github.com/jlaustill/c-next/compare/v0.1.45...HEAD
+[0.1.45]: https://github.com/jlaustill/c-next/compare/v0.1.44...v0.1.45
+[0.1.44]: https://github.com/jlaustill/c-next/compare/v0.1.43...v0.1.44
+[0.1.43]: https://github.com/jlaustill/c-next/compare/v0.1.42...v0.1.43
+[0.1.42]: https://github.com/jlaustill/c-next/compare/v0.1.41...v0.1.42
 [0.1.41]: https://github.com/jlaustill/c-next/compare/v0.1.40...v0.1.41
 [0.1.40]: https://github.com/jlaustill/c-next/compare/v0.1.39...v0.1.40
 [0.1.39]: https://github.com/jlaustill/c-next/compare/v0.1.38...v0.1.39

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "c-next",
-  "version": "0.1.44",
+  "version": "0.1.45",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "c-next",
-      "version": "0.1.44",
+      "version": "0.1.45",
       "license": "MIT",
       "dependencies": {
         "antlr4ng": "^3.0.16",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "c-next",
-  "version": "0.1.44",
+  "version": "0.1.45",
   "description": "A safer C for embedded systems development. Transpiles to clean, readable C.",
   "main": "src/index.ts",
   "bin": {


### PR DESCRIPTION
## Summary

Re-release of v0.1.44 content due to npm publish issue. The v0.1.44 publish succeeded according to npm confirmation email but the package never appeared in the registry.

- Cross-scope method calls returning enum types now correctly resolved (Issue #483)

## Test plan

- [x] All 815 tests pass
- [ ] Verify npm publish succeeds after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)