### PR TITLE
fix: VS Code extension diagnostics and included file output paths

### DIFF
--- a/src/lib/transpiler.ts
+++ b/src/lib/transpiler.ts
@@ -15,6 +15,8 @@ import { CNextParser } from "../antlr_parser/grammar/CNextParser";
 import CodeGenerator from "../codegen/CodeGenerator";
 import CommentExtractor from "../codegen/CommentExtractor";
 import InitializationAnalyzer from "../analysis/InitializationAnalyzer";
+import CNextResolver from "../symbol_resolution/cnext";
+import TSymbolInfoAdapter from "../symbol_resolution/cnext/adapters/TSymbolInfoAdapter";
 import FunctionCallAnalyzer from "../analysis/FunctionCallAnalyzer";
 import NullCheckAnalyzer from "../analysis/NullCheckAnalyzer";
 import DivisionByZeroAnalyzer from "../analysis/DivisionByZeroAnalyzer";
@@ -296,10 +298,15 @@ function transpile(
 
   // Generate C code
   try {
+    // ADR-055: Collect symbols using CNextResolver + TSymbolInfoAdapter
+    const tSymbols = CNextResolver.resolve(tree, "<source>");
+    const symbolInfo = TSymbolInfoAdapter.convert(tSymbols);
+
     const generator = new CodeGenerator();
     const code = generator.generate(tree, undefined, tokenStream, {
       debugMode,
       target,
+      symbolInfo,
     });
 
     return {

--- a/src/pipeline/Pipeline.ts
+++ b/src/pipeline/Pipeline.ts
@@ -946,9 +946,10 @@ class Pipeline {
       return outputPath;
     }
 
-    // Fallback: flat output in outDir
+    // Fallback: output next to the source file (not in outDir)
+    // This handles included files that aren't under any input directory
     const outputName = basename(file.path).replace(/\.cnx$|\.cnext$/, ext);
-    return join(this.config.outDir, outputName);
+    return join(dirname(file.path), outputName);
   }
 
   /**
@@ -1069,9 +1070,10 @@ class Pipeline {
       return outputPath;
     }
 
-    // Fallback: flat output in headerDir
+    // Fallback: output next to the source file (not in headerDir)
+    // This handles included files that aren't under any input directory
     const headerName = basename(file.path).replace(/\.cnx$|\.cnext$/, ".h");
-    return join(headerDir, headerName);
+    return join(dirname(file.path), headerName);
   }
 
   /**

--- a/vscode-extension/package-lock.json
+++ b/vscode-extension/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "c-next",
-  "version": "0.1.43",
+  "version": "0.1.44",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "c-next",
-      "version": "0.1.43",
+      "version": "0.1.44",
       "license": "MIT",
       "dependencies": {
         "antlr4ng": "^3.0.0"

--- a/vscode-extension/src/completionProvider.ts
+++ b/vscode-extension/src/completionProvider.ts
@@ -82,7 +82,7 @@ const ACCESS_MODIFIERS = ["rw", "ro", "wo", "w1c", "w1s"];
 /**
  * Boolean and null literals
  */
-const LITERALS = ["true", "false", "null", "NULL"];
+const LITERALS = ["true", "false", "NULL"];
 
 /**
  * Overflow behavior modifiers (ADR-044)

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -80,7 +80,8 @@ function validateDocument(document: vscode.TextDocument): void {
   }
 
   const source = document.getText();
-  const result = transpile(source, { parseOnly: true });
+  // Full transpile to catch code generation errors (not just parse errors)
+  const result = transpile(source);
 
   // Clear diagnostics for this specific document
   diagnosticCollection.delete(document.uri);
@@ -115,7 +116,14 @@ function validateDocument(document: vscode.TextDocument): void {
         : vscode.DiagnosticSeverity.Warning,
     );
     diagnostic.source = "C-Next";
-    diagnostic.code = "parse-error";
+    // Categorize error type based on message content
+    if (error.message.includes("Code generation failed")) {
+      diagnostic.code = "codegen-error";
+    } else if (error.message.includes("error[")) {
+      diagnostic.code = "analysis-error";
+    } else {
+      diagnostic.code = "parse-error";
+    }
     return diagnostic;
   });
 

--- a/vscode-extension/syntaxes/cnext.tmLanguage.json
+++ b/vscode-extension/syntaxes/cnext.tmLanguage.json
@@ -239,7 +239,7 @@
       "patterns": [
         {
           "name": "keyword.operator.assignment.compound.cnext",
-          "match": "(\\+<-|-<-|\\*<-|/<-|%<-|&<-|\\|<-|\\^<-|<<-|>><-)"
+          "match": "(\\+<-|-<-|\\*<-|/<-|%<-|&<-|\\|<-|\\^<-|<<<-|>><-)"
         },
         {
           "name": "keyword.operator.assignment.cnext",
@@ -279,7 +279,7 @@
         },
         {
           "name": "constant.language.null.cnext",
-          "match": "\\b(null|NULL)\\b"
+          "match": "\\b(NULL)\\b"
         },
         {
           "name": "constant.numeric.hex.cnext",


### PR DESCRIPTION
## Summary

- **Fix "symbolInfo is required" error**: Updated `transpiler.ts` to use CNextResolver + TSymbolInfoAdapter for ADR-055 compliance. The VS Code extension preview was broken after ADR-055 changed symbol resolution.

- **Fix misplaced output files for includes**: Included files now output next to their source instead of all going to the main file's directory. Previously `cnext src/Data/Main.cnx` would put all included file outputs in `src/Data/` regardless of where the included file lived.

- **Show code generation errors as diagnostics**: Changed from `parseOnly: true` to full transpile so errors like "Use 'this.X' to access scope member" show as red underlines, not just in the preview panel.

- **Fix syntax highlighting**: Corrected left-shift assignment operator regex (`<<-` → `<<<-`) and removed invalid lowercase `null` (C-Next only supports `NULL`).

## Test plan

- [x] Verified transpiler compiles without errors
- [x] Tested output path fix with mock directory structure
- [x] Rebuilt and installed VS Code extension
- [x] All quality checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)