### PR TITLE
fix: respect headerOut config for single-file inputs + add --config option

### DIFF
--- a/src/pipeline/types/IPipelineConfig.ts
+++ b/src/pipeline/types/IPipelineConfig.ts
@@ -17,6 +17,9 @@ interface IPipelineConfig {
   /** Separate output directory for header files (defaults to outDir) */
   headerOutDir?: string;
 
+  /** Base path to strip from header output paths (only used with headerOutDir) */
+  basePath?: string;
+
   /** Preprocessor defines for C/C++ headers */
   defines?: Record<string, string | boolean>;
 

--- a/src/project/Project.ts
+++ b/src/project/Project.ts
@@ -46,6 +46,7 @@ class Project {
       includeDirs: this.config.includeDirs,
       outDir: this.config.outDir,
       headerOutDir: this.config.headerOutDir,
+      basePath: this.config.basePath,
       defines: this.config.defines,
       preprocess: this.config.preprocess,
       cppRequired: this.config.cppRequired,

--- a/src/project/types/IProjectConfig.ts
+++ b/src/project/types/IProjectConfig.ts
@@ -17,6 +17,9 @@ interface IProjectConfig {
   /** Separate output directory for header files (defaults to outDir) */
   headerOutDir?: string;
 
+  /** Base path to strip from header output paths (only used with headerOutDir) */
+  basePath?: string;
+
   /** Specific files to compile (overrides srcDirs) */
   files?: string[];
 


### PR DESCRIPTION
## Summary
- Fix `headerOut` config option being ignored when transpiling single files (e.g., `cnext src/AppConfig.cnx`)
- Add `--config` CLI option to display effective configuration showing config file path and merged settings
- Add `basePath` option to strip path prefix from header output (only used with `headerOut`)

## Example

With config:
```json
{
  "headerOut": "include",
  "basePath": "src"
}
```

Input `src/AppConfig.cnx` outputs header to `include/AppConfig.h` instead of `include/src/AppConfig.h`.

## Test plan
- [x] Verified `cnext src/AppConfig.cnx` with `headerOut: "include"` config now outputs to `include/src/AppConfig.h`
- [x] Verified `basePath: "src"` strips prefix, outputting to `include/AppConfig.h`
- [x] Verified `--config` displays config file path, all settings including basePath
- [x] All 815 integration tests pass
- [x] All 998 unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)