### PR TITLE
fix: include filename in E0381 error output

### DIFF
--- a/bugs/issue-492-missing-filename/helper.cnx
+++ b/bugs/issue-492-missing-filename/helper.cnx
@@ -1,0 +1,4 @@
+// Helper file - this one should compile fine
+struct Data {
+    i32 value;
+}

--- a/bugs/issue-492-missing-filename/test.cnx
+++ b/bugs/issue-492-missing-filename/test.cnx
@@ -1,0 +1,15 @@
+// Bug reproduction for issue #492
+// Error output should include filename, but currently shows:
+// Error: 11:15 error[E0381]: use of uninitialized variable 'p.x'
+// Should show:
+// Error: test.cnx:11:15 error[E0381]: use of uninitialized variable 'p.x'
+
+struct Point {
+    i32 x;
+    i32 y;
+}
+
+void main() {
+    Point p;
+    i32 val <- p.x;  // E0381: use of uninitialized variable 'p.x'
+}

--- a/src/lib/types/ITranspileError.ts
+++ b/src/lib/types/ITranspileError.ts
@@ -10,6 +10,8 @@ interface ITranspileError {
   message: string;
   /** Severity: 'error' or 'warning' */
   severity: "error" | "warning";
+  /** Source file path (optional, for multi-file compilation) */
+  sourcePath?: string;
 }
 
 export default ITranspileError;

--- a/src/pipeline/Pipeline.ts
+++ b/src/pipeline/Pipeline.ts
@@ -215,7 +215,12 @@ class Pipeline {
 
         if (!fileResult.success) {
           result.success = false;
-          result.errors.push(...fileResult.errors);
+          result.errors.push(
+            ...fileResult.errors.map((e) => ({
+              ...e,
+              sourcePath: fileResult.sourcePath,
+            })),
+          );
         } else if (fileResult.outputPath) {
           result.outputFiles.push(fileResult.outputPath);
         }

--- a/src/project/Project.ts
+++ b/src/project/Project.ts
@@ -113,6 +113,8 @@ class Project {
       }
       // Attach the output path to the result for aggregation
       (fileResult as any).outputPath = outputPath;
+      // Attach sourcePath to the result for error formatting
+      (fileResult as any).sourcePath = file;
       results.push(fileResult);
     }
 
@@ -131,7 +133,11 @@ class Project {
       aggregate.success &&= r.success;
       if (r.errors?.length) {
         const formatted = r.errors.map((e: any) =>
-          typeof e === "string" ? e : `${e.line}:${e.column} ${e.message}`,
+          typeof e === "string"
+            ? e
+            : r.sourcePath
+              ? `${r.sourcePath}:${e.line}:${e.column} ${e.message}`
+              : `${e.line}:${e.column} ${e.message}`,
         );
         aggregate.errors.push(...formatted);
       }


### PR DESCRIPTION
## Summary

- Fixes #492 - E0381 errors now include the source filename in output
- Added `sourcePath` field to `ITranspileError` interface
- Pipeline now attaches source path when aggregating file errors
- Project formats errors with filename prefix when available

## Before
```
Error: 14:15 error[E0381]: use of uninitialized variable 'p.x'
```

## After
```
Error: test.cnx:14:15 error[E0381]: use of uninitialized variable 'p.x'
```

## Test plan
- [x] Bug reproduction case in `bugs/issue-492-missing-filename/`
- [x] All 817 integration tests pass
- [x] All 998 unit tests pass
- [x] Multi-file compilation correctly identifies source file for each error

🤖 Generated with [Claude Code](https://claude.com/claude-code)