### PR TITLE
refactor: extract CNextSourceParser from Pipeline.ts

### DIFF
--- a/src/pipeline/CNextSourceParser.ts
+++ b/src/pipeline/CNextSourceParser.ts
@@ -1,0 +1,80 @@
+/**
+ * CNextSourceParser
+ * Handles parsing of C-Next source code with error collection.
+ *
+ * Extracted from Pipeline.ts to reduce duplication and improve testability.
+ */
+
+import { CharStream, CommonTokenStream } from "antlr4ng";
+
+import { CNextLexer } from "../antlr_parser/grammar/CNextLexer";
+import {
+  CNextParser,
+  ProgramContext,
+} from "../antlr_parser/grammar/CNextParser";
+import ITranspileError from "../lib/types/ITranspileError";
+
+/**
+ * Result of parsing C-Next source code
+ */
+interface IParseResult {
+  /** The parsed AST */
+  tree: ProgramContext;
+  /** Token stream for code generation */
+  tokenStream: CommonTokenStream;
+  /** Any parse errors encountered */
+  errors: ITranspileError[];
+  /** Number of top-level declarations */
+  declarationCount: number;
+}
+
+/**
+ * Parses C-Next source code and collects errors
+ */
+class CNextSourceParser {
+  /**
+   * Parse C-Next source code
+   * @param source - The source code string to parse
+   * @returns Parse result with tree, token stream, errors, and declaration count
+   */
+  static parse(source: string): IParseResult {
+    const charStream = CharStream.fromString(source);
+    const lexer = new CNextLexer(charStream);
+    const tokenStream = new CommonTokenStream(lexer);
+    const parser = new CNextParser(tokenStream);
+
+    const errors: ITranspileError[] = [];
+    parser.removeErrorListeners();
+    parser.addErrorListener({
+      syntaxError(
+        _recognizer,
+        _offendingSymbol,
+        line,
+        charPositionInLine,
+        msg,
+      ) {
+        errors.push({
+          line,
+          column: charPositionInLine,
+          message: msg,
+          severity: "error",
+        });
+      },
+      reportAmbiguity() {},
+      reportAttemptingFullContext() {},
+      reportContextSensitivity() {},
+    });
+
+    const tree = parser.program();
+    const declarationCount = tree.declaration().length;
+
+    return {
+      tree,
+      tokenStream,
+      errors,
+      declarationCount,
+    };
+  }
+}
+
+export default CNextSourceParser;

--- a/src/pipeline/__tests__/CNextSourceParser.test.ts
+++ b/src/pipeline/__tests__/CNextSourceParser.test.ts
@@ -1,0 +1,66 @@
+/**
+ * Unit tests for CNextSourceParser.
+ * Tests C-Next source parsing with error collection.
+ */
+
+import { describe, expect, it } from "vitest";
+import CNextSourceParser from "../CNextSourceParser";
+
+describe("CNextSourceParser", () => {
+  describe("parse", () => {
+    it("parses valid C-Next source and returns tree with no errors", () => {
+      const source = `u32 x <- 5;`;
+
+      const result = CNextSourceParser.parse(source);
+
+      expect(result.errors).toHaveLength(0);
+      expect(result.tree).toBeDefined();
+      expect(result.tokenStream).toBeDefined();
+      expect(result.declarationCount).toBe(1);
+    });
+
+    it("collects syntax errors with line and column info", () => {
+      const source = `u32 x <- ;`; // Missing value
+
+      const result = CNextSourceParser.parse(source);
+
+      expect(result.errors.length).toBeGreaterThan(0);
+      expect(result.errors[0].line).toBe(1);
+      expect(result.errors[0].column).toBeGreaterThanOrEqual(0);
+      expect(result.errors[0].severity).toBe("error");
+      expect(result.errors[0].message).toBeDefined();
+    });
+
+    it("returns tree even when there are parse errors", () => {
+      const source = `u32 x <- ;`; // Invalid syntax
+
+      const result = CNextSourceParser.parse(source);
+
+      // Tree is still returned (partial parse)
+      expect(result.tree).toBeDefined();
+      expect(result.tokenStream).toBeDefined();
+    });
+
+    it("counts multiple declarations correctly", () => {
+      const source = `
+        u32 x <- 5;
+        u32 y <- 10;
+        void foo() { }
+      `;
+
+      const result = CNextSourceParser.parse(source);
+
+      expect(result.errors).toHaveLength(0);
+      expect(result.declarationCount).toBe(3);
+    });
+
+    it("handles empty source", () => {
+      const source = ``;
+
+      const result = CNextSourceParser.parse(source);
+
+      expect(result.errors).toHaveLength(0);
+      expect(result.declarationCount).toBe(0);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Addresses SonarCloud finding of 32 duplicated lines between `transpileFile()` and `transpileSource()` methods
- Extracts shared C-Next parsing logic into a new `CNextSourceParser` class
- Adds comprehensive unit tests for the extracted parser

## Changes

- **New file**: `src/pipeline/CNextSourceParser.ts` - Static `parse()` method with clean interface
- **New tests**: `src/pipeline/__tests__/CNextSourceParser.test.ts` - 5 unit tests covering valid parsing, error collection, partial parses, multiple declarations, and empty source
- **Updated**: `src/pipeline/Pipeline.ts` - Both `transpileFile()` and `transpileSource()` now use the shared parser

## Test plan

- [x] All 847 integration tests pass
- [x] All 1302 unit tests pass
- [x] TypeScript type check passes
- [x] Linting passes

Fixes #509

🤖 Generated with [Claude Code](https://claude.com/claude-code)