### PR TITLE
refactor: consolidate parser setup into CNextSourceParser

### DIFF
--- a/src/lib/__tests__/parseWithSymbols.test.ts
+++ b/src/lib/__tests__/parseWithSymbols.test.ts
@@ -1,0 +1,118 @@
+/**
+ * Unit tests for parseWithSymbols.ts
+ * Tests symbol extraction for IDE features like autocomplete.
+ */
+
+import { describe, expect, it } from "vitest";
+import parseWithSymbols from "../parseWithSymbols";
+
+describe("parseWithSymbols", () => {
+  describe("successful parsing", () => {
+    it("extracts variable symbols", () => {
+      const source = `u32 counter <- 0;`;
+
+      const result = parseWithSymbols(source);
+
+      expect(result.success).toBe(true);
+      expect(result.errors).toHaveLength(0);
+      expect(result.symbols.some((s) => s.name === "counter")).toBe(true);
+    });
+
+    it("extracts function symbols", () => {
+      const source = `void myFunction() { }`;
+
+      const result = parseWithSymbols(source);
+
+      expect(result.success).toBe(true);
+      const func = result.symbols.find((s) => s.name === "myFunction");
+      expect(func).toBeDefined();
+      expect(func?.kind).toBe("function");
+    });
+
+    it("extracts scope symbols", () => {
+      const source = `
+        scope LED {
+          void on() { }
+          void off() { }
+        }
+      `;
+
+      const result = parseWithSymbols(source);
+
+      expect(result.success).toBe(true);
+      // Scope is extracted as a namespace
+      const scope = result.symbols.find((s) => s.name === "LED");
+      expect(scope).toBeDefined();
+      expect(scope?.kind).toBe("namespace");
+      // Scope functions get prefixed names like LED_on
+      const onFunc = result.symbols.find((s) => s.fullName === "LED_on");
+      expect(onFunc).toBeDefined();
+      expect(onFunc?.kind).toBe("function");
+    });
+
+    it("extracts struct symbols", () => {
+      const source = `
+        struct Point {
+          i32 x;
+          i32 y;
+        }
+      `;
+
+      const result = parseWithSymbols(source);
+
+      expect(result.success).toBe(true);
+      const struct = result.symbols.find((s) => s.name === "Point");
+      expect(struct).toBeDefined();
+      expect(struct?.kind).toBe("struct");
+    });
+  });
+
+  describe("error handling", () => {
+    it("returns errors for invalid syntax but still extracts partial symbols", () => {
+      const source = `
+        u32 validVar <- 5;
+        u32 invalid <- ;
+      `;
+
+      const result = parseWithSymbols(source);
+
+      expect(result.success).toBe(false);
+      expect(result.errors.length).toBeGreaterThan(0);
+      // Should still extract the valid symbol
+      expect(result.symbols.some((s) => s.name === "validVar")).toBe(true);
+    });
+
+    it("captures lexer errors", () => {
+      const source = "u32 x <- `backtick`;";
+
+      const result = parseWithSymbols(source);
+
+      expect(result.success).toBe(false);
+      expect(result.errors.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe("symbol info properties", () => {
+    it("includes type information", () => {
+      const source = `i64 bigNumber <- 100;`;
+
+      const result = parseWithSymbols(source);
+
+      const sym = result.symbols.find((s) => s.name === "bigNumber");
+      expect(sym?.type).toBe("i64");
+    });
+
+    it("includes line information", () => {
+      const source = `
+        u32 first <- 1;
+        u32 second <- 2;
+      `;
+
+      const result = parseWithSymbols(source);
+
+      const first = result.symbols.find((s) => s.name === "first");
+      const second = result.symbols.find((s) => s.name === "second");
+      expect(first?.line).toBeLessThan(second?.line ?? 0);
+    });
+  });
+});

--- a/src/lib/__tests__/transpiler.test.ts
+++ b/src/lib/__tests__/transpiler.test.ts
@@ -1,0 +1,132 @@
+/**
+ * Unit tests for transpiler.ts
+ * Tests the synchronous transpile() function for in-memory transpilation.
+ */
+
+import { describe, expect, it } from "vitest";
+import transpile from "../transpiler";
+
+describe("transpile", () => {
+  describe("successful transpilation", () => {
+    it("transpiles valid C-Next source to C", () => {
+      const source = `u32 x <- 5;`;
+
+      const result = transpile(source);
+
+      expect(result.success).toBe(true);
+      expect(result.code).toContain("uint32_t x = 5;");
+      expect(result.errors).toHaveLength(0);
+      expect(result.declarationCount).toBe(1);
+    });
+
+    it("transpiles functions correctly", () => {
+      const source = `
+        void foo() {
+          u32 x <- 10;
+        }
+      `;
+
+      const result = transpile(source);
+
+      expect(result.success).toBe(true);
+      expect(result.code).toContain("void foo(void)");
+      expect(result.declarationCount).toBe(1);
+    });
+
+    it("transpiles multiple declarations", () => {
+      const source = `
+        u32 x <- 1;
+        u32 y <- 2;
+        void bar() { }
+      `;
+
+      const result = transpile(source);
+
+      expect(result.success).toBe(true);
+      expect(result.declarationCount).toBe(3);
+    });
+  });
+
+  describe("parse errors", () => {
+    it("returns errors for invalid syntax", () => {
+      const source = `u32 x <- ;`; // Missing value
+
+      const result = transpile(source);
+
+      expect(result.success).toBe(false);
+      expect(result.errors.length).toBeGreaterThan(0);
+      expect(result.code).toBe("");
+    });
+
+    it("captures lexer errors for invalid characters", () => {
+      const source = "u32 x <- `invalid`;";
+
+      const result = transpile(source);
+
+      expect(result.success).toBe(false);
+      expect(result.errors.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe("parseOnly mode", () => {
+    it("returns empty code in parseOnly mode", () => {
+      const source = `u32 x <- 5;`;
+
+      const result = transpile(source, { parseOnly: true });
+
+      expect(result.success).toBe(true);
+      expect(result.code).toBe("");
+      expect(result.declarationCount).toBe(1);
+    });
+
+    it("still reports parse errors in parseOnly mode", () => {
+      const source = `u32 x <- ;`;
+
+      const result = transpile(source, { parseOnly: true });
+
+      expect(result.success).toBe(false);
+      expect(result.errors.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe("analysis errors", () => {
+    it("catches uninitialized variable usage", () => {
+      const source = `
+        void test() {
+          u32 x;
+          u32 y <- x;
+        }
+      `;
+
+      const result = transpile(source);
+
+      expect(result.success).toBe(false);
+      expect(result.errors.some((e) => e.message.includes("E0381"))).toBe(true);
+    });
+
+    it("catches undefined function calls", () => {
+      const source = `
+        void test() {
+          undefinedFunc();
+        }
+      `;
+
+      const result = transpile(source);
+
+      expect(result.success).toBe(false);
+      expect(result.errors.some((e) => e.message.includes("E0422"))).toBe(true);
+    });
+  });
+
+  describe("grammar coverage", () => {
+    it("collects grammar coverage when requested", () => {
+      const source = `u32 x <- 5;`;
+
+      const result = transpile(source, { collectGrammarCoverage: true });
+
+      expect(result.success).toBe(true);
+      expect(result.grammarCoverage).toBeDefined();
+      expect(result.grammarCoverage?.visitedParserRules).toBeGreaterThan(0);
+    });
+  });
+});

--- a/src/pipeline/CNextSourceParser.ts
+++ b/src/pipeline/CNextSourceParser.ts
@@ -44,26 +44,31 @@ class CNextSourceParser {
     const parser = new CNextParser(tokenStream);
 
     const errors: ITranspileError[] = [];
-    parser.removeErrorListeners();
-    parser.addErrorListener({
+    const errorListener = {
       syntaxError(
-        _recognizer,
-        _offendingSymbol,
-        line,
-        charPositionInLine,
-        msg,
+        _recognizer: unknown,
+        _offendingSymbol: unknown,
+        line: number,
+        charPositionInLine: number,
+        msg: string,
       ) {
         errors.push({
           line,
           column: charPositionInLine,
           message: msg,
-          severity: "error",
+          severity: "error" as const,
         });
       },
       reportAmbiguity() {},
       reportAttemptingFullContext() {},
       reportContextSensitivity() {},
-    });
+    };
+
+    // Add error listener to both lexer and parser
+    lexer.removeErrorListeners();
+    lexer.addErrorListener(errorListener);
+    parser.removeErrorListeners();
+    parser.addErrorListener(errorListener);
 
     const tree = parser.program();
     const declarationCount = tree.declaration().length;

--- a/src/pipeline/__tests__/CNextSourceParser.test.ts
+++ b/src/pipeline/__tests__/CNextSourceParser.test.ts
@@ -62,5 +62,24 @@ describe("CNextSourceParser", () => {
       expect(result.errors).toHaveLength(0);
       expect(result.declarationCount).toBe(0);
     });
+
+    it("collects lexer errors for invalid characters", () => {
+      // Backtick is not a valid C-Next character - should trigger lexer error
+      const source = "u32 x <- `invalid`;";
+
+      const result = CNextSourceParser.parse(source);
+
+      expect(result.errors.length).toBeGreaterThan(0);
+      expect(result.errors[0].severity).toBe("error");
+    });
+
+    it("does not throw on malformed input", () => {
+      // Even severely malformed input should return a result, not throw
+      const source = "{{{{[[[[";
+
+      expect(() => CNextSourceParser.parse(source)).not.toThrow();
+      const result = CNextSourceParser.parse(source);
+      expect(result.tree).toBeDefined();
+    });
   });
 });


### PR DESCRIPTION
## Summary

- Extends `CNextSourceParser` (from #509) to be the single source of truth for C-Next parsing
- Consolidates all 4 parser setup locations into one shared utility
- Removes ~85 lines of duplicated code

## Changes

- **Enhanced** `CNextSourceParser.ts` - Now captures both lexer and parser errors
- **Updated** `parseWithSymbols.ts` - Uses shared parser (55 lines removed)
- **Updated** `transpiler.ts` - Uses shared parser (49 lines removed)
- **Added tests** for lexer error collection and malformed input handling

## Parser Setup Locations (Now Consolidated)

| Location | Status |
|----------|--------|
| `Pipeline.transpileFile()` | ✅ Using CNextSourceParser (PR #530) |
| `Pipeline.transpileSource()` | ✅ Using CNextSourceParser (PR #530) |
| `parseWithSymbols.ts` | ✅ Using CNextSourceParser (this PR) |
| `transpiler.ts` | ✅ Using CNextSourceParser (this PR) |

## Test plan

- [x] All 847 integration tests pass
- [x] All 1304 unit tests pass
- [x] TypeScript type check passes
- [x] Linting passes

Fixes #513

🤖 Generated with [Claude Code](https://claude.com/claude-code)