### PR TITLE
refactor: extract enum/bitmap type registration helpers

### DIFF
--- a/src/codegen/TypeRegistrationUtils.ts
+++ b/src/codegen/TypeRegistrationUtils.ts
@@ -1,0 +1,110 @@
+/**
+ * TypeRegistrationUtils
+ * Extracted helpers for enum/bitmap type registration in CodeGenerator.
+ *
+ * This reduces duplication across the 4 type contexts (scopedType, globalType,
+ * qualifiedType, userType) that each had identical enum/bitmap handling.
+ */
+
+import TTypeInfo from "./types/TTypeInfo";
+import TOverflowBehavior from "./types/TOverflowBehavior";
+
+/**
+ * Minimal symbol info interface for type registration.
+ * Subset of ISymbolInfo used by registration helpers.
+ */
+interface ITypeSymbols {
+  knownEnums: ReadonlySet<string>;
+  knownBitmaps: ReadonlySet<string>;
+  bitmapBitWidth: ReadonlyMap<string, number>;
+}
+
+/**
+ * Utilities for registering enum and bitmap types in the type registry.
+ */
+class TypeRegistrationUtils {
+  /**
+   * Try to register a type as an enum.
+   * Returns true if the type was a known enum and was registered.
+   */
+  static tryRegisterEnumType(
+    typeRegistry: Map<string, TTypeInfo>,
+    symbols: ITypeSymbols,
+    name: string,
+    baseType: string,
+    isConst: boolean,
+    overflowBehavior: TOverflowBehavior,
+    isAtomic: boolean,
+  ): boolean {
+    if (!symbols.knownEnums.has(baseType)) {
+      return false;
+    }
+
+    typeRegistry.set(name, {
+      baseType,
+      bitWidth: 0,
+      isArray: false,
+      isConst,
+      isEnum: true,
+      enumTypeName: baseType,
+      overflowBehavior,
+      isAtomic,
+    });
+
+    return true;
+  }
+
+  /**
+   * Try to register a type as a bitmap.
+   * Returns true if the type was a known bitmap and was registered.
+   *
+   * Handles both array and non-array bitmap types.
+   */
+  static tryRegisterBitmapType(
+    typeRegistry: Map<string, TTypeInfo>,
+    symbols: ITypeSymbols,
+    name: string,
+    baseType: string,
+    isConst: boolean,
+    arrayDimensions: number[] | undefined,
+    overflowBehavior: TOverflowBehavior,
+    isAtomic: boolean,
+  ): boolean {
+    if (!symbols.knownBitmaps.has(baseType)) {
+      return false;
+    }
+
+    const bitWidth = symbols.bitmapBitWidth.get(baseType) || 0;
+
+    if (arrayDimensions && arrayDimensions.length > 0) {
+      // Bitmap array
+      typeRegistry.set(name, {
+        baseType,
+        bitWidth,
+        isArray: true,
+        arrayDimensions,
+        isConst,
+        isBitmap: true,
+        bitmapTypeName: baseType,
+        overflowBehavior,
+        isAtomic,
+      });
+    } else {
+      // Non-array bitmap
+      typeRegistry.set(name, {
+        baseType,
+        bitWidth,
+        isArray: false,
+        isConst,
+        isBitmap: true,
+        bitmapTypeName: baseType,
+        overflowBehavior,
+        isAtomic,
+      });
+    }
+
+    return true;
+  }
+}
+
+export default TypeRegistrationUtils;

--- a/src/codegen/__tests__/TypeRegistrationUtils.test.ts
+++ b/src/codegen/__tests__/TypeRegistrationUtils.test.ts
@@ -1,0 +1,222 @@
+/**
+ * Unit tests for TypeRegistrationUtils.
+ * Tests the extracted enum/bitmap type registration helpers.
+ */
+
+import { describe, expect, it } from "vitest";
+import TypeRegistrationUtils from "../TypeRegistrationUtils";
+import TTypeInfo from "../types/TTypeInfo";
+
+/**
+ * Create mock symbols for testing
+ */
+function createMockSymbols(overrides: Record<string, unknown> = {}) {
+  return {
+    knownEnums: new Set<string>(),
+    knownBitmaps: new Set<string>(),
+    bitmapBitWidth: new Map<string, number>(),
+    ...overrides,
+  };
+}
+
+describe("TypeRegistrationUtils", () => {
+  describe("tryRegisterEnumType", () => {
+    it("returns false if type is not a known enum", () => {
+      const typeRegistry = new Map<string, TTypeInfo>();
+      const symbols = createMockSymbols();
+
+      const result = TypeRegistrationUtils.tryRegisterEnumType(
+        typeRegistry,
+        symbols,
+        "myVar",
+        "UnknownType",
+        false,
+        "clamp",
+        false,
+      );
+
+      expect(result).toBe(false);
+      expect(typeRegistry.size).toBe(0);
+    });
+
+    it("registers enum type and returns true", () => {
+      const typeRegistry = new Map<string, TTypeInfo>();
+      const symbols = createMockSymbols({
+        knownEnums: new Set(["MyEnum"]),
+      });
+
+      const result = TypeRegistrationUtils.tryRegisterEnumType(
+        typeRegistry,
+        symbols,
+        "myVar",
+        "MyEnum",
+        false,
+        "clamp",
+        false,
+      );
+
+      expect(result).toBe(true);
+      expect(typeRegistry.has("myVar")).toBe(true);
+
+      const info = typeRegistry.get("myVar")!;
+      expect(info.baseType).toBe("MyEnum");
+      expect(info.isEnum).toBe(true);
+      expect(info.enumTypeName).toBe("MyEnum");
+      expect(info.isConst).toBe(false);
+    });
+
+    it("respects isConst flag", () => {
+      const typeRegistry = new Map<string, TTypeInfo>();
+      const symbols = createMockSymbols({
+        knownEnums: new Set(["MyEnum"]),
+      });
+
+      TypeRegistrationUtils.tryRegisterEnumType(
+        typeRegistry,
+        symbols,
+        "myVar",
+        "MyEnum",
+        true,
+        "clamp",
+        false,
+      );
+
+      expect(typeRegistry.get("myVar")!.isConst).toBe(true);
+    });
+
+    it("respects overflowBehavior", () => {
+      const typeRegistry = new Map<string, TTypeInfo>();
+      const symbols = createMockSymbols({
+        knownEnums: new Set(["MyEnum"]),
+      });
+
+      TypeRegistrationUtils.tryRegisterEnumType(
+        typeRegistry,
+        symbols,
+        "myVar",
+        "MyEnum",
+        false,
+        "wrap",
+        false,
+      );
+
+      expect(typeRegistry.get("myVar")!.overflowBehavior).toBe("wrap");
+    });
+
+    it("respects isAtomic flag", () => {
+      const typeRegistry = new Map<string, TTypeInfo>();
+      const symbols = createMockSymbols({
+        knownEnums: new Set(["MyEnum"]),
+      });
+
+      TypeRegistrationUtils.tryRegisterEnumType(
+        typeRegistry,
+        symbols,
+        "myVar",
+        "MyEnum",
+        false,
+        "clamp",
+        true,
+      );
+
+      expect(typeRegistry.get("myVar")!.isAtomic).toBe(true);
+    });
+  });
+
+  describe("tryRegisterBitmapType", () => {
+    it("returns false if type is not a known bitmap", () => {
+      const typeRegistry = new Map<string, TTypeInfo>();
+      const symbols = createMockSymbols();
+
+      const result = TypeRegistrationUtils.tryRegisterBitmapType(
+        typeRegistry,
+        symbols,
+        "myVar",
+        "UnknownType",
+        false,
+        undefined,
+        "clamp",
+        false,
+      );
+
+      expect(result).toBe(false);
+      expect(typeRegistry.size).toBe(0);
+    });
+
+    it("registers non-array bitmap type", () => {
+      const typeRegistry = new Map<string, TTypeInfo>();
+      const symbols = createMockSymbols({
+        knownBitmaps: new Set(["MyFlags"]),
+        bitmapBitWidth: new Map([["MyFlags", 8]]),
+      });
+
+      const result = TypeRegistrationUtils.tryRegisterBitmapType(
+        typeRegistry,
+        symbols,
+        "flags",
+        "MyFlags",
+        false,
+        undefined,
+        "clamp",
+        false,
+      );
+
+      expect(result).toBe(true);
+      expect(typeRegistry.has("flags")).toBe(true);
+
+      const info = typeRegistry.get("flags")!;
+      expect(info.baseType).toBe("MyFlags");
+      expect(info.isBitmap).toBe(true);
+      expect(info.bitmapTypeName).toBe("MyFlags");
+      expect(info.bitWidth).toBe(8);
+      expect(info.isArray).toBe(false);
+    });
+
+    it("registers bitmap array type with dimensions", () => {
+      const typeRegistry = new Map<string, TTypeInfo>();
+      const symbols = createMockSymbols({
+        knownBitmaps: new Set(["MyFlags"]),
+        bitmapBitWidth: new Map([["MyFlags", 16]]),
+      });
+
+      const result = TypeRegistrationUtils.tryRegisterBitmapType(
+        typeRegistry,
+        symbols,
+        "flagsArray",
+        "MyFlags",
+        false,
+        [10, 5], // Array dimensions
+        "clamp",
+        false,
+      );
+
+      expect(result).toBe(true);
+
+      const info = typeRegistry.get("flagsArray")!;
+      expect(info.isArray).toBe(true);
+      expect(info.arrayDimensions).toEqual([10, 5]);
+      expect(info.bitWidth).toBe(16);
+    });
+
+    it("defaults bitWidth to 0 if not found", () => {
+      const typeRegistry = new Map<string, TTypeInfo>();
+      const symbols = createMockSymbols({
+        knownBitmaps: new Set(["MyFlags"]),
+        // No bitWidth entry
+      });
+
+      TypeRegistrationUtils.tryRegisterBitmapType(
+        typeRegistry,
+        symbols,
+        "flags",
+        "MyFlags",
+        false,
+        undefined,
+        "clamp",
+        false,
+      );
+
+      expect(typeRegistry.get("flags")!.bitWidth).toBe(0);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Create `TypeRegistrationUtils` with `tryRegisterEnumType` and `tryRegisterBitmapType` helpers
- Add `_evaluateArrayDimensions` and `_tryRegisterEnumOrBitmapType` wrapper methods in CodeGenerator
- Replace 4 duplicated enum/bitmap registration blocks with single helper calls

## File Size Impact
- **CodeGenerator.ts**: 10,010 → 9,904 lines (**-106 lines**)
- New `TypeRegistrationUtils.ts`: ~100 lines with tests

## Changes
| Type Context | Before | After |
|--------------|--------|-------|
| `scopedType()` | 60 lines | 10 lines |
| `globalType()` | 60 lines | 10 lines |
| `qualifiedType()` | 60 lines | 10 lines |
| `userType()` | 60 lines | 10 lines |

## Test plan
- [x] All 1360 unit tests pass
- [x] All 847 integration tests pass
- [x] 9 new unit tests for TypeRegistrationUtils

Closes #510

🤖 Generated with [Claude Code](https://claude.com/claude-code)