### PR TITLE
refactor: extract IBaseAnalysisError interface for shared error fields

### DIFF
--- a/src/analysis/types/IBaseAnalysisError.ts
+++ b/src/analysis/types/IBaseAnalysisError.ts
@@ -1,0 +1,20 @@
+/**
+ * Base interface for all analysis errors.
+ *
+ * All analyzer error interfaces extend this common base,
+ * providing a consistent structure for error reporting.
+ */
+interface IBaseAnalysisError {
+  /** Error code (e.g., E0381, E0800) */
+  code: string;
+  /** Line number where the error occurred */
+  line: number;
+  /** Column number where the error occurred */
+  column: number;
+  /** Human-readable error message */
+  message: string;
+  /** Optional help text with suggested fix */
+  helpText?: string;
+}
+
+export default IBaseAnalysisError;

--- a/src/analysis/types/IDivisionByZeroError.ts
+++ b/src/analysis/types/IDivisionByZeroError.ts
@@ -7,19 +7,11 @@
  * - E0802: Modulo by literal zero
  * - E0803: Modulo by const that evaluates to zero
  */
-interface IDivisionByZeroError {
-  /** Error code (E0800-E0803) */
-  code: string;
+import IBaseAnalysisError from "./IBaseAnalysisError";
+
+interface IDivisionByZeroError extends IBaseAnalysisError {
   /** Operator used ('/' or '%') */
   operator: string;
-  /** Line number where the error occurred */
-  line: number;
-  /** Column number where the error occurred */
-  column: number;
-  /** Human-readable error message */
-  message: string;
-  /** Optional help text with suggested fix */
-  helpText?: string;
 }
 
 export default IDivisionByZeroError;

--- a/src/analysis/types/IFloatModuloError.ts
+++ b/src/analysis/types/IFloatModuloError.ts
@@ -4,17 +4,8 @@
  * Error codes:
  * - E0804: Modulo operator used with floating-point operand
  */
-interface IFloatModuloError {
-  /** Error code (E0804) */
-  code: string;
-  /** Line number where the error occurred */
-  line: number;
-  /** Column number where the error occurred */
-  column: number;
-  /** Human-readable error message */
-  message: string;
-  /** Optional help text with suggested fix */
-  helpText?: string;
-}
+import IBaseAnalysisError from "./IBaseAnalysisError";
+
+interface IFloatModuloError extends IBaseAnalysisError {}
 
 export default IFloatModuloError;

--- a/src/analysis/types/IFunctionCallError.ts
+++ b/src/analysis/types/IFunctionCallError.ts
@@ -1,17 +1,11 @@
 /**
  * Error reported when a function is called before it's defined (ADR-030)
  */
-interface IFunctionCallError {
-  /** Error code (E0422) */
-  code: string;
+import IBaseAnalysisError from "./IBaseAnalysisError";
+
+interface IFunctionCallError extends IBaseAnalysisError {
   /** Name of the function that was called */
   functionName: string;
-  /** Line number where the call occurred */
-  line: number;
-  /** Column number where the call occurred */
-  column: number;
-  /** Human-readable error message */
-  message: string;
 }
 
 export default IFunctionCallError;

--- a/src/analysis/types/IInitializationError.ts
+++ b/src/analysis/types/IInitializationError.ts
@@ -2,27 +2,19 @@
  * Initialization analysis error types
  * Used for Rust-style "use before initialization" detection
  */
-
+import IBaseAnalysisError from "./IBaseAnalysisError";
 import IDeclarationInfo from "./IDeclarationInfo";
 
 /**
  * Error for using a variable before initialization
  */
-interface IInitializationError {
-  /** Error code (E0381 matches Rust's error code) */
-  code: "E0381";
+interface IInitializationError extends IBaseAnalysisError {
   /** The variable or field that was used before initialization */
   variable: string;
-  /** Line where the uninitialized use occurred */
-  line: number;
-  /** Column where the uninitialized use occurred */
-  column: number;
   /** Declaration info for the variable */
   declaration: IDeclarationInfo;
   /** Whether this is a "may be uninitialized" (conditional) or "definitely uninitialized" */
   mayBeUninitialized: boolean;
-  /** Human-readable message */
-  message: string;
 }
 
 export default IInitializationError;

--- a/src/analysis/types/INullCheckError.ts
+++ b/src/analysis/types/INullCheckError.ts
@@ -11,19 +11,11 @@
  * - E0907: NULL comparison on non-nullable variable
  * - E0908: Nullable c_ variable used without prior NULL check (flow analysis)
  */
-interface INullCheckError {
-  /** Error code (E0901-E0908) */
-  code: string;
+import IBaseAnalysisError from "./IBaseAnalysisError";
+
+interface INullCheckError extends IBaseAnalysisError {
   /** Name of the function or literal involved */
   functionName: string;
-  /** Line number where the error occurred */
-  line: number;
-  /** Column number where the error occurred */
-  column: number;
-  /** Human-readable error message */
-  message: string;
-  /** Optional help text with suggested fix */
-  helpText?: string;
 }
 
 export default INullCheckError;

--- a/src/analysis/types/IParameterNamingError.ts
+++ b/src/analysis/types/IParameterNamingError.ts
@@ -2,21 +2,13 @@
  * Error reported when a function parameter has a reserved naming pattern
  * Issue #227: Parameters cannot start with their function name followed by underscore
  */
-interface IParameterNamingError {
-  /** Error code (E0227) - matches issue number */
-  code: string;
+import IBaseAnalysisError from "./IBaseAnalysisError";
+
+interface IParameterNamingError extends IBaseAnalysisError {
   /** Name of the parameter */
   parameterName: string;
   /** Name of the containing function */
   functionName: string;
-  /** Line number where the parameter is declared */
-  line: number;
-  /** Column number where the parameter is declared */
-  column: number;
-  /** Human-readable error message */
-  message: string;
-  /** Optional help text with suggested fix */
-  helpText?: string;
 }
 
 export default IParameterNamingError;

--- a/src/analysis/types/IStructFieldError.ts
+++ b/src/analysis/types/IStructFieldError.ts
@@ -2,21 +2,13 @@
  * Error reported when a struct field has a reserved name
  * Struct fields cannot use names that conflict with C-Next built-in properties
  */
-interface IStructFieldError {
-  /** Error code (E0355) */
-  code: string;
+import IBaseAnalysisError from "./IBaseAnalysisError";
+
+interface IStructFieldError extends IBaseAnalysisError {
   /** Name of the struct */
   structName: string;
   /** Name of the problematic field */
   fieldName: string;
-  /** Line number where the field is declared */
-  line: number;
-  /** Column number where the field is declared */
-  column: number;
-  /** Human-readable error message */
-  message: string;
-  /** Optional help text with suggested fix */
-  helpText?: string;
 }
 
 export default IStructFieldError;

--- a/src/analysis/types/__tests__/IBaseAnalysisError.test.ts
+++ b/src/analysis/types/__tests__/IBaseAnalysisError.test.ts
@@ -1,0 +1,180 @@
+/**
+ * Unit tests for IBaseAnalysisError interface.
+ * Tests that concrete error objects properly satisfy the base interface.
+ */
+
+import { describe, expect, it } from "vitest";
+import IBaseAnalysisError from "../IBaseAnalysisError";
+import IFloatModuloError from "../IFloatModuloError";
+import IDivisionByZeroError from "../IDivisionByZeroError";
+import IFunctionCallError from "../IFunctionCallError";
+import INullCheckError from "../INullCheckError";
+import IInitializationError from "../IInitializationError";
+import IParameterNamingError from "../IParameterNamingError";
+import IStructFieldError from "../IStructFieldError";
+
+describe("IBaseAnalysisError", () => {
+  describe("interface extension", () => {
+    it("allows IFloatModuloError to be used as base error", () => {
+      const error: IFloatModuloError = {
+        code: "E0804",
+        line: 10,
+        column: 5,
+        message: "Modulo operator not supported for floating-point types",
+      };
+
+      // Should be assignable to base type
+      const baseError: IBaseAnalysisError = error;
+      expect(baseError.code).toBe("E0804");
+      expect(baseError.line).toBe(10);
+      expect(baseError.column).toBe(5);
+      expect(baseError.message).toBe(
+        "Modulo operator not supported for floating-point types",
+      );
+    });
+
+    it("allows IDivisionByZeroError to be used as base error", () => {
+      const error: IDivisionByZeroError = {
+        code: "E0800",
+        operator: "/",
+        line: 20,
+        column: 10,
+        message: "Division by zero",
+        helpText: "Use safe_div for runtime safety",
+      };
+
+      const baseError: IBaseAnalysisError = error;
+      expect(baseError.code).toBe("E0800");
+      expect(baseError.helpText).toBe("Use safe_div for runtime safety");
+    });
+
+    it("allows IFunctionCallError to be used as base error", () => {
+      const error: IFunctionCallError = {
+        code: "E0422",
+        functionName: "undefinedFunc",
+        line: 15,
+        column: 3,
+        message: "Function 'undefinedFunc' is not defined",
+      };
+
+      const baseError: IBaseAnalysisError = error;
+      expect(baseError.code).toBe("E0422");
+      expect(baseError.message).toBe("Function 'undefinedFunc' is not defined");
+    });
+
+    it("allows INullCheckError to be used as base error", () => {
+      const error: INullCheckError = {
+        code: "E0901",
+        functionName: "fopen",
+        line: 30,
+        column: 12,
+        message: "C library function can return NULL",
+        helpText: "Check for NULL before use",
+      };
+
+      const baseError: IBaseAnalysisError = error;
+      expect(baseError.code).toBe("E0901");
+    });
+
+    it("allows IInitializationError to be used as base error", () => {
+      const error: IInitializationError = {
+        code: "E0381",
+        variable: "x",
+        line: 5,
+        column: 8,
+        declaration: { name: "x", line: 3, column: 4 },
+        mayBeUninitialized: false,
+        message: "use of uninitialized variable 'x'",
+      };
+
+      const baseError: IBaseAnalysisError = error;
+      expect(baseError.code).toBe("E0381");
+    });
+
+    it("allows IParameterNamingError to be used as base error", () => {
+      const error: IParameterNamingError = {
+        code: "E0227",
+        parameterName: "foo_bar",
+        functionName: "foo",
+        line: 10,
+        column: 15,
+        message: "Parameter 'foo_bar' conflicts with function name",
+      };
+
+      const baseError: IBaseAnalysisError = error;
+      expect(baseError.code).toBe("E0227");
+    });
+
+    it("allows IStructFieldError to be used as base error", () => {
+      const error: IStructFieldError = {
+        code: "E0355",
+        structName: "MyStruct",
+        fieldName: "type",
+        line: 12,
+        column: 6,
+        message: "Reserved field name 'type'",
+      };
+
+      const baseError: IBaseAnalysisError = error;
+      expect(baseError.code).toBe("E0355");
+    });
+  });
+
+  describe("helpText optional field", () => {
+    it("allows errors without helpText", () => {
+      const error: IBaseAnalysisError = {
+        code: "E0000",
+        line: 1,
+        column: 1,
+        message: "Test error",
+      };
+
+      expect(error.helpText).toBeUndefined();
+    });
+
+    it("allows errors with helpText", () => {
+      const error: IBaseAnalysisError = {
+        code: "E0000",
+        line: 1,
+        column: 1,
+        message: "Test error",
+        helpText: "Here is how to fix it",
+      };
+
+      expect(error.helpText).toBe("Here is how to fix it");
+    });
+  });
+
+  describe("generic error handling", () => {
+    it("can process mixed error types in a single array", () => {
+      const errors: IBaseAnalysisError[] = [
+        {
+          code: "E0804",
+          line: 1,
+          column: 1,
+          message: "Float modulo error",
+        } as IFloatModuloError,
+        {
+          code: "E0800",
+          operator: "/",
+          line: 2,
+          column: 5,
+          message: "Division by zero",
+        } as IDivisionByZeroError,
+        {
+          code: "E0422",
+          functionName: "test",
+          line: 3,
+          column: 10,
+          message: "Undefined function",
+        } as IFunctionCallError,
+      ];
+
+      expect(errors.length).toBe(3);
+      expect(errors.every((e) => typeof e.code === "string")).toBe(true);
+      expect(errors.every((e) => typeof e.line === "number")).toBe(true);
+      expect(errors.every((e) => typeof e.column === "number")).toBe(true);
+      expect(errors.every((e) => typeof e.message === "string")).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Extract `IBaseAnalysisError` interface with common error fields (`code`, `line`, `column`, `message`, `helpText?`)
- Update all 7 analyzer error interfaces to extend the base interface
- Reduce interface duplication by 35 lines (163 → 128)
- Add 10 unit tests for interface extension validation

## Test plan
- [x] All unit tests pass (1370 tests)
- [x] All integration tests pass (847 tests)
- [x] TypeScript compilation succeeds
- [x] Linting passes

Closes #399

🤖 Generated with [Claude Code](https://claude.com/claude-code)