### PR TITLE
refactor: add composition helpers to SymbolCollectorContext

### DIFF
--- a/src/symbol_resolution/CSymbolCollector.ts
+++ b/src/symbol_resolution/CSymbolCollector.ts
@@ -35,7 +35,7 @@ class CSymbolCollector {
    * Get warnings generated during symbol collection
    */
   getWarnings(): string[] {
-    return this.ctx.warnings;
+    return SymbolCollectorContext.getWarnings(this.ctx);
   }
 
   /**
@@ -46,14 +46,14 @@ class CSymbolCollector {
 
     const translationUnit = tree.translationUnit();
     if (!translationUnit) {
-      return this.ctx.symbols;
+      return SymbolCollectorContext.getSymbols(this.ctx);
     }
 
     for (const extDecl of translationUnit.externalDeclaration()) {
       this.collectExternalDeclaration(extDecl);
     }
 
-    return this.ctx.symbols;
+    return SymbolCollectorContext.getSymbols(this.ctx);
   }
 
   private collectExternalDeclaration(
@@ -89,7 +89,7 @@ class CSymbolCollector {
       ? this.extractTypeFromDeclSpecs(declSpecs)
       : "int";
 
-    this.ctx.symbols.push({
+    SymbolCollectorContext.addSymbol(this.ctx, {
       name,
       kind: ESymbolKind.Function,
       type: returnType,
@@ -172,7 +172,7 @@ class CSymbolCollector {
       const isFunction = this.declaratorIsFunction(declarator);
 
       if (isTypedef) {
-        this.ctx.symbols.push({
+        SymbolCollectorContext.addSymbol(this.ctx, {
           name,
           kind: ESymbolKind.Type,
           type: baseType,
@@ -182,7 +182,7 @@ class CSymbolCollector {
           isExported: true,
         });
       } else if (isFunction) {
-        this.ctx.symbols.push({
+        SymbolCollectorContext.addSymbol(this.ctx, {
           name,
           kind: ESymbolKind.Function,
           type: baseType,
@@ -193,7 +193,7 @@ class CSymbolCollector {
           isDeclaration: true,
         });
       } else {
-        this.ctx.symbols.push({
+        SymbolCollectorContext.addSymbol(this.ctx, {
           name,
           kind: ESymbolKind.Variable,
           type: baseType,
@@ -221,7 +221,7 @@ class CSymbolCollector {
 
     const isUnion = structSpec.structOrUnion()?.getText() === "union";
 
-    this.ctx.symbols.push({
+    SymbolCollectorContext.addSymbol(this.ctx, {
       name,
       kind: ESymbolKind.Struct,
       type: isUnion ? "union" : "struct",
@@ -256,7 +256,7 @@ class CSymbolCollector {
 
     const name = identifier.getText();
 
-    this.ctx.symbols.push({
+    SymbolCollectorContext.addSymbol(this.ctx, {
       name,
       kind: ESymbolKind.Enum,
       sourceFile: this.ctx.sourceFile,
@@ -273,7 +273,7 @@ class CSymbolCollector {
         if (enumConst) {
           const memberName = enumConst.Identifier()?.getText();
           if (memberName) {
-            this.ctx.symbols.push({
+            SymbolCollectorContext.addSymbol(this.ctx, {
               name: memberName,
               kind: ESymbolKind.EnumMember,
               sourceFile: this.ctx.sourceFile,
@@ -312,7 +312,8 @@ class CSymbolCollector {
 
       // Warn if field name conflicts with C-Next reserved property names
       if (SymbolUtils.isReservedFieldName(fieldName)) {
-        this.ctx.warnings.push(
+        SymbolCollectorContext.addWarning(
+          this.ctx,
           `Warning: C header struct '${structName}' has field '${fieldName}' which conflicts with C-Next's .${fieldName} property. ` +
             `Consider renaming the field or be aware that '${structName}.${fieldName}' may not work as expected in C-Next code.`,
         );

--- a/src/symbol_resolution/SymbolCollectorContext.ts
+++ b/src/symbol_resolution/SymbolCollectorContext.ts
@@ -6,6 +6,7 @@
  */
 
 import ICollectorContext from "./types/ICollectorContext";
+import ISymbol from "../types/ISymbol";
 import SymbolTable from "./SymbolTable";
 
 /**
@@ -33,6 +34,34 @@ class SymbolCollectorContext {
   static reset(ctx: ICollectorContext): void {
     ctx.symbols = [];
     ctx.warnings = [];
+  }
+
+  /**
+   * Get collected symbols
+   */
+  static getSymbols(ctx: ICollectorContext): ISymbol[] {
+    return ctx.symbols;
+  }
+
+  /**
+   * Get warnings generated during collection
+   */
+  static getWarnings(ctx: ICollectorContext): string[] {
+    return ctx.warnings;
+  }
+
+  /**
+   * Add a symbol to the context
+   */
+  static addSymbol(ctx: ICollectorContext, symbol: ISymbol): void {
+    ctx.symbols.push(symbol);
+  }
+
+  /**
+   * Add a warning to the context
+   */
+  static addWarning(ctx: ICollectorContext, message: string): void {
+    ctx.warnings.push(message);
   }
 }
 

--- a/src/symbol_resolution/__tests__/SymbolCollectorContext.test.ts
+++ b/src/symbol_resolution/__tests__/SymbolCollectorContext.test.ts
@@ -113,6 +113,91 @@ describe("SymbolCollectorContext", () => {
     });
   });
 
+  describe("getSymbols", () => {
+    it("returns empty array for new context", () => {
+      const ctx = SymbolCollectorContext.create("/path/to/file.h");
+
+      expect(SymbolCollectorContext.getSymbols(ctx)).toEqual([]);
+    });
+
+    it("returns symbols added to context", () => {
+      const ctx = SymbolCollectorContext.create("/path/to/file.h");
+      ctx.symbols.push(createMockSymbol("sym1"));
+      ctx.symbols.push(createMockSymbol("sym2"));
+
+      const symbols = SymbolCollectorContext.getSymbols(ctx);
+      expect(symbols).toHaveLength(2);
+      expect(symbols[0].name).toBe("sym1");
+      expect(symbols[1].name).toBe("sym2");
+    });
+  });
+
+  describe("getWarnings", () => {
+    it("returns empty array for new context", () => {
+      const ctx = SymbolCollectorContext.create("/path/to/file.h");
+
+      expect(SymbolCollectorContext.getWarnings(ctx)).toEqual([]);
+    });
+
+    it("returns warnings added to context", () => {
+      const ctx = SymbolCollectorContext.create("/path/to/file.h");
+      ctx.warnings.push("warning1");
+      ctx.warnings.push("warning2");
+
+      const warnings = SymbolCollectorContext.getWarnings(ctx);
+      expect(warnings).toHaveLength(2);
+      expect(warnings[0]).toBe("warning1");
+      expect(warnings[1]).toBe("warning2");
+    });
+  });
+
+  describe("addSymbol", () => {
+    it("adds symbol to context", () => {
+      const ctx = SymbolCollectorContext.create("/path/to/file.h");
+      const symbol = createMockSymbol("testFunc");
+
+      SymbolCollectorContext.addSymbol(ctx, symbol);
+
+      expect(ctx.symbols).toHaveLength(1);
+      expect(ctx.symbols[0].name).toBe("testFunc");
+    });
+
+    it("adds multiple symbols in order", () => {
+      const ctx = SymbolCollectorContext.create("/path/to/file.h");
+
+      SymbolCollectorContext.addSymbol(ctx, createMockSymbol("first"));
+      SymbolCollectorContext.addSymbol(ctx, createMockSymbol("second"));
+      SymbolCollectorContext.addSymbol(ctx, createMockSymbol("third"));
+
+      expect(ctx.symbols).toHaveLength(3);
+      expect(ctx.symbols[0].name).toBe("first");
+      expect(ctx.symbols[1].name).toBe("second");
+      expect(ctx.symbols[2].name).toBe("third");
+    });
+  });
+
+  describe("addWarning", () => {
+    it("adds warning to context", () => {
+      const ctx = SymbolCollectorContext.create("/path/to/file.h");
+
+      SymbolCollectorContext.addWarning(ctx, "Test warning message");
+
+      expect(ctx.warnings).toHaveLength(1);
+      expect(ctx.warnings[0]).toBe("Test warning message");
+    });
+
+    it("adds multiple warnings in order", () => {
+      const ctx = SymbolCollectorContext.create("/path/to/file.h");
+
+      SymbolCollectorContext.addWarning(ctx, "first warning");
+      SymbolCollectorContext.addWarning(ctx, "second warning");
+
+      expect(ctx.warnings).toHaveLength(2);
+      expect(ctx.warnings[0]).toBe("first warning");
+      expect(ctx.warnings[1]).toBe("second warning");
+    });
+  });
+
   describe("integration patterns", () => {
     it("supports C symbol collection pattern", () => {
       const symbolTable = new SymbolTable();


### PR DESCRIPTION
## Summary
- Add composition helper methods to `SymbolCollectorContext`:
  - `addSymbol(ctx, symbol)` - encapsulate symbol addition
  - `addWarning(ctx, message)` - encapsulate warning addition
  - `getSymbols(ctx)` - encapsulate symbol retrieval
  - `getWarnings(ctx)` - encapsulate warning retrieval
- Update `CSymbolCollector` and `CppSymbolCollector` to use the helpers
- Add 8 unit tests for the new methods (21 total for SymbolCollectorContext)

## Approach
Issue #396 suggested creating a `BaseSymbolCollector` abstract class. Instead, this uses **composition** by extending `SymbolCollectorContext` with helper methods that encapsulate context mutations. This avoids inheritance while providing the same benefits of code reuse and encapsulation.

## Test plan
- [x] All unit tests pass (1378 tests)
- [x] All integration tests pass (847 tests)
- [x] TypeScript compilation succeeds
- [x] Linting passes

Closes #396

🤖 Generated with [Claude Code](https://claude.com/claude-code)