### PR TITLE
feat(cli): Add PlatformIO CLI tests and implement --target flag (Issue #405)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -114,6 +114,16 @@ See `CONTRIBUTING.md` for complete TypeScript coding standards.
   3. Handle effect in `processEffects()` switch statement
   4. Generate output in `assembleOutput()` where other effects are emitted
 
+### Adding CLI Flags
+
+When adding a new CLI flag that affects code generation, update all layers:
+
+1. `src/index.ts` — Parse the argument and compute `final<Flag>` value
+2. `src/index.ts` — Pass to `runUnifiedMode()`
+3. `src/project/types/IProjectConfig.ts` — Add to interface
+4. `src/project/Project.ts` — Pass to `Pipeline` constructor (both locations)
+5. `src/pipeline/types/IPipelineConfig.ts` — Already has most fields, verify it exists
+
 ### Error Messages
 
 - Use simple `Error: message` format (not `Error[EXXX]`) — matches 111/114 existing errors.
@@ -138,6 +148,12 @@ See `CONTRIBUTING.md` for complete TypeScript coding standards.
 - `npm run test:all` — Run both test suites
 - `npm test -- <path> --update` — Generate/update `.expected.c` snapshots for new tests
 - Tests without `.expected.c` snapshots are **skipped** (not failed) — use `--update` to generate initial snapshot
+
+### Test Architecture
+
+- **`npm test`** — Tests transpilation via `Pipeline.transpileSource()` API (parallelized, fast)
+- **`npm run test:cli`** — Tests CLI behavior via subprocess in `scripts/test-cli.js` (flags, exit codes, file I/O)
+- CLI-specific features (PlatformIO detection, `--target` flag) need `test:cli` tests, not `npm test`
 
 ### Unit Test File Location
 

--- a/docs/plans/2026-01-31-platformio-cli-tests-design.md
+++ b/docs/plans/2026-01-31-platformio-cli-tests-design.md
@@ -1,0 +1,74 @@
+# PlatformIO CLI Test Coverage Design
+
+**Issue:** #405 - Test coverage: platformio-detect (PlatformIO integration)
+**Date:** 2026-01-31
+**Status:** Implemented
+
+## Problem
+
+The PlatformIO integration features (`--pio-install`, `--pio-uninstall`, `--target`) had no test coverage. Additionally, the `--target` CLI flag was documented in `--help` but never implemented.
+
+## Solution
+
+### 1. Implemented Missing `--target` CLI Flag
+
+The `--target` flag was advertised in help but the argument parser didn't handle it. Fixed by:
+
+- Added `cliTarget` variable and argument parsing in `src/index.ts`
+- Added `finalTarget` computation (CLI takes precedence over config)
+- Passed `target` through `runUnifiedMode()` to `Project`
+- Added `target` to `IProjectConfig` interface
+- Updated `Project` to pass `target` to `Pipeline`
+
+### 2. Added 14 Comprehensive CLI Tests
+
+Extended `scripts/test-cli.js` with four test categories:
+
+#### Category 1: `--pio-install` (4 tests)
+
+- Creates `cnext_build.py` and modifies `platformio.ini`
+- Idempotent (safe to run twice)
+- Fails gracefully without `platformio.ini`
+- Preserves existing `extra_scripts`
+
+#### Category 2: `--pio-uninstall` (4 tests)
+
+- Removes integration cleanly
+- Idempotent (safe on clean project)
+- Fails gracefully without `platformio.ini`
+- Preserves other `extra_scripts`
+
+#### Category 3: `--target` flag (4 tests)
+
+- `--target teensy41` generates LDREX/STREX code
+- `--target cortex-m0` generates PRIMASK fallback
+- `--target avr` generates PRIMASK fallback
+- Unknown target uses default (graceful degradation)
+
+#### Category 4: Config file integration (2 tests)
+
+- `cnext.config.json` target is respected
+- CLI `--target` overrides config file
+
+## Test Infrastructure Added
+
+Helper functions in `test-cli.js`:
+
+- `createTempPioProject(pioIniContent)` — Creates isolated test fixture
+- `runCliInDir(cwd, args)` — Runs CLI in specific directory
+- `assertFileContains(path, substring)` — Verifies file content
+- `assertFileNotExists(path)` — Verifies cleanup
+- `cleanupTempDir(dir)` — Cleanup helper
+
+## Files Changed
+
+- `src/index.ts` — Added `--target` argument parsing
+- `src/project/types/IProjectConfig.ts` — Added `target` field
+- `src/project/Project.ts` — Pass `target` to Pipeline
+- `scripts/test-cli.js` — Added 14 new tests
+
+## Test Results
+
+- CLI tests: 25 passed (11 original + 14 new)
+- Integration tests: 874 passed
+- Unit tests: 1450 passed

--- a/src/index.ts
+++ b/src/index.ts
@@ -227,6 +227,7 @@ async function runUnifiedMode(
   parseOnly: boolean,
   headerOutDir?: string,
   basePath?: string,
+  target?: string,
 ): Promise<void> {
   // Issue #337: Identify which inputs are directories (for structure preservation)
   // These will be passed to Project.srcDirs so Pipeline can preserve directory structure
@@ -314,6 +315,7 @@ async function runUnifiedMode(
     cppRequired,
     noCache,
     parseOnly,
+    target,
   });
 
   // Step 5: Compile
@@ -521,6 +523,7 @@ async function main(): Promise<void> {
   const includeDirs: string[] = [];
   const defines: Record<string, string | boolean> = {};
   let cliCppRequired: boolean | undefined;
+  let cliTarget: string | undefined;
   let preprocess = true;
   let verbose = false;
   let noCache = false;
@@ -554,6 +557,9 @@ async function main(): Promise<void> {
       i++;
     } else if (arg === "--base-path" && i + 1 < args.length) {
       basePath = args[i + 1];
+      i++;
+    } else if (arg === "--target" && i + 1 < args.length) {
+      cliTarget = args[i + 1];
       i++;
     } else if (arg === "--clean") {
       cleanMode = true;
@@ -598,6 +604,7 @@ async function main(): Promise<void> {
 
   // Apply config defaults, CLI flags take precedence
   const finalCppRequired = cliCppRequired ?? config.cppRequired ?? false;
+  const finalTarget = cliTarget ?? config.target;
   const finalNoCache = noCache || config.noCache === true;
   const finalOutputPath = outputPath || config.output || "";
   const finalHeaderOutDir = headerOutDir ?? config.headerOut;
@@ -612,7 +619,7 @@ async function main(): Promise<void> {
     console.log("  Config file:    " + (config._path ?? "(none)"));
     console.log("  cppRequired:    " + finalCppRequired);
     console.log("  debugMode:      " + (config.debugMode ?? false));
-    console.log("  target:         " + (config.target ?? "(none)"));
+    console.log("  target:         " + (finalTarget ?? "(none)"));
     console.log("  noCache:        " + finalNoCache);
     console.log("  preprocess:     " + preprocess);
     console.log(
@@ -665,6 +672,7 @@ async function main(): Promise<void> {
     parseOnly,
     finalHeaderOutDir,
     finalBasePath,
+    finalTarget,
   );
 }
 

--- a/src/project/Project.ts
+++ b/src/project/Project.ts
@@ -55,6 +55,7 @@ class Project {
       cppRequired: this.config.cppRequired,
       noCache: this.config.noCache,
       parseOnly: this.config.parseOnly,
+      target: this.config.target,
     });
   }
 
@@ -83,6 +84,7 @@ class Project {
         cppRequired: this.config.cppRequired,
         noCache: this.config.noCache,
         parseOnly: this.config.parseOnly,
+        target: this.config.target,
       });
 
       const source = readFileSync(file, "utf-8");

--- a/src/project/types/IProjectConfig.ts
+++ b/src/project/types/IProjectConfig.ts
@@ -40,6 +40,9 @@ interface IProjectConfig {
 
   /** Parse only mode - validate syntax without generating output */
   parseOnly?: boolean;
+
+  /** ADR-049: Target platform for atomic code generation (e.g., "teensy41", "cortex-m0") */
+  target?: string;
 }
 
 export default IProjectConfig;


### PR DESCRIPTION
## Summary

- Add comprehensive CLI test coverage for PlatformIO integration (Issue #405)
- Implement the `--target` CLI flag which was documented but not implemented

## Changes

### Bug Fix: Missing `--target` CLI Flag
The `--target` flag was advertised in `--help` but the argument parser didn't handle it. Now works:
```bash
cnext --target cortex-m0 myfile.cnx  # Uses PRIMASK fallback
cnext --target teensy41 myfile.cnx   # Uses LDREX/STREX
```

### New CLI Tests (14 tests added)

| Category | Tests | What They Verify |
|----------|-------|------------------|
| `--pio-install` | 4 | Creates/modifies files, idempotent, error handling |
| `--pio-uninstall` | 4 | Removes files cleanly, idempotent, preserves other scripts |
| `--target` flag | 4 | teensy41→LDREX, cortex-m0→PRIMASK, avr→PRIMASK, unknown→default |
| Config integration | 2 | Config file respected, CLI overrides config |

## Test plan

- [x] All 25 CLI tests pass (11 original + 14 new)
- [x] All 874 integration tests pass
- [x] All 1450 unit tests pass
- [x] TypeScript compiles without errors
- [x] Pre-commit hooks pass (prettier, oxlint)

Closes #405

🤖 Generated with [Claude Code](https://claude.com/claude-code)