### PR TITLE
Release v0.1.50

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.50] - 2026-01-31
+
+### Fixed
+
+- C++ mode: `this.method()` calls now correctly resolve for const inference - private functions calling cross-file modifying functions are properly tracked (Issue #561, PR #562)
+
+### Changed
+
+- Unified `Pipeline.run()` and `Pipeline.transpileSource()` code paths for cross-file const inference - both now use the same modification tracking mechanism (Issue #561, PR #562)
+- Added `CodeGenerator.analyzeModificationsOnly()` for standalone modification analysis without full code generation
+
 ## [0.1.49] - 2026-01-31
 
 ### Fixed
@@ -574,7 +585,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - 38 legacy ESLint errors (non-blocking, tracked for future cleanup)
 
-[Unreleased]: https://github.com/jlaustill/c-next/compare/v0.1.49...HEAD
+[Unreleased]: https://github.com/jlaustill/c-next/compare/v0.1.50...HEAD
+[0.1.50]: https://github.com/jlaustill/c-next/compare/v0.1.49...v0.1.50
 [0.1.49]: https://github.com/jlaustill/c-next/compare/v0.1.48...v0.1.49
 [0.1.48]: https://github.com/jlaustill/c-next/compare/v0.1.47...v0.1.48
 [0.1.47]: https://github.com/jlaustill/c-next/compare/v0.1.46...v0.1.47

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "c-next",
-  "version": "0.1.49",
+  "version": "0.1.50",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "c-next",
-      "version": "0.1.49",
+      "version": "0.1.50",
       "license": "MIT",
       "dependencies": {
         "antlr4ng": "^3.0.16",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "c-next",
-  "version": "0.1.49",
+  "version": "0.1.50",
   "description": "A safer C for embedded systems development. Transpiles to clean, readable C.",
   "main": "src/index.ts",
   "bin": {

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "c-next",
   "displayName": "C-Next",
   "description": "Syntax highlighting and live C preview for C-Next, a safer C for embedded systems",
-  "version": "0.1.49",
+  "version": "0.1.50",
   "publisher": "jlaustill",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
## Release v0.1.50

### Fixed

- C++ mode: `this.method()` calls now correctly resolve for const inference - private functions calling cross-file modifying functions are properly tracked (Issue #561, PR #562)

### Changed

- Unified `Pipeline.run()` and `Pipeline.transpileSource()` code paths for cross-file const inference - both now use the same modification tracking mechanism (Issue #561, PR #562)
- Added `CodeGenerator.analyzeModificationsOnly()` for standalone modification analysis without full code generation

---

**Checklist:**
- [x] CHANGELOG.md updated
- [x] Version bumped in package.json
- [x] Version bumped in vscode-extension/package.json
- [x] package-lock.json updated
- [x] All tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)