### PR TITLE
docs: add session learnings to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,6 +63,8 @@ class TestUtils {
 export default TestUtils;
 ```
 
+**Readonly Map restoration** - Can't reassign `readonly` Map properties. Use `map.clear()` then `for (const [k, v] of saved) map.set(k, v)` to restore state.
+
 **No destructuring** - Always use the class name prefix for self-documenting code:
 
 ```typescript
@@ -107,6 +109,10 @@ See `CONTRIBUTING.md` for complete TypeScript coding standards.
 
 - **Array dimensions**: `IVariableSymbol.arrayDimensions` is `(number | string)[]` - numbers for resolved constants, strings for C macros from headers
 - **C macro pass-through**: Unresolved array dimension identifiers (e.g., `DEVICE_COUNT` from included C headers) pass through as strings to generated headers
+
+### Parser Keyword Tokens
+
+- **Keyword tokens vs IDENTIFIER**: Keywords like `this`, `global` are separate tokens, not IDENTIFIERs. Use `ctx.THIS()` not `ctx.IDENTIFIER()?.getText() === "this"` - the latter returns undefined.
 
 ### Code Generation Patterns
 
@@ -312,6 +318,8 @@ When adding features involving cross-file symbols (enums, structs, types):
 1. Test with `npm test` (uses `transpileSource()`) — may pass with incomplete implementation
 2. Verify with `npx tsx src/index.ts` (uses `run()`) — tests the full pipeline
 3. Ensure both paths receive the same symbol information (e.g., `allKnownEnums`)
+
+**Cross-file modification tracking**: Both paths now accumulate modifications via `accumulatedModifications` (Issue #561). If CLI works but tests don't (or vice versa), check if the feature relies on cross-file state that only one path handles.
 
 ## Task Completion Requirements
 


### PR DESCRIPTION
## Summary

Adds learnings from Issue #561 debugging session to help future Claude sessions.

## Changes

- **TypeScript patterns**: Readonly Map restoration (can't reassign, must clear+repopulate)
- **Parser keyword tokens**: Keywords like `this`, `global` need `ctx.THIS()` not `ctx.IDENTIFIER()?.getText()`
- **Pipeline code paths**: Cross-file modification tracking note referencing Issue #561

🤖 Generated with [Claude Code](https://claude.com/claude-code)