### PR TITLE
refactor(pipeline): unify run() and transpileSource() code paths

### DIFF
--- a/src/pipeline/types/IFileResult.ts
+++ b/src/pipeline/types/IFileResult.ts
@@ -1,4 +1,5 @@
 import ITranspileError from "../../lib/types/ITranspileError";
+import ITranspileContribution from "./ITranspileContribution";
 
 /**
  * Result of transpiling a single file
@@ -24,6 +25,9 @@ interface IFileResult {
 
   /** Number of top-level declarations found */
   declarationCount: number;
+
+  /** Contributions from this file for accumulation in run() */
+  contribution?: ITranspileContribution;
 }
 
 export default IFileResult;

--- a/src/pipeline/types/ITranspileContext.ts
+++ b/src/pipeline/types/ITranspileContext.ts
@@ -1,0 +1,49 @@
+import ISymbolInfo from "../../codegen/generators/ISymbolInfo";
+import SymbolTable from "../../symbol_resolution/SymbolTable";
+
+/**
+ * Cross-file context passed to transpileSource() when called from run().
+ *
+ * This interface encapsulates the shared state built during Stages 1-4 of
+ * the Pipeline, allowing transpileSource() to skip redundant parsing when
+ * operating in multi-file mode.
+ *
+ * When context is provided:
+ * - Uses shared symbolTable (already populated with all symbols)
+ * - Skips header parsing (Step 4a) and C-Next include parsing (Step 4b)
+ * - Uses pre-collected symbolInfoByFile for transitive enum resolution
+ * - Uses accumulatedModifications for cross-file C++ const inference
+ *
+ * When context is undefined (standalone mode):
+ * - transpileSource() behaves as before (backwards compatible)
+ */
+interface ITranspileContext {
+  /** Shared symbol table populated with all symbols from Stages 2-3 */
+  readonly symbolTable: SymbolTable;
+
+  /** Per-file symbol info collected during Stage 3 for external enum resolution */
+  readonly symbolInfoByFile: ReadonlyMap<string, ISymbolInfo>;
+
+  /** Cross-file parameter modifications for C++ const inference (Issue #558) */
+  readonly accumulatedModifications: Map<string, Set<string>>;
+
+  /** Cross-file function parameter lists for transitive propagation (Issue #558) */
+  readonly accumulatedParamLists: Map<string, string[]>;
+
+  /** C header include directives for type headers (Issue #497) */
+  readonly headerIncludeDirectives: ReadonlyMap<string, string>;
+
+  /** Whether C++ output mode is active (Issue #211) */
+  readonly cppMode: boolean;
+
+  /** Include directories from config */
+  readonly includeDirs: readonly string[];
+
+  /** Target platform from config */
+  readonly target: string;
+
+  /** Debug mode flag from config */
+  readonly debugMode: boolean;
+}
+
+export default ITranspileContext;

--- a/src/pipeline/types/ITranspileContribution.ts
+++ b/src/pipeline/types/ITranspileContribution.ts
@@ -1,0 +1,32 @@
+import ISymbolInfo from "../../codegen/generators/ISymbolInfo";
+
+/**
+ * Data contributed by transpiling a single file.
+ *
+ * When run() delegates to transpileSource(), each file transpilation
+ * produces these contributions that run() accumulates:
+ *
+ * - symbolInfo: For header generation (Issue #220)
+ * - passByValueParams: For header parameter optimization (Issue #280)
+ * - userIncludes: For header include directives (Issue #424)
+ * - modifiedParameters: For C++ const inference accumulation (Issue #558)
+ * - functionParamLists: For C++ const inference transitive propagation
+ */
+interface ITranspileContribution {
+  /** Symbol info collected from this file (for header generation) */
+  readonly symbolInfo: ISymbolInfo;
+
+  /** Pass-by-value parameters: funcName -> Set of param names */
+  readonly passByValueParams: ReadonlyMap<string, ReadonlySet<string>>;
+
+  /** User .cnx includes transformed to .h (for header generation) */
+  readonly userIncludes: readonly string[];
+
+  /** Modified parameters in this file (C++ mode only) */
+  readonly modifiedParameters?: ReadonlyMap<string, Set<string>>;
+
+  /** Function parameter lists in this file (C++ mode only) */
+  readonly functionParamLists?: ReadonlyMap<string, readonly string[]>;
+}
+
+export default ITranspileContribution;


### PR DESCRIPTION
## Summary

- Refactor Pipeline to eliminate duplicate transpilation logic that caused bugs when features worked in one path but not the other
- Create `ITranspileContext` interface to encapsulate cross-file state
- Create `ITranspileContribution` interface for per-file transpilation output
- Add optional context parameter to `transpileSource()` - when provided, uses shared state and skips redundant header/include parsing
- Refactor `run()` Stage 5 to delegate to `transpileSource()` with context
- Remove redundant `transpileFile()` method (~160 lines)
- Extract `collectUserIncludes()` helper to eliminate duplication

Fixes #568

## Test plan

- [x] All 880 integration tests pass
- [x] All 1464 unit tests pass
- [x] All 27 CLI tests pass
- [x] Cross-file const inference tests (#565) pass
- [x] C++ mode detection works correctly in both paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)