### PR TITLE
docs: add coverage report badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 [![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=jlaustill_c-next&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=jlaustill_c-next)
 [![Coverage](https://sonarcloud.io/api/project_badges/measure?project=jlaustill_c-next&metric=coverage)](https://sonarcloud.io/summary/new_code?id=jlaustill_c-next)
+[![Coverage Report](https://img.shields.io/badge/Coverage-Report-blue)](https://jlaustill.github.io/c-next/coverage/)
 [![Maintainability Rating](https://sonarcloud.io/api/project_badges/measure?project=jlaustill_c-next&metric=sqale_rating)](https://sonarcloud.io/summary/new_code?id=jlaustill_c-next)
 
 A safer C for embedded systems development. Transpiles to clean, readable C.


### PR DESCRIPTION
## Summary
- Adds a "Coverage Report" badge linking to the GitHub Pages coverage report
- Complements the existing SonarCloud coverage percentage badge

![image](https://img.shields.io/badge/Coverage-Report-blue)

## Test plan
- [x] Badge renders correctly
- [x] Link goes to https://jlaustill.github.io/c-next/coverage/

🤖 Generated with [Claude Code](https://claude.com/claude-code)