### PR TITLE
refactor: create HeaderParser wrapper for C/C++ header parsing

### DIFF
--- a/src/transpiler/logic/parser/HeaderParser.ts
+++ b/src/transpiler/logic/parser/HeaderParser.ts
@@ -1,0 +1,91 @@
+/**
+ * HeaderParser
+ * Parses C and C++ header files for symbol extraction.
+ *
+ * Encapsulates ANTLR lexer/parser setup for header files,
+ * providing a clean interface for the Transpiler to use.
+ */
+
+import { CharStream, CommonTokenStream } from "antlr4ng";
+
+import { CLexer } from "./c/grammar/CLexer";
+import { CParser, CompilationUnitContext } from "./c/grammar/CParser";
+import { CPP14Lexer } from "./cpp/grammar/CPP14Lexer";
+import { CPP14Parser, TranslationUnitContext } from "./cpp/grammar/CPP14Parser";
+
+/**
+ * Result of parsing a C header
+ */
+interface ICParseResult {
+  /** The parsed AST, or null if parsing failed */
+  tree: CompilationUnitContext | null;
+}
+
+/**
+ * Result of parsing a C++ header
+ */
+interface ICppParseResult {
+  /** The parsed AST, or null if parsing failed */
+  tree: TranslationUnitContext | null;
+}
+
+/**
+ * Parses C and C++ header files
+ */
+class HeaderParser {
+  /**
+   * Parse a C header file
+   *
+   * Error listeners are removed to suppress parse errors, as headers
+   * may contain constructs that the C parser doesn't fully support.
+   *
+   * @param content - The header file content
+   * @returns Parse result with tree (null if parsing failed)
+   */
+  static parseC(content: string): ICParseResult {
+    try {
+      const charStream = CharStream.fromString(content);
+      const lexer = new CLexer(charStream);
+      const tokenStream = new CommonTokenStream(lexer);
+      const parser = new CParser(tokenStream);
+
+      // Suppress parse errors - headers may have unsupported constructs
+      parser.removeErrorListeners();
+
+      const tree = parser.compilationUnit();
+      return { tree };
+    } catch {
+      // Return null tree on parse failure
+      return { tree: null };
+    }
+  }
+
+  /**
+   * Parse a C++ header file
+   *
+   * Error listeners are removed to suppress parse errors, as headers
+   * may contain complex C++ features that aren't fully supported.
+   *
+   * @param content - The header file content
+   * @returns Parse result with tree (null if parsing failed)
+   */
+  static parseCpp(content: string): ICppParseResult {
+    try {
+      const charStream = CharStream.fromString(content);
+      const lexer = new CPP14Lexer(charStream);
+      const tokenStream = new CommonTokenStream(lexer);
+      const parser = new CPP14Parser(tokenStream);
+
+      // Suppress parse errors - headers may have complex C++ features
+      parser.removeErrorListeners();
+
+      const tree = parser.translationUnit();
+      return { tree };
+    } catch {
+      // Return null tree on parse failure
+      return { tree: null };
+    }
+  }
+}
+
+export default HeaderParser;

--- a/src/transpiler/logic/parser/__tests__/HeaderParser.test.ts
+++ b/src/transpiler/logic/parser/__tests__/HeaderParser.test.ts
@@ -1,0 +1,139 @@
+/**
+ * Unit tests for HeaderParser
+ */
+
+import { describe, it, expect } from "vitest";
+import HeaderParser from "../HeaderParser";
+
+describe("HeaderParser", () => {
+  describe("parseC", () => {
+    it("parses a simple C header", () => {
+      const content = `
+        typedef unsigned int uint32_t;
+        void foo(int x);
+      `;
+
+      const result = HeaderParser.parseC(content);
+
+      expect(result.tree).not.toBeNull();
+    });
+
+    it("parses C structs", () => {
+      const content = `
+        struct Point {
+          int x;
+          int y;
+        };
+      `;
+
+      const result = HeaderParser.parseC(content);
+
+      expect(result.tree).not.toBeNull();
+    });
+
+    it("parses C enums", () => {
+      const content = `
+        enum Color {
+          RED,
+          GREEN,
+          BLUE
+        };
+      `;
+
+      const result = HeaderParser.parseC(content);
+
+      expect(result.tree).not.toBeNull();
+    });
+
+    it("handles invalid C syntax with error recovery", () => {
+      // ANTLR parsers use error recovery rather than throwing
+      // They still produce a tree, but with error nodes
+      const content = "@@@ invalid syntax $$$";
+
+      const result = HeaderParser.parseC(content);
+
+      // Tree is returned (with error nodes) due to error recovery
+      expect(result.tree).not.toBeNull();
+    });
+
+    it("handles empty content", () => {
+      const result = HeaderParser.parseC("");
+
+      expect(result.tree).not.toBeNull();
+    });
+  });
+
+  describe("parseCpp", () => {
+    it("parses a simple C++ header", () => {
+      const content = `
+        class Foo {
+        public:
+          void bar();
+        };
+      `;
+
+      const result = HeaderParser.parseCpp(content);
+
+      expect(result.tree).not.toBeNull();
+    });
+
+    it("parses C++ typed enums", () => {
+      const content = `
+        enum class Color : unsigned char {
+          RED,
+          GREEN,
+          BLUE
+        };
+      `;
+
+      const result = HeaderParser.parseCpp(content);
+
+      expect(result.tree).not.toBeNull();
+    });
+
+    it("parses C++ namespaces", () => {
+      const content = `
+        namespace MyLib {
+          class Widget {
+          public:
+            void draw();
+          };
+        }
+      `;
+
+      const result = HeaderParser.parseCpp(content);
+
+      expect(result.tree).not.toBeNull();
+    });
+
+    it("parses C++ templates", () => {
+      const content = `
+        template<typename T>
+        class Container {
+          T value;
+        };
+      `;
+
+      const result = HeaderParser.parseCpp(content);
+
+      expect(result.tree).not.toBeNull();
+    });
+
+    it("handles invalid C++ syntax with error recovery", () => {
+      // ANTLR parsers use error recovery rather than throwing
+      // They still produce a tree, but with error nodes
+      const content = "@@@ invalid syntax $$$";
+
+      const result = HeaderParser.parseCpp(content);
+
+      // Tree is returned (with error nodes) due to error recovery
+      expect(result.tree).not.toBeNull();
+    });
+
+    it("handles empty content", () => {
+      const result = HeaderParser.parseCpp("");
+
+      expect(result.tree).not.toBeNull();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Extracts C/C++ header parsing into a dedicated `HeaderParser` class in the logic layer, improving separation of concerns in the Transpiler.

Fixes #584

## Changes

### New: `src/transpiler/logic/parser/HeaderParser.ts`
- `parseC(content)` - Parse C headers, returns AST or null on failure
- `parseCpp(content)` - Parse C++ headers, returns AST or null on failure
- Encapsulates ANTLR lexer/parser setup
- Handles error recovery gracefully (ANTLR produces partial trees with error nodes)

### Updated: `src/transpiler/Transpiler.ts`
- `parsePureCHeader()` now uses `HeaderParser.parseC()`
- `parseCppHeader()` now uses `HeaderParser.parseCpp()`
- Removed direct ANTLR imports: `CharStream`, `CommonTokenStream`, `CLexer`, `CParser`, `CPP14Lexer`, `CPP14Parser`

## Impact

- **+210 lines** (new HeaderParser + tests)
- **-25 lines** (removed from Transpiler)
- Cleaner separation between parsing and symbol collection
- Parsing logic now in appropriate layer (`logic/parser/`)

## Test plan

- [x] `npm run typecheck` passes
- [x] `npm run test:q` - all 884 tests pass
- [x] `npm run unit` - all 1647 unit tests pass
- [x] 11 new unit tests for HeaderParser:
  - Simple C/C++ headers
  - Structs, enums, classes, namespaces, templates
  - Error recovery behavior
  - Empty content handling

🤖 Generated with [Claude Code](https://claude.com/claude-code)