### PR TITLE
refactor(cache): add setSymbolsFromTable to CacheManager (#590)

### DIFF
--- a/src/transpiler/Transpiler.ts
+++ b/src/transpiler/Transpiler.ts
@@ -53,7 +53,6 @@ import ITranspileContribution from "./types/ITranspileContribution";
 import runAnalyzers from "./logic/analysis/runAnalyzers";
 import ModificationAnalyzer from "./logic/analysis/ModificationAnalyzer";
 import CacheManager from "../utils/cache/CacheManager";
-import IStructFieldInfo from "./logic/symbols/types/IStructFieldInfo";
 import detectCppSyntax from "./logic/detectCppSyntax";
 import LiteralUtils from "../utils/LiteralUtils";
 
@@ -580,21 +579,9 @@ class Transpiler {
       console.log(`[DEBUG]   Found ${symbols.length} symbols in ${file.path}`);
     }
 
-    // After parsing, cache the results
+    // Issue #590: Cache the results using simplified API
     if (this.cacheManager) {
-      const symbols = this.symbolTable.getSymbolsByFile(file.path);
-      const structFields = this.extractStructFieldsForFile(file.path);
-      const needsStructKeyword = this.extractNeedsStructKeywordForFile(
-        file.path,
-      );
-      const enumBitWidth = this.extractEnumBitWidthsForFile(file.path);
-      this.cacheManager.setSymbols(
-        file.path,
-        symbols,
-        structFields,
-        needsStructKeyword,
-        enumBitWidth,
-      );
+      this.cacheManager.setSymbolsFromTable(file.path, this.symbolTable);
     }
   }
 
@@ -1608,68 +1595,6 @@ class Transpiler {
 
     // Fallback: use first input's directory
     return startDir;
-  }
-
-  /**
-   * Extract struct fields for a specific file
-   * Returns only struct fields for structs defined in that file
-   */
-  private extractStructFieldsForFile(
-    filePath: string,
-  ): Map<string, Map<string, IStructFieldInfo>> {
-    const result = new Map<string, Map<string, IStructFieldInfo>>();
-
-    // Get struct names defined in this file
-    const structNames = this.symbolTable.getStructNamesByFile(filePath);
-
-    // Get fields for each struct
-    const allStructFields = this.symbolTable.getAllStructFields();
-    for (const structName of structNames) {
-      const fields = allStructFields.get(structName);
-      if (fields) {
-        result.set(structName, fields);
-      }
-    }
-
-    return result;
-  }
-
-  /**
-   * Issue #196 Bug 3: Extract struct names requiring 'struct' keyword for a specific file
-   * Returns struct names from this file that need the 'struct' keyword in C
-   */
-  private extractNeedsStructKeywordForFile(filePath: string): string[] {
-    // Get struct names defined in this file
-    const structNames = this.symbolTable.getStructNamesByFile(filePath);
-
-    // Filter to only those that need struct keyword
-    const allNeedsKeyword = this.symbolTable.getAllNeedsStructKeyword();
-    return structNames.filter((name) => allNeedsKeyword.includes(name));
-  }
-
-  /**
-   * Issue #208: Extract enum bit widths for a specific file
-   * Returns enum bit widths for enums defined in that file
-   */
-  private extractEnumBitWidthsForFile(filePath: string): Map<string, number> {
-    const result = new Map<string, number>();
-
-    // Get enum names defined in this file
-    const fileSymbols = this.symbolTable.getSymbolsByFile(filePath);
-    const enumNames = fileSymbols
-      .filter((s) => s.kind === "enum")
-      .map((s) => s.name);
-
-    // Get bit widths for each enum
-    const allBitWidths = this.symbolTable.getAllEnumBitWidths();
-    for (const enumName of enumNames) {
-      const width = allBitWidths.get(enumName);
-      if (width !== undefined) {
-        result.set(enumName, width);
-      }
-    }
-
-    return result;
   }
 }
 


### PR DESCRIPTION
## Summary

- **Extract cache serialization logic from Transpiler into CacheManager** by adding `setSymbolsFromTable()` method that accepts SymbolTable directly
- **Add private helpers** for per-file extraction: `extractStructFieldsForFile`, `extractNeedsStructKeywordForFile`, `extractEnumBitWidthsForFile`
- **Simplify Transpiler.run()** caching from 30+ lines of extraction code to a single method call
- **Add 14 unit tests** achieving 100% coverage on CacheManager

This creates a cleaner API where CacheManager encapsulates all serialization logic, making it the single source of truth for cache operations. The Transpiler no longer needs to know about cache internals.

Closes #590

## Test plan

- [x] All 14 new unit tests pass for `setSymbolsFromTable()` method
- [x] 100% code coverage on CacheManager.ts
- [x] All 1647 unit tests pass
- [x] All 884 integration tests pass
- [x] All quality checks pass (prettier, oxlint, TypeScript)

🤖 Generated with [Claude Code](https://claude.com/claude-code)