### PR TITLE
refactor: extract include/type-header utilities from Transpiler

### DIFF
--- a/src/transpiler/logic/IncludeExtractor.ts
+++ b/src/transpiler/logic/IncludeExtractor.ts
@@ -1,0 +1,41 @@
+/**
+ * IncludeExtractor
+ * Extracts and transforms #include directives from parsed C-Next programs.
+ *
+ * Issue #589: Extracted from Transpiler.collectUserIncludes()
+ */
+
+import * as Parser from "./parser/grammar/CNextParser.js";
+
+/**
+ * Extracts include directives from C-Next parse trees
+ */
+class IncludeExtractor {
+  /**
+   * Extract user includes from a parsed C-Next program.
+   *
+   * Extracts #include directives for .cnx files and transforms them to .h includes.
+   * This enables cross-file type definitions in generated headers.
+   *
+   * @param tree The parsed C-Next program
+   * @returns Array of transformed include strings (e.g., '#include "types.h"')
+   */
+  static collectUserIncludes(tree: Parser.ProgramContext): string[] {
+    const userIncludes: string[] = [];
+    for (const includeDir of tree.includeDirective()) {
+      const includeText = includeDir.getText();
+      // Include both quoted ("...") and angle-bracket (<...>) .cnx includes
+      // These define types used in function signatures that need to be in the header
+      if (includeText.includes(".cnx")) {
+        // Transform .cnx includes to .h (the generated header for the included .cnx file)
+        const transformedInclude = includeText
+          .replace(/\.cnx"/, '.h"')
+          .replace(/\.cnx>/, ".h>");
+        userIncludes.push(transformedInclude);
+      }
+    }
+    return userIncludes;
+  }
+}
+
+export default IncludeExtractor;

--- a/src/transpiler/logic/__tests__/IncludeExtractor.test.ts
+++ b/src/transpiler/logic/__tests__/IncludeExtractor.test.ts
@@ -1,0 +1,113 @@
+/**
+ * Unit tests for IncludeExtractor
+ */
+
+import { describe, it, expect } from "vitest";
+import IncludeExtractor from "../IncludeExtractor";
+import CNextSourceParser from "../parser/CNextSourceParser";
+
+describe("IncludeExtractor", () => {
+  describe("collectUserIncludes", () => {
+    it("extracts and transforms .cnx includes to .h", () => {
+      const source = `
+        #include "types.cnx"
+        #include "utils.cnx"
+
+        void main() {}
+      `;
+      const { tree } = CNextSourceParser.parse(source);
+      const includes = IncludeExtractor.collectUserIncludes(tree);
+
+      expect(includes).toHaveLength(2);
+      // Verify the includes contain the transformed .h extension
+      expect(includes[0]).toContain("types.h");
+      expect(includes[1]).toContain("utils.h");
+    });
+
+    it("transforms angle-bracket .cnx includes", () => {
+      const source = `
+        #include <system.cnx>
+
+        void main() {}
+      `;
+      const { tree } = CNextSourceParser.parse(source);
+      const includes = IncludeExtractor.collectUserIncludes(tree);
+
+      expect(includes).toHaveLength(1);
+      expect(includes[0]).toContain("system.h");
+      expect(includes[0]).toContain("<");
+    });
+
+    it("ignores non-.cnx includes", () => {
+      const source = `
+        #include "types.h"
+        #include <stdio.h>
+        #include "utils.cnx"
+
+        void main() {}
+      `;
+      const { tree } = CNextSourceParser.parse(source);
+      const includes = IncludeExtractor.collectUserIncludes(tree);
+
+      expect(includes).toHaveLength(1);
+      expect(includes[0]).toContain("utils.h");
+    });
+
+    it("returns empty array when no .cnx includes", () => {
+      const source = `
+        #include "types.h"
+        #include <stdio.h>
+
+        void main() {}
+      `;
+      const { tree } = CNextSourceParser.parse(source);
+      const includes = IncludeExtractor.collectUserIncludes(tree);
+
+      expect(includes).toHaveLength(0);
+    });
+
+    it("returns empty array for source with no includes", () => {
+      const source = `
+        void main() {}
+      `;
+      const { tree } = CNextSourceParser.parse(source);
+      const includes = IncludeExtractor.collectUserIncludes(tree);
+
+      expect(includes).toHaveLength(0);
+    });
+
+    it("handles mixed include styles", () => {
+      const source = `
+        #include "local.cnx"
+        #include <system.h>
+        #include "other.cnx"
+        #include <lib.cnx>
+
+        void main() {}
+      `;
+      const { tree } = CNextSourceParser.parse(source);
+      const includes = IncludeExtractor.collectUserIncludes(tree);
+
+      expect(includes).toHaveLength(3);
+      // Verify each transformed include is present
+      const combined = includes.join(" ");
+      expect(combined).toContain("local.h");
+      expect(combined).toContain("other.h");
+      expect(combined).toContain("lib.h");
+    });
+
+    it("does not include original .cnx extension in output", () => {
+      const source = `
+        #include "test.cnx"
+
+        void main() {}
+      `;
+      const { tree } = CNextSourceParser.parse(source);
+      const includes = IncludeExtractor.collectUserIncludes(tree);
+
+      expect(includes).toHaveLength(1);
+      expect(includes[0]).not.toContain(".cnx");
+      expect(includes[0]).toContain(".h");
+    });
+  });
+});

--- a/src/transpiler/output/headers/ExternalTypeHeaderBuilder.ts
+++ b/src/transpiler/output/headers/ExternalTypeHeaderBuilder.ts
@@ -1,0 +1,65 @@
+/**
+ * ExternalTypeHeaderBuilder
+ * Builds mapping from external type names to their C header include directives.
+ *
+ * Issue #589: Extracted from Transpiler.buildExternalTypeHeaders()
+ * Issue #497: Enables header generation to include original C headers instead of
+ * generating conflicting forward declarations for types like anonymous struct typedefs.
+ */
+
+import ESymbolKind from "../../../utils/types/ESymbolKind";
+import ISymbol from "../../../utils/types/ISymbol";
+
+/**
+ * Interface for accessing symbols by file path
+ */
+interface ISymbolSource {
+  getSymbolsByFile(filePath: string): ISymbol[];
+}
+
+/**
+ * Builds mapping from external type names to their C header include directives
+ */
+class ExternalTypeHeaderBuilder {
+  /**
+   * Build a map from external type names to their C header include directives.
+   *
+   * This enables header generation to include the original C headers instead of
+   * generating conflicting forward declarations for types like anonymous struct typedefs.
+   *
+   * @param headerIncludeDirectives Map from header file paths to their include directives
+   * @param symbolSource Source for retrieving symbols by file path (typically SymbolTable)
+   * @returns Map from type names to include directives (e.g., "MyStruct" -> '#include "mystruct.h"')
+   */
+  static build(
+    headerIncludeDirectives: ReadonlyMap<string, string>,
+    symbolSource: ISymbolSource,
+  ): Map<string, string> {
+    const typeHeaders = new Map<string, string>();
+
+    // Check each header we have an include directive for
+    for (const [headerPath, directive] of headerIncludeDirectives) {
+      // Get all symbols defined in this header
+      const symbols = symbolSource.getSymbolsByFile(headerPath);
+
+      // Map each struct/type/enum name to the include directive
+      for (const sym of symbols) {
+        if (
+          sym.kind === ESymbolKind.Struct ||
+          sym.kind === ESymbolKind.Type ||
+          sym.kind === ESymbolKind.Enum ||
+          sym.kind === ESymbolKind.Class
+        ) {
+          // Only add if we don't already have a mapping (first include wins)
+          if (!typeHeaders.has(sym.name)) {
+            typeHeaders.set(sym.name, directive);
+          }
+        }
+      }
+    }
+
+    return typeHeaders;
+  }
+}
+
+export default ExternalTypeHeaderBuilder;

--- a/src/transpiler/output/headers/__tests__/ExternalTypeHeaderBuilder.test.ts
+++ b/src/transpiler/output/headers/__tests__/ExternalTypeHeaderBuilder.test.ts
@@ -1,0 +1,219 @@
+/**
+ * Unit tests for ExternalTypeHeaderBuilder
+ */
+
+import { describe, it, expect } from "vitest";
+import ExternalTypeHeaderBuilder from "../ExternalTypeHeaderBuilder";
+import ESymbolKind from "../../../../utils/types/ESymbolKind";
+import ISymbol from "../../../../utils/types/ISymbol";
+import ESourceLanguage from "../../../../utils/types/ESourceLanguage";
+
+/**
+ * Create a minimal test symbol
+ */
+function createSymbol(
+  name: string,
+  kind: ESymbolKind,
+  sourceFile: string,
+): ISymbol {
+  return {
+    name,
+    kind,
+    sourceFile,
+    sourceLine: 1,
+    sourceLanguage: ESourceLanguage.C,
+    isExported: false,
+  };
+}
+
+/**
+ * Mock symbol source for testing
+ */
+class MockSymbolSource {
+  private symbolsByFile: Map<string, ISymbol[]> = new Map();
+
+  addSymbols(filePath: string, symbols: ISymbol[]): void {
+    this.symbolsByFile.set(filePath, symbols);
+  }
+
+  getSymbolsByFile(filePath: string): ISymbol[] {
+    return this.symbolsByFile.get(filePath) ?? [];
+  }
+}
+
+describe("ExternalTypeHeaderBuilder", () => {
+  describe("build", () => {
+    it("maps struct types to their include directives", () => {
+      const source = new MockSymbolSource();
+      source.addSymbols("/path/to/types.h", [
+        createSymbol("MyStruct", ESymbolKind.Struct, "/path/to/types.h"),
+      ]);
+
+      const headerDirectives = new Map([
+        ["/path/to/types.h", '#include "types.h"'],
+      ]);
+
+      const result = ExternalTypeHeaderBuilder.build(headerDirectives, source);
+
+      expect(result.get("MyStruct")).toBe('#include "types.h"');
+    });
+
+    it("maps enum types to their include directives", () => {
+      const source = new MockSymbolSource();
+      source.addSymbols("/path/to/enums.h", [
+        createSymbol("Status", ESymbolKind.Enum, "/path/to/enums.h"),
+      ]);
+
+      const headerDirectives = new Map([
+        ["/path/to/enums.h", '#include "enums.h"'],
+      ]);
+
+      const result = ExternalTypeHeaderBuilder.build(headerDirectives, source);
+
+      expect(result.get("Status")).toBe('#include "enums.h"');
+    });
+
+    it("maps typedef types to their include directives", () => {
+      const source = new MockSymbolSource();
+      source.addSymbols("/path/to/types.h", [
+        createSymbol("size_t", ESymbolKind.Type, "/path/to/types.h"),
+      ]);
+
+      const headerDirectives = new Map([
+        ["/path/to/types.h", '#include "types.h"'],
+      ]);
+
+      const result = ExternalTypeHeaderBuilder.build(headerDirectives, source);
+
+      expect(result.get("size_t")).toBe('#include "types.h"');
+    });
+
+    it("maps class types to their include directives", () => {
+      const source = new MockSymbolSource();
+      source.addSymbols("/path/to/serial.hpp", [
+        createSymbol("Serial", ESymbolKind.Class, "/path/to/serial.hpp"),
+      ]);
+
+      const headerDirectives = new Map([
+        ["/path/to/serial.hpp", '#include "serial.hpp"'],
+      ]);
+
+      const result = ExternalTypeHeaderBuilder.build(headerDirectives, source);
+
+      expect(result.get("Serial")).toBe('#include "serial.hpp"');
+    });
+
+    it("ignores function symbols", () => {
+      const source = new MockSymbolSource();
+      source.addSymbols("/path/to/funcs.h", [
+        createSymbol("doSomething", ESymbolKind.Function, "/path/to/funcs.h"),
+      ]);
+
+      const headerDirectives = new Map([
+        ["/path/to/funcs.h", '#include "funcs.h"'],
+      ]);
+
+      const result = ExternalTypeHeaderBuilder.build(headerDirectives, source);
+
+      expect(result.has("doSomething")).toBe(false);
+    });
+
+    it("ignores variable symbols", () => {
+      const source = new MockSymbolSource();
+      source.addSymbols("/path/to/vars.h", [
+        createSymbol("globalVar", ESymbolKind.Variable, "/path/to/vars.h"),
+      ]);
+
+      const headerDirectives = new Map([
+        ["/path/to/vars.h", '#include "vars.h"'],
+      ]);
+
+      const result = ExternalTypeHeaderBuilder.build(headerDirectives, source);
+
+      expect(result.has("globalVar")).toBe(false);
+    });
+
+    it("first include wins for duplicate type names", () => {
+      const source = new MockSymbolSource();
+      source.addSymbols("/path/to/first.h", [
+        createSymbol("DuplicateType", ESymbolKind.Struct, "/path/to/first.h"),
+      ]);
+      source.addSymbols("/path/to/second.h", [
+        createSymbol("DuplicateType", ESymbolKind.Struct, "/path/to/second.h"),
+      ]);
+
+      const headerDirectives = new Map([
+        ["/path/to/first.h", '#include "first.h"'],
+        ["/path/to/second.h", '#include "second.h"'],
+      ]);
+
+      const result = ExternalTypeHeaderBuilder.build(headerDirectives, source);
+
+      expect(result.get("DuplicateType")).toBe('#include "first.h"');
+    });
+
+    it("handles multiple types from same header", () => {
+      const source = new MockSymbolSource();
+      source.addSymbols("/path/to/types.h", [
+        createSymbol("StructA", ESymbolKind.Struct, "/path/to/types.h"),
+        createSymbol("EnumB", ESymbolKind.Enum, "/path/to/types.h"),
+        createSymbol("TypeC", ESymbolKind.Type, "/path/to/types.h"),
+      ]);
+
+      const headerDirectives = new Map([
+        ["/path/to/types.h", '#include "types.h"'],
+      ]);
+
+      const result = ExternalTypeHeaderBuilder.build(headerDirectives, source);
+
+      expect(result.get("StructA")).toBe('#include "types.h"');
+      expect(result.get("EnumB")).toBe('#include "types.h"');
+      expect(result.get("TypeC")).toBe('#include "types.h"');
+    });
+
+    it("handles multiple headers", () => {
+      const source = new MockSymbolSource();
+      source.addSymbols("/path/to/a.h", [
+        createSymbol("TypeA", ESymbolKind.Struct, "/path/to/a.h"),
+      ]);
+      source.addSymbols("/path/to/b.h", [
+        createSymbol("TypeB", ESymbolKind.Enum, "/path/to/b.h"),
+      ]);
+
+      const headerDirectives = new Map([
+        ["/path/to/a.h", '#include "a.h"'],
+        ["/path/to/b.h", '#include "b.h"'],
+      ]);
+
+      const result = ExternalTypeHeaderBuilder.build(headerDirectives, source);
+
+      expect(result.get("TypeA")).toBe('#include "a.h"');
+      expect(result.get("TypeB")).toBe('#include "b.h"');
+    });
+
+    it("returns empty map when no headers", () => {
+      const source = new MockSymbolSource();
+      const headerDirectives = new Map<string, string>();
+
+      const result = ExternalTypeHeaderBuilder.build(headerDirectives, source);
+
+      expect(result.size).toBe(0);
+    });
+
+    it("returns empty map when headers have no type symbols", () => {
+      const source = new MockSymbolSource();
+      source.addSymbols("/path/to/funcs.h", [
+        createSymbol("func1", ESymbolKind.Function, "/path/to/funcs.h"),
+        createSymbol("func2", ESymbolKind.Function, "/path/to/funcs.h"),
+      ]);
+
+      const headerDirectives = new Map([
+        ["/path/to/funcs.h", '#include "funcs.h"'],
+      ]);
+
+      const result = ExternalTypeHeaderBuilder.build(headerDirectives, source);
+
+      expect(result.size).toBe(0);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Create `IncludeExtractor` in logic layer for collecting user includes from AST
- Create `ExternalTypeHeaderBuilder` in output/headers for building type-to-header mappings
- Remove private methods from Transpiler (~60 lines)
- Add comprehensive unit tests (18 tests)

Closes #589

## Changes
| File | Description |
|------|-------------|
| `src/transpiler/logic/IncludeExtractor.ts` | New: Extracts #include directives from parse trees |
| `src/transpiler/output/headers/ExternalTypeHeaderBuilder.ts` | New: Builds type name to header directive mappings |
| `src/transpiler/Transpiler.ts` | Updated to use new utilities, removed private methods |

## Test plan
- [x] All 885 C-Next integration tests pass
- [x] All 1757 unit tests pass (including 18 new tests)
- [x] Lint checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)