### PR TITLE
refactor(arch): extract file discovery from IncludeGenerator to data layer

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "c-next",
-  "version": "0.1.51",
+  "version": "0.1.52",
   "description": "A safer C for embedded systems development. Transpiles to clean, readable C.",
   "main": "src/index.ts",
   "bin": {

--- a/src/transpiler/data/CnxFileResolver.ts
+++ b/src/transpiler/data/CnxFileResolver.ts
@@ -1,0 +1,76 @@
+/**
+ * CnxFileResolver
+ * Static utilities for resolving C-Next file paths.
+ *
+ * Extracted from IncludeGenerator.ts as part of layer architecture cleanup.
+ * File discovery and path resolution belong in the data layer, not output layer.
+ */
+
+import { existsSync, statSync } from "node:fs";
+import { resolve, relative } from "node:path";
+
+/**
+ * Find a .cnx file in the given search paths.
+ * Returns the absolute path if found, null otherwise.
+ *
+ * Issue #349: Used by IncludeGenerator for angle-bracket include resolution.
+ */
+const findCnxFile = (
+  filename: string,
+  searchPaths: string[],
+): string | null => {
+  for (const searchPath of searchPaths) {
+    const cnxPath = resolve(searchPath, `${filename}.cnx`);
+    if (existsSync(cnxPath)) {
+      return cnxPath;
+    }
+  }
+  return null;
+};
+
+/**
+ * Calculate the relative path from input directories.
+ * Returns the relative path (e.g., "Display/utils.cnx") or null if not found.
+ *
+ * Issue #349: Used by IncludeGenerator for correct header path calculation.
+ *
+ * Note: PathResolver has an instance method version that uses config.inputs.
+ * This static version is for cases where inputs are passed as a parameter.
+ */
+const getRelativePathFromInputs = (
+  filePath: string,
+  inputs: string[],
+): string | null => {
+  for (const input of inputs) {
+    const resolvedInput = resolve(input);
+
+    // Skip if input is a file (not a directory)
+    if (existsSync(resolvedInput) && statSync(resolvedInput).isFile()) {
+      continue;
+    }
+
+    const relativePath = relative(resolvedInput, filePath);
+
+    // If relative path doesn't start with '..' it's under this input
+    if (!relativePath.startsWith("..") && !relativePath.startsWith("/")) {
+      return relativePath;
+    }
+  }
+  return null;
+};
+
+/**
+ * Check if a .cnx file exists at the given path.
+ * Used by IncludeGenerator for quote-style include validation.
+ */
+const cnxFileExists = (cnxPath: string): boolean => {
+  return existsSync(cnxPath);
+};
+
+class CnxFileResolver {
+  static findCnxFile = findCnxFile;
+  static getRelativePathFromInputs = getRelativePathFromInputs;
+  static cnxFileExists = cnxFileExists;
+}
+
+export default CnxFileResolver;


### PR DESCRIPTION
## Summary

- Extract file I/O operations from `IncludeGenerator.ts` (output layer) to new `CnxFileResolver.ts` (data layer)
- Improves adherence to 3-layer architecture: data → logic → output
- Output layer now has zero file system operations — pure code generation only

## Changes

**New file: `src/transpiler/data/CnxFileResolver.ts`**
- `findCnxFile(filename, searchPaths)` - search for .cnx files
- `getRelativePathFromInputs(filePath, inputs)` - calculate relative paths  
- `cnxFileExists(cnxPath)` - check file existence

**Updated: `src/transpiler/output/codegen/generators/support/IncludeGenerator.ts`**
- Removed `fs` import and file discovery functions (~40 lines)
- Now delegates to `CnxFileResolver` for all file operations

**Patch release: 0.1.51 → 0.1.52**

## Test plan

- [x] All 885 integration tests pass
- [x] All 1774 unit tests pass
- [x] Linting passes
- [x] Pre-push quality checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)