### PR TITLE
test(scripts): add unit tests for coverage tracking scripts

### DIFF
--- a/scripts/__tests__/coverage-parser.test.ts
+++ b/scripts/__tests__/coverage-parser.test.ts
@@ -1,0 +1,653 @@
+/**
+ * Unit tests for coverage-parser.ts
+ *
+ * Tests all parsing functions for coverage.md file format.
+ */
+
+import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import coverageParser from "../coverage-parser";
+
+describe("toKebabCase", () => {
+  it("should convert simple string to kebab-case", () => {
+    expect(coverageParser.toKebabCase("Hello World")).toBe("hello-world");
+  });
+
+  it("should handle multiple spaces", () => {
+    expect(coverageParser.toKebabCase("Hello   World")).toBe("hello-world");
+  });
+
+  it("should remove special characters", () => {
+    expect(coverageParser.toKebabCase("Hello! World?")).toBe("hello-world");
+  });
+
+  it("should handle numbers", () => {
+    expect(coverageParser.toKebabCase("u8 Variable 123")).toBe(
+      "u8-variable-123",
+    );
+  });
+
+  it("should trim leading and trailing hyphens", () => {
+    expect(coverageParser.toKebabCase("  Hello World  ")).toBe("hello-world");
+  });
+
+  it("should remove error marker", () => {
+    expect(coverageParser.toKebabCase("Some **(error)** test")).toBe(
+      "some-test",
+    );
+  });
+
+  it("should handle case-insensitive error marker", () => {
+    expect(coverageParser.toKebabCase("Test **(ERROR)** case")).toBe(
+      "test-case",
+    );
+  });
+
+  it("should collapse multiple hyphens", () => {
+    expect(coverageParser.toKebabCase("Hello---World")).toBe("hello-world");
+  });
+
+  it("should handle empty string", () => {
+    expect(coverageParser.toKebabCase("")).toBe("");
+  });
+
+  it("should handle string with only special characters", () => {
+    expect(coverageParser.toKebabCase("!!!")).toBe("");
+  });
+});
+
+describe("extractSectionNumber", () => {
+  it("should extract section number from heading", () => {
+    expect(coverageParser.extractSectionNumber("## 1. Primitive Types")).toBe(
+      "1",
+    );
+  });
+
+  it("should extract multi-digit section number", () => {
+    expect(
+      coverageParser.extractSectionNumber("## 12. Advanced Features"),
+    ).toBe("12");
+  });
+
+  it("should return empty string for non-numbered heading", () => {
+    expect(coverageParser.extractSectionNumber("## Table of Contents")).toBe(
+      "",
+    );
+  });
+
+  it("should return empty string for subsection heading", () => {
+    expect(
+      coverageParser.extractSectionNumber("### 1.1 Unsigned Integers"),
+    ).toBe("");
+  });
+
+  it("should return empty string for invalid format", () => {
+    expect(coverageParser.extractSectionNumber("Not a heading")).toBe("");
+  });
+});
+
+describe("extractSubsectionNumber", () => {
+  it("should extract subsection number from heading", () => {
+    expect(
+      coverageParser.extractSubsectionNumber("### 1.1 Unsigned Integers"),
+    ).toBe("1");
+  });
+
+  it("should extract multi-digit subsection number", () => {
+    expect(
+      coverageParser.extractSubsectionNumber("### 5.12 Complex Types"),
+    ).toBe("12");
+  });
+
+  it("should return empty string for section heading", () => {
+    expect(
+      coverageParser.extractSubsectionNumber("## 1. Primitive Types"),
+    ).toBe("");
+  });
+
+  it("should return empty string for type header", () => {
+    expect(coverageParser.extractSubsectionNumber("#### u8")).toBe("");
+  });
+
+  it("should return empty string for plain text", () => {
+    expect(coverageParser.extractSubsectionNumber("Some text")).toBe("");
+  });
+});
+
+describe("extractSectionTitle", () => {
+  it("should extract full section title", () => {
+    expect(coverageParser.extractSectionTitle("## 1. Primitive Types")).toBe(
+      "1. Primitive Types",
+    );
+  });
+
+  it("should trim whitespace", () => {
+    expect(coverageParser.extractSectionTitle("##   1. Types   ")).toBe(
+      "1. Types",
+    );
+  });
+
+  it("should handle non-numbered sections", () => {
+    expect(coverageParser.extractSectionTitle("## Table of Contents")).toBe(
+      "Table of Contents",
+    );
+  });
+
+  it("should match subsection heading (regex only checks ##)", () => {
+    // Note: The regex /^##\s*(.+)$/ also matches ### headings since ## is a prefix
+    // The parser logic handles level distinction, not this function
+    expect(coverageParser.extractSectionTitle("### 1.1 Subsection")).toBe(
+      "# 1.1 Subsection",
+    );
+  });
+
+  it("should return empty for plain text", () => {
+    expect(coverageParser.extractSectionTitle("Not a heading")).toBe("");
+  });
+});
+
+describe("extractSubsectionTitle", () => {
+  it("should extract full subsection title", () => {
+    expect(
+      coverageParser.extractSubsectionTitle("### 1.1 Unsigned Integers"),
+    ).toBe("1.1 Unsigned Integers");
+  });
+
+  it("should trim whitespace", () => {
+    expect(coverageParser.extractSubsectionTitle("###   1.2 Types   ")).toBe(
+      "1.2 Types",
+    );
+  });
+
+  it("should return empty for section headings", () => {
+    expect(coverageParser.extractSubsectionTitle("## 1. Section")).toBe("");
+  });
+
+  it("should match type header (regex only checks ###)", () => {
+    // Note: The regex /^###\s*(.+)$/ also matches #### headings since ### is a prefix
+    // The parser logic handles level distinction, not this function
+    expect(coverageParser.extractSubsectionTitle("#### u8")).toBe("# u8");
+  });
+});
+
+describe("extractTypeHeader", () => {
+  it("should extract type from header", () => {
+    expect(coverageParser.extractTypeHeader("#### u8")).toBe("u8");
+  });
+
+  it("should extract multi-character type", () => {
+    expect(coverageParser.extractTypeHeader("#### string")).toBe("string");
+  });
+
+  it("should only extract first word", () => {
+    expect(coverageParser.extractTypeHeader("#### u8 (unsigned)")).toBe("u8");
+  });
+
+  it("should trim whitespace", () => {
+    expect(coverageParser.extractTypeHeader("####   i32   ")).toBe("i32");
+  });
+
+  it("should return empty for non-type headers", () => {
+    expect(coverageParser.extractTypeHeader("### 1.1 Subsection")).toBe("");
+  });
+
+  it("should return empty for section headers", () => {
+    expect(coverageParser.extractTypeHeader("## 1. Section")).toBe("");
+  });
+});
+
+describe("parseTableRow", () => {
+  const baseParams = {
+    sectionNum: "1",
+    section: "1. Primitive Types",
+    subsectionNum: "1",
+    subsection: "1.1 Unsigned Integers",
+    lineNumber: 10,
+  };
+
+  it("should parse tested row with test file", () => {
+    const line = "| Global variable declaration | [x] | `u8.test.cnx` |";
+    const result = coverageParser.parseTableRow(
+      line,
+      baseParams.sectionNum,
+      baseParams.section,
+      baseParams.subsectionNum,
+      baseParams.subsection,
+      "u8",
+      baseParams.lineNumber,
+    );
+
+    expect(result).not.toBeNull();
+    expect(result!.tested).toBe(true);
+    expect(result!.context).toBe("Global variable declaration");
+    expect(result!.testFile).toBe("u8.test.cnx");
+    expect(result!.typeHeader).toBe("u8");
+    expect(result!.lineNumber).toBe(10);
+    expect(result!.isErrorTest).toBe(false);
+  });
+
+  it("should parse untested row", () => {
+    const line = "| Local variable | [ ] | |";
+    const result = coverageParser.parseTableRow(
+      line,
+      baseParams.sectionNum,
+      baseParams.section,
+      baseParams.subsectionNum,
+      baseParams.subsection,
+      "u16",
+      baseParams.lineNumber,
+    );
+
+    expect(result).not.toBeNull();
+    expect(result!.tested).toBe(false);
+    expect(result!.context).toBe("Local variable");
+    expect(result!.testFile).toBeUndefined();
+  });
+
+  it("should parse row without type header", () => {
+    const line = "| Function call | [x] | `test.cnx` |";
+    const result = coverageParser.parseTableRow(
+      line,
+      baseParams.sectionNum,
+      baseParams.section,
+      baseParams.subsectionNum,
+      baseParams.subsection,
+      undefined,
+      baseParams.lineNumber,
+    );
+
+    expect(result).not.toBeNull();
+    expect(result!.typeHeader).toBeUndefined();
+    expect(result!.id).toBe("1.1-function-call");
+  });
+
+  it("should detect error test marker", () => {
+    const line = "| **(ERROR)** Invalid syntax | [x] | `error.test.cnx` |";
+    const result = coverageParser.parseTableRow(
+      line,
+      baseParams.sectionNum,
+      baseParams.section,
+      baseParams.subsectionNum,
+      baseParams.subsection,
+      undefined,
+      baseParams.lineNumber,
+    );
+
+    expect(result).not.toBeNull();
+    expect(result!.isErrorTest).toBe(true);
+    expect(result!.context).toBe("Invalid syntax");
+  });
+
+  it("should skip header row with Status", () => {
+    const line = "| Context | Status | Test File |";
+    const result = coverageParser.parseTableRow(
+      line,
+      baseParams.sectionNum,
+      baseParams.section,
+      baseParams.subsectionNum,
+      baseParams.subsection,
+      undefined,
+      baseParams.lineNumber,
+    );
+
+    expect(result).toBeNull();
+  });
+
+  it("should skip separator row with dashes", () => {
+    const line = "|---------|--------|-----------|";
+    const result = coverageParser.parseTableRow(
+      line,
+      baseParams.sectionNum,
+      baseParams.section,
+      baseParams.subsectionNum,
+      baseParams.subsection,
+      undefined,
+      baseParams.lineNumber,
+    );
+
+    expect(result).toBeNull();
+  });
+
+  it("should return null for row without checkbox", () => {
+    const line = "| Some content | maybe | test |";
+    const result = coverageParser.parseTableRow(
+      line,
+      baseParams.sectionNum,
+      baseParams.section,
+      baseParams.subsectionNum,
+      baseParams.subsection,
+      undefined,
+      baseParams.lineNumber,
+    );
+
+    expect(result).toBeNull();
+  });
+
+  it("should return null for row with too few columns", () => {
+    const line = "| Single column |";
+    const result = coverageParser.parseTableRow(
+      line,
+      baseParams.sectionNum,
+      baseParams.section,
+      baseParams.subsectionNum,
+      baseParams.subsection,
+      undefined,
+      baseParams.lineNumber,
+    );
+
+    expect(result).toBeNull();
+  });
+});
+
+describe("generateCoverageId", () => {
+  it("should generate ID with type header", () => {
+    const id = coverageParser.generateCoverageId(
+      "1",
+      "1",
+      "u8",
+      "Global variable declaration",
+    );
+    expect(id).toBe("1.1-u8-global-variable-declaration");
+  });
+
+  it("should generate ID without type header", () => {
+    const id = coverageParser.generateCoverageId(
+      "2",
+      "3",
+      undefined,
+      "Function call",
+    );
+    expect(id).toBe("2.3-function-call");
+  });
+
+  it("should handle special characters in context", () => {
+    const id = coverageParser.generateCoverageId(
+      "1",
+      "1",
+      "i32",
+      "Array[index] access!",
+    );
+    expect(id).toBe("1.1-i32-array-index-access");
+  });
+
+  it("should lowercase type header", () => {
+    const id = coverageParser.generateCoverageId(
+      "1",
+      "1",
+      "U32",
+      "Test context",
+    );
+    expect(id).toBe("1.1-u32-test-context");
+  });
+});
+
+describe("shouldSkipSection", () => {
+  it("should skip Table of Contents", () => {
+    expect(coverageParser.shouldSkipSection("Table of Contents")).toBe(true);
+  });
+
+  it("should skip How to Use This Document", () => {
+    expect(coverageParser.shouldSkipSection("How to Use This Document")).toBe(
+      true,
+    );
+  });
+
+  it("should skip Recent Updates", () => {
+    expect(coverageParser.shouldSkipSection("Recent Updates")).toBe(true);
+  });
+
+  it("should skip Statistics", () => {
+    expect(coverageParser.shouldSkipSection("Statistics")).toBe(true);
+  });
+
+  it("should skip Priority Summary", () => {
+    expect(coverageParser.shouldSkipSection("Priority Summary")).toBe(true);
+  });
+
+  it("should skip Coverage by Test File", () => {
+    expect(coverageParser.shouldSkipSection("Coverage by Test File")).toBe(
+      true,
+    );
+  });
+
+  it("should be case insensitive", () => {
+    expect(coverageParser.shouldSkipSection("TABLE OF CONTENTS")).toBe(true);
+  });
+
+  it("should not skip numbered sections", () => {
+    expect(coverageParser.shouldSkipSection("1. Primitive Types")).toBe(false);
+  });
+
+  it("should not skip regular content sections", () => {
+    expect(coverageParser.shouldSkipSection("Control Flow")).toBe(false);
+  });
+});
+
+describe("checkForDuplicates", () => {
+  it("should return empty map when no duplicates", () => {
+    const items = [
+      { id: "1.1-u8-test", lineNumber: 10 },
+      { id: "1.1-u16-test", lineNumber: 20 },
+      { id: "1.2-i32-test", lineNumber: 30 },
+    ] as Parameters<typeof coverageParser.checkForDuplicates>[0];
+
+    const duplicates = coverageParser.checkForDuplicates(items);
+    expect(duplicates.size).toBe(0);
+  });
+
+  it("should detect duplicate IDs", () => {
+    const items = [
+      { id: "1.1-u8-test", lineNumber: 10 },
+      { id: "1.1-u8-test", lineNumber: 25 },
+      { id: "1.2-i32-test", lineNumber: 30 },
+    ] as Parameters<typeof coverageParser.checkForDuplicates>[0];
+
+    const duplicates = coverageParser.checkForDuplicates(items);
+    expect(duplicates.size).toBe(1);
+    expect(duplicates.get("1.1-u8-test")).toEqual([10, 25]);
+  });
+
+  it("should detect multiple occurrences of same ID", () => {
+    const items = [
+      { id: "1.1-u8-test", lineNumber: 10 },
+      { id: "1.1-u8-test", lineNumber: 20 },
+      { id: "1.1-u8-test", lineNumber: 30 },
+    ] as Parameters<typeof coverageParser.checkForDuplicates>[0];
+
+    const duplicates = coverageParser.checkForDuplicates(items);
+    expect(duplicates.size).toBe(1);
+    expect(duplicates.get("1.1-u8-test")).toEqual([10, 20, 30]);
+  });
+
+  it("should handle empty array", () => {
+    const duplicates = coverageParser.checkForDuplicates([]);
+    expect(duplicates.size).toBe(0);
+  });
+});
+
+describe("parseCoverageDocument", () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), "coverage-parser-test-"));
+  });
+
+  afterEach(() => {
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it("should parse a minimal coverage document", () => {
+    const content = `# Coverage Document
+
+## 1. Primitive Types
+
+### 1.1 Unsigned Integers
+
+#### u8
+
+| Context | Status | Test File |
+|---------|--------|-----------|
+| Global variable declaration | [x] | \`u8.test.cnx\` |
+| Local variable | [ ] | |
+`;
+    const filePath = join(tempDir, "coverage.md");
+    writeFileSync(filePath, content);
+
+    const items = coverageParser.parseCoverageDocument(filePath);
+
+    expect(items).toHaveLength(2);
+    expect(items[0].id).toBe("1.1-u8-global-variable-declaration");
+    expect(items[0].tested).toBe(true);
+    expect(items[0].testFile).toBe("u8.test.cnx");
+    expect(items[1].id).toBe("1.1-u8-local-variable");
+    expect(items[1].tested).toBe(false);
+  });
+
+  it("should skip non-numbered sections", () => {
+    const content = `# Coverage
+
+## Table of Contents
+
+| Context | Status | Test |
+|---------|--------|------|
+| Should be skipped | [x] | |
+
+## 1. Real Section
+
+### 1.1 Subsection
+
+| Context | Status | Test |
+|---------|--------|------|
+| Should be included | [x] | |
+`;
+    const filePath = join(tempDir, "coverage.md");
+    writeFileSync(filePath, content);
+
+    const items = coverageParser.parseCoverageDocument(filePath);
+
+    expect(items).toHaveLength(1);
+    expect(items[0].context).toBe("Should be included");
+  });
+
+  it("should handle multiple sections and subsections", () => {
+    const content = `# Coverage
+
+## 1. Section One
+
+### 1.1 Sub One
+
+| Context | Status | Test |
+|---------|--------|------|
+| Item 1.1 | [x] | |
+
+### 1.2 Sub Two
+
+| Context | Status | Test |
+|---------|--------|------|
+| Item 1.2 | [ ] | |
+
+## 2. Section Two
+
+### 2.1 Sub One
+
+| Context | Status | Test |
+|---------|--------|------|
+| Item 2.1 | [x] | |
+`;
+    const filePath = join(tempDir, "coverage.md");
+    writeFileSync(filePath, content);
+
+    const items = coverageParser.parseCoverageDocument(filePath);
+
+    expect(items).toHaveLength(3);
+    expect(items[0].section).toBe("1. Section One");
+    expect(items[0].subsection).toBe("1.1 Sub One");
+    expect(items[1].section).toBe("1. Section One");
+    expect(items[1].subsection).toBe("1.2 Sub Two");
+    expect(items[2].section).toBe("2. Section Two");
+  });
+
+  it("should handle items without type header", () => {
+    const content = `# Coverage
+
+## 1. Control Flow
+
+### 1.1 Conditionals
+
+| Context | Status | Test |
+|---------|--------|------|
+| If statement | [x] | |
+`;
+    const filePath = join(tempDir, "coverage.md");
+    writeFileSync(filePath, content);
+
+    const items = coverageParser.parseCoverageDocument(filePath);
+
+    expect(items).toHaveLength(1);
+    expect(items[0].typeHeader).toBeUndefined();
+    expect(items[0].id).toBe("1.1-if-statement");
+  });
+
+  it("should detect error tests", () => {
+    const content = `# Coverage
+
+## 1. Errors
+
+### 1.1 Syntax Errors
+
+| Context | Status | Test |
+|---------|--------|------|
+| **(ERROR)** Invalid token | [x] | \`error.test.cnx\` |
+`;
+    const filePath = join(tempDir, "coverage.md");
+    writeFileSync(filePath, content);
+
+    const items = coverageParser.parseCoverageDocument(filePath);
+
+    expect(items).toHaveLength(1);
+    expect(items[0].isErrorTest).toBe(true);
+    expect(items[0].context).toBe("Invalid token");
+  });
+
+  it("should track correct line numbers", () => {
+    const content = `# Coverage
+
+## 1. Types
+
+### 1.1 Integers
+
+| Context | Status | Test |
+|---------|--------|------|
+| First item | [x] | |
+| Second item | [ ] | |
+`;
+    const filePath = join(tempDir, "coverage.md");
+    writeFileSync(filePath, content);
+
+    const items = coverageParser.parseCoverageDocument(filePath);
+
+    expect(items).toHaveLength(2);
+    expect(items[0].lineNumber).toBe(9);
+    expect(items[1].lineNumber).toBe(10);
+  });
+
+  it("should return empty array for document with no items", () => {
+    const content = `# Coverage
+
+## Table of Contents
+
+Nothing here
+
+## Statistics
+
+Also nothing
+`;
+    const filePath = join(tempDir, "coverage.md");
+    writeFileSync(filePath, content);
+
+    const items = coverageParser.parseCoverageDocument(filePath);
+
+    expect(items).toHaveLength(0);
+  });
+});

--- a/scripts/__tests__/report-generator.test.ts
+++ b/scripts/__tests__/report-generator.test.ts
@@ -1,0 +1,368 @@
+/**
+ * Unit tests for report-generator.ts
+ *
+ * Tests report building and formatting logic.
+ */
+
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import reportGenerator from "../report-generator";
+import ICoverageItem from "../types/ICoverageItem";
+import ITestAnnotation from "../types/ITestAnnotation";
+
+describe("getPercentageColor", () => {
+  it("should return green for percentage >= 80", () => {
+    expect(reportGenerator.getPercentageColor(80)).toBe(
+      reportGenerator.colors.green,
+    );
+    expect(reportGenerator.getPercentageColor(100)).toBe(
+      reportGenerator.colors.green,
+    );
+    expect(reportGenerator.getPercentageColor(95)).toBe(
+      reportGenerator.colors.green,
+    );
+  });
+
+  it("should return yellow for percentage >= 50 and < 80", () => {
+    expect(reportGenerator.getPercentageColor(50)).toBe(
+      reportGenerator.colors.yellow,
+    );
+    expect(reportGenerator.getPercentageColor(79)).toBe(
+      reportGenerator.colors.yellow,
+    );
+    expect(reportGenerator.getPercentageColor(65)).toBe(
+      reportGenerator.colors.yellow,
+    );
+  });
+
+  it("should return red for percentage < 50", () => {
+    expect(reportGenerator.getPercentageColor(49)).toBe(
+      reportGenerator.colors.red,
+    );
+    expect(reportGenerator.getPercentageColor(0)).toBe(
+      reportGenerator.colors.red,
+    );
+    expect(reportGenerator.getPercentageColor(25)).toBe(
+      reportGenerator.colors.red,
+    );
+  });
+});
+
+describe("buildReport", () => {
+  const createItem = (
+    id: string,
+    section: string,
+    tested: boolean,
+  ): ICoverageItem => ({
+    id,
+    section,
+    subsection: "1.1 Subsection",
+    context: "Test context",
+    tested,
+    lineNumber: 10,
+    isErrorTest: false,
+  });
+
+  const createAnnotation = (
+    coverageId: string,
+    testFile: string,
+  ): ITestAnnotation => ({
+    coverageId,
+    testFile: `/tests/${testFile}`,
+    relativePath: testFile,
+    lineNumber: 5,
+  });
+
+  it("should build report with correct summary totals", () => {
+    const items: ICoverageItem[] = [
+      createItem("1.1-test1", "1. Section", true),
+      createItem("1.1-test2", "1. Section", true),
+      createItem("1.1-test3", "1. Section", false),
+    ];
+    const annotations: ITestAnnotation[] = [];
+
+    const report = reportGenerator.buildReport(items, annotations);
+
+    expect(report.summary.totalItems).toBe(3);
+    expect(report.summary.testedItems).toBe(2);
+    expect(report.summary.untestedItems).toBe(1);
+    expect(report.summary.coveragePercentage).toBe(67);
+  });
+
+  it("should identify untested items as gaps", () => {
+    const items: ICoverageItem[] = [
+      createItem("1.1-tested", "1. Section", true),
+      createItem("1.1-untested1", "1. Section", false),
+      createItem("1.1-untested2", "1. Section", false),
+    ];
+
+    const report = reportGenerator.buildReport(items, []);
+
+    expect(report.gaps).toHaveLength(2);
+    expect(report.gaps[0].id).toBe("1.1-untested1");
+    expect(report.gaps[1].id).toBe("1.1-untested2");
+  });
+
+  it("should count annotated items", () => {
+    const items: ICoverageItem[] = [
+      createItem("1.1-item1", "1. Section", true),
+      createItem("1.1-item2", "1. Section", true),
+      createItem("1.1-item3", "1. Section", false),
+    ];
+    const annotations: ITestAnnotation[] = [
+      createAnnotation("1.1-item1", "test1.cnx"),
+      createAnnotation("1.1-item2", "test2.cnx"),
+    ];
+
+    const report = reportGenerator.buildReport(items, annotations);
+
+    expect(report.summary.annotatedItems).toBe(2);
+  });
+
+  it("should detect unknown coverage IDs in annotations", () => {
+    const items: ICoverageItem[] = [
+      createItem("1.1-known", "1. Section", true),
+    ];
+    const annotations: ITestAnnotation[] = [
+      createAnnotation("1.1-unknown", "test.cnx"),
+    ];
+
+    const report = reportGenerator.buildReport(items, annotations);
+
+    expect(report.mismatches).toHaveLength(1);
+    expect(report.mismatches[0].type).toBe("unknown_id");
+    expect(report.mismatches[0].issue).toContain("Unknown coverage ID");
+  });
+
+  it("should detect status mismatch (annotation exists but not marked tested)", () => {
+    const items: ICoverageItem[] = [
+      createItem("1.1-item", "1. Section", false), // Not marked as tested
+    ];
+    const annotations: ITestAnnotation[] = [
+      createAnnotation("1.1-item", "test.cnx"), // But has annotation
+    ];
+
+    const report = reportGenerator.buildReport(items, annotations);
+
+    expect(report.mismatches).toHaveLength(1);
+    expect(report.mismatches[0].type).toBe("status_mismatch");
+    expect(report.mismatches[0].issue).toContain(
+      "has annotation but is marked [ ]",
+    );
+  });
+
+  it("should build section summaries", () => {
+    const items: ICoverageItem[] = [
+      createItem("1.1-a", "1. First Section", true),
+      createItem("1.1-b", "1. First Section", false),
+      createItem("2.1-a", "2. Second Section", true),
+      createItem("2.1-b", "2. Second Section", true),
+    ];
+
+    const report = reportGenerator.buildReport(items, []);
+
+    expect(report.summary.sections).toHaveLength(2);
+
+    const section1 = report.summary.sections.find((s) =>
+      s.name.includes("First"),
+    );
+    expect(section1).toBeDefined();
+    expect(section1!.total).toBe(2);
+    expect(section1!.tested).toBe(1);
+    expect(section1!.percentage).toBe(50);
+
+    const section2 = report.summary.sections.find((s) =>
+      s.name.includes("Second"),
+    );
+    expect(section2).toBeDefined();
+    expect(section2!.total).toBe(2);
+    expect(section2!.tested).toBe(2);
+    expect(section2!.percentage).toBe(100);
+  });
+
+  it("should sort sections by section number", () => {
+    const items: ICoverageItem[] = [
+      createItem("10.1-a", "10. Tenth Section", true),
+      createItem("2.1-a", "2. Second Section", true),
+      createItem("1.1-a", "1. First Section", true),
+    ];
+
+    const report = reportGenerator.buildReport(items, []);
+
+    expect(report.summary.sections[0].name).toBe("1. First Section");
+    expect(report.summary.sections[1].name).toBe("2. Second Section");
+    expect(report.summary.sections[2].name).toBe("10. Tenth Section");
+  });
+
+  it("should include generated timestamp", () => {
+    const report = reportGenerator.buildReport([], []);
+
+    expect(report.generated).toBeInstanceOf(Date);
+  });
+
+  it("should handle empty items and annotations", () => {
+    const report = reportGenerator.buildReport([], []);
+
+    expect(report.summary.totalItems).toBe(0);
+    expect(report.summary.testedItems).toBe(0);
+    expect(report.summary.untestedItems).toBe(0);
+    expect(report.summary.annotatedItems).toBe(0);
+    expect(report.gaps).toHaveLength(0);
+    expect(report.mismatches).toHaveLength(0);
+  });
+
+  it("should handle multiple annotations for same coverage ID", () => {
+    const items: ICoverageItem[] = [
+      createItem("1.1-item", "1. Section", false),
+    ];
+    const annotations: ITestAnnotation[] = [
+      createAnnotation("1.1-item", "test1.cnx"),
+      createAnnotation("1.1-item", "test2.cnx"),
+    ];
+
+    const report = reportGenerator.buildReport(items, annotations);
+
+    // Should only count one mismatch even with multiple annotations
+    expect(report.mismatches).toHaveLength(1);
+    // Annotated count should be 1 (one unique item is annotated)
+    expect(report.summary.annotatedItems).toBe(1);
+  });
+
+  it("should track annotated count per section", () => {
+    const items: ICoverageItem[] = [
+      createItem("1.1-a", "1. Section", true),
+      createItem("1.1-b", "1. Section", true),
+    ];
+    const annotations: ITestAnnotation[] = [
+      createAnnotation("1.1-a", "test.cnx"),
+    ];
+
+    const report = reportGenerator.buildReport(items, annotations);
+
+    expect(report.summary.sections[0].annotated).toBe(1);
+  });
+});
+
+describe("generateMarkdownReport", () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), "report-gen-test-"));
+  });
+
+  afterEach(() => {
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it("should generate markdown file with summary table", () => {
+    const items: ICoverageItem[] = [
+      {
+        id: "1.1-test",
+        section: "1. Section",
+        subsection: "1.1 Sub",
+        context: "Test",
+        tested: true,
+        lineNumber: 10,
+        isErrorTest: false,
+      },
+    ];
+    const report = reportGenerator.buildReport(items, []);
+    const outputPath = join(tempDir, "report.md");
+
+    reportGenerator.generateMarkdownReport(report, outputPath);
+
+    const content = readFileSync(outputPath, "utf-8");
+    expect(content).toContain("# C-Next Coverage Report");
+    expect(content).toContain("## Summary");
+    expect(content).toContain("| Total Points | 1 | 100% |");
+    expect(content).toContain("| Tested | 1 | 100% |");
+  });
+
+  it("should include section breakdown in markdown", () => {
+    const items: ICoverageItem[] = [
+      {
+        id: "1.1-test",
+        section: "1. Types",
+        subsection: "1.1 Sub",
+        context: "Test",
+        tested: true,
+        lineNumber: 10,
+        isErrorTest: false,
+      },
+    ];
+    const report = reportGenerator.buildReport(items, []);
+    const outputPath = join(tempDir, "report.md");
+
+    reportGenerator.generateMarkdownReport(report, outputPath);
+
+    const content = readFileSync(outputPath, "utf-8");
+    expect(content).toContain("## Section Breakdown");
+    expect(content).toContain("| 1. Types | 1 | 1 | 100% |");
+  });
+
+  it("should include mismatches section when present", () => {
+    const items: ICoverageItem[] = [];
+    const annotations: ITestAnnotation[] = [
+      {
+        coverageId: "unknown-id",
+        testFile: "/test.cnx",
+        relativePath: "test.cnx",
+        lineNumber: 5,
+      },
+    ];
+    const report = reportGenerator.buildReport(items, annotations);
+    const outputPath = join(tempDir, "report.md");
+
+    reportGenerator.generateMarkdownReport(report, outputPath);
+
+    const content = readFileSync(outputPath, "utf-8");
+    expect(content).toContain("## Mismatches");
+    expect(content).toContain("unknown_id");
+  });
+
+  it("should not include mismatches section when none exist", () => {
+    const items: ICoverageItem[] = [];
+    const report = reportGenerator.buildReport(items, []);
+    const outputPath = join(tempDir, "report.md");
+
+    reportGenerator.generateMarkdownReport(report, outputPath);
+
+    const content = readFileSync(outputPath, "utf-8");
+    expect(content).not.toContain("## Mismatches");
+  });
+
+  it("should include gaps by section", () => {
+    const items: ICoverageItem[] = [
+      {
+        id: "1.1-gap",
+        section: "1. Section",
+        subsection: "1.1 Sub",
+        context: "Gap item",
+        tested: false,
+        lineNumber: 10,
+        isErrorTest: false,
+      },
+    ];
+    const report = reportGenerator.buildReport(items, []);
+    const outputPath = join(tempDir, "report.md");
+
+    reportGenerator.generateMarkdownReport(report, outputPath);
+
+    const content = readFileSync(outputPath, "utf-8");
+    expect(content).toContain("## Gaps by Section");
+    expect(content).toContain("### 1. Section");
+    expect(content).toContain("- [ ] `1.1-gap`");
+  });
+
+  it("should include generation date", () => {
+    const report = reportGenerator.buildReport([], []);
+    const outputPath = join(tempDir, "report.md");
+
+    reportGenerator.generateMarkdownReport(report, outputPath);
+
+    const content = readFileSync(outputPath, "utf-8");
+    // Should have date in YYYY-MM-DD format
+    expect(content).toMatch(/Generated: \d{4}-\d{2}-\d{2}/);
+  });
+});

--- a/scripts/__tests__/test-scanner.test.ts
+++ b/scripts/__tests__/test-scanner.test.ts
@@ -1,0 +1,330 @@
+/**
+ * Unit tests for test-scanner.ts
+ *
+ * Tests coverage annotation extraction from test files.
+ */
+
+import { mkdtempSync, writeFileSync, mkdirSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import testScanner from "../test-scanner";
+
+describe("extractAnnotations", () => {
+  it("should extract single annotation from content", () => {
+    const content = `// Test file
+/* test-coverage: 1.1-u8-global-variable */
+void test() {}
+`;
+    const annotations = testScanner.extractAnnotations(
+      content,
+      "/tests/test.test.cnx",
+      "/tests",
+    );
+
+    expect(annotations).toHaveLength(1);
+    expect(annotations[0].coverageId).toBe("1.1-u8-global-variable");
+    expect(annotations[0].testFile).toBe("/tests/test.test.cnx");
+    expect(annotations[0].relativePath).toBe("test.test.cnx");
+    expect(annotations[0].lineNumber).toBe(2);
+  });
+
+  it("should extract multiple annotations from same line", () => {
+    const content = `/* test-coverage: 1.1-a, 1.1-b, 1.1-c */
+void test() {}
+`;
+    const annotations = testScanner.extractAnnotations(
+      content,
+      "/tests/test.cnx",
+      "/tests",
+    );
+
+    expect(annotations).toHaveLength(3);
+    expect(annotations[0].coverageId).toBe("1.1-a");
+    expect(annotations[1].coverageId).toBe("1.1-b");
+    expect(annotations[2].coverageId).toBe("1.1-c");
+  });
+
+  it("should extract annotations from multiple lines", () => {
+    const content = `/* test-coverage: 1.1-first */
+void test1() {}
+
+/* test-coverage: 2.1-second */
+void test2() {}
+`;
+    const annotations = testScanner.extractAnnotations(
+      content,
+      "/tests/test.cnx",
+      "/tests",
+    );
+
+    expect(annotations).toHaveLength(2);
+    expect(annotations[0].coverageId).toBe("1.1-first");
+    expect(annotations[0].lineNumber).toBe(1);
+    expect(annotations[1].coverageId).toBe("2.1-second");
+    expect(annotations[1].lineNumber).toBe(4);
+  });
+
+  it("should handle whitespace in annotation", () => {
+    const content = `/*   test-coverage:   1.1-test   */`;
+    const annotations = testScanner.extractAnnotations(
+      content,
+      "/tests/test.cnx",
+      "/tests",
+    );
+
+    expect(annotations).toHaveLength(1);
+    expect(annotations[0].coverageId).toBe("1.1-test");
+  });
+
+  it("should handle whitespace in comma-separated list", () => {
+    const content = `/* test-coverage: 1.1-a ,  1.1-b  , 1.1-c */`;
+    const annotations = testScanner.extractAnnotations(
+      content,
+      "/tests/test.cnx",
+      "/tests",
+    );
+
+    expect(annotations).toHaveLength(3);
+    expect(annotations[0].coverageId).toBe("1.1-a");
+    expect(annotations[1].coverageId).toBe("1.1-b");
+    expect(annotations[2].coverageId).toBe("1.1-c");
+  });
+
+  it("should return empty array for content without annotations", () => {
+    const content = `// Just a regular test file
+void test() {}
+`;
+    const annotations = testScanner.extractAnnotations(
+      content,
+      "/tests/test.cnx",
+      "/tests",
+    );
+
+    expect(annotations).toHaveLength(0);
+  });
+
+  it("should not extract from line comments", () => {
+    const content = `// test-coverage: 1.1-should-not-match
+void test() {}
+`;
+    const annotations = testScanner.extractAnnotations(
+      content,
+      "/tests/test.cnx",
+      "/tests",
+    );
+
+    expect(annotations).toHaveLength(0);
+  });
+
+  it("should handle complex coverage IDs", () => {
+    const content = `/* test-coverage: 1.1-u8-global-variable-declaration */
+/* test-coverage: 2.3-i32-array-index-access */
+`;
+    const annotations = testScanner.extractAnnotations(
+      content,
+      "/tests/test.cnx",
+      "/tests",
+    );
+
+    expect(annotations).toHaveLength(2);
+    expect(annotations[0].coverageId).toBe(
+      "1.1-u8-global-variable-declaration",
+    );
+    expect(annotations[1].coverageId).toBe("2.3-i32-array-index-access");
+  });
+
+  it("should handle relative path calculation", () => {
+    const content = `/* test-coverage: 1.1-test */`;
+    const annotations = testScanner.extractAnnotations(
+      content,
+      "/workspace/tests/subdir/test.test.cnx",
+      "/workspace/tests",
+    );
+
+    expect(annotations[0].relativePath).toBe("subdir/test.test.cnx");
+  });
+
+  it("should skip empty IDs in comma-separated list", () => {
+    const content = `/* test-coverage: 1.1-a, , 1.1-b */`;
+    const annotations = testScanner.extractAnnotations(
+      content,
+      "/tests/test.cnx",
+      "/tests",
+    );
+
+    expect(annotations).toHaveLength(2);
+    expect(annotations[0].coverageId).toBe("1.1-a");
+    expect(annotations[1].coverageId).toBe("1.1-b");
+  });
+
+  it("should handle multiple annotations on same line", () => {
+    const content = `/* test-coverage: 1.1-a */ void foo(); /* test-coverage: 1.1-b */`;
+    const annotations = testScanner.extractAnnotations(
+      content,
+      "/tests/test.cnx",
+      "/tests",
+    );
+
+    expect(annotations).toHaveLength(2);
+    expect(annotations[0].coverageId).toBe("1.1-a");
+    expect(annotations[1].coverageId).toBe("1.1-b");
+    // Both should report same line number
+    expect(annotations[0].lineNumber).toBe(1);
+    expect(annotations[1].lineNumber).toBe(1);
+  });
+
+  it("should handle empty content", () => {
+    const annotations = testScanner.extractAnnotations(
+      "",
+      "/tests/test.cnx",
+      "/tests",
+    );
+
+    expect(annotations).toHaveLength(0);
+  });
+});
+
+describe("findTestFiles", () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), "test-scanner-test-"));
+  });
+
+  afterEach(() => {
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it("should find .test.cnx files in directory", () => {
+    writeFileSync(join(tempDir, "one.test.cnx"), "// test");
+    writeFileSync(join(tempDir, "two.test.cnx"), "// test");
+    writeFileSync(join(tempDir, "not-a-test.cnx"), "// not a test");
+
+    const files = testScanner.findTestFiles(tempDir);
+
+    expect(files).toHaveLength(2);
+    expect(files.some((f) => f.endsWith("one.test.cnx"))).toBe(true);
+    expect(files.some((f) => f.endsWith("two.test.cnx"))).toBe(true);
+  });
+
+  it("should find files in subdirectories", () => {
+    const subdir = join(tempDir, "subdir");
+    mkdirSync(subdir);
+    writeFileSync(join(tempDir, "root.test.cnx"), "// test");
+    writeFileSync(join(subdir, "nested.test.cnx"), "// test");
+
+    const files = testScanner.findTestFiles(tempDir);
+
+    expect(files).toHaveLength(2);
+    expect(files.some((f) => f.endsWith("root.test.cnx"))).toBe(true);
+    expect(files.some((f) => f.endsWith("nested.test.cnx"))).toBe(true);
+  });
+
+  it("should find files in deeply nested directories", () => {
+    const deepDir = join(tempDir, "a", "b", "c");
+    mkdirSync(deepDir, { recursive: true });
+    writeFileSync(join(deepDir, "deep.test.cnx"), "// test");
+
+    const files = testScanner.findTestFiles(tempDir);
+
+    expect(files).toHaveLength(1);
+    expect(files[0]).toContain("deep.test.cnx");
+  });
+
+  it("should return empty array for directory with no test files", () => {
+    writeFileSync(join(tempDir, "regular.cnx"), "// not a test");
+    writeFileSync(join(tempDir, "readme.md"), "# Readme");
+
+    const files = testScanner.findTestFiles(tempDir);
+
+    expect(files).toHaveLength(0);
+  });
+
+  it("should return empty array for empty directory", () => {
+    const files = testScanner.findTestFiles(tempDir);
+
+    expect(files).toHaveLength(0);
+  });
+
+  it("should ignore non-.test.cnx files", () => {
+    writeFileSync(join(tempDir, "test.cnx"), "// not a test file");
+    writeFileSync(join(tempDir, "test.c"), "// c file");
+    writeFileSync(join(tempDir, "test.test.c"), "// wrong extension");
+    writeFileSync(join(tempDir, "actual.test.cnx"), "// test file");
+
+    const files = testScanner.findTestFiles(tempDir);
+
+    expect(files).toHaveLength(1);
+    expect(files[0]).toContain("actual.test.cnx");
+  });
+});
+
+describe("scanTestFiles", () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), "scan-test-"));
+  });
+
+  afterEach(() => {
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it("should scan directory and extract all annotations", () => {
+    writeFileSync(
+      join(tempDir, "one.test.cnx"),
+      `/* test-coverage: 1.1-first */
+void test() {}
+`,
+    );
+    writeFileSync(
+      join(tempDir, "two.test.cnx"),
+      `/* test-coverage: 2.1-second, 2.1-third */
+void test() {}
+`,
+    );
+
+    const annotations = testScanner.scanTestFiles(tempDir);
+
+    expect(annotations).toHaveLength(3);
+    expect(annotations.some((a) => a.coverageId === "1.1-first")).toBe(true);
+    expect(annotations.some((a) => a.coverageId === "2.1-second")).toBe(true);
+    expect(annotations.some((a) => a.coverageId === "2.1-third")).toBe(true);
+  });
+
+  it("should handle directory with no test files", () => {
+    writeFileSync(join(tempDir, "not-a-test.cnx"), "// nothing");
+
+    const annotations = testScanner.scanTestFiles(tempDir);
+
+    expect(annotations).toHaveLength(0);
+  });
+
+  it("should handle test files without annotations", () => {
+    writeFileSync(
+      join(tempDir, "empty.test.cnx"),
+      `// No annotations here
+void test() {}
+`,
+    );
+
+    const annotations = testScanner.scanTestFiles(tempDir);
+
+    expect(annotations).toHaveLength(0);
+  });
+
+  it("should scan subdirectories", () => {
+    const subdir = join(tempDir, "subdir");
+    mkdirSync(subdir);
+    writeFileSync(
+      join(subdir, "nested.test.cnx"),
+      `/* test-coverage: 1.1-nested */`,
+    );
+
+    const annotations = testScanner.scanTestFiles(tempDir);
+
+    expect(annotations).toHaveLength(1);
+    expect(annotations[0].coverageId).toBe("1.1-nested");
+    expect(annotations[0].relativePath).toBe("subdir/nested.test.cnx");
+  });
+});

--- a/scripts/coverage-checker.ts
+++ b/scripts/coverage-checker.ts
@@ -17,7 +17,7 @@ import { fileURLToPath } from "node:url";
 import { existsSync } from "node:fs";
 
 import coverageParser from "./coverage-parser";
-import scanTestFiles from "./test-scanner";
+import testScanner from "./test-scanner";
 import reportGenerator from "./report-generator";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -93,7 +93,7 @@ async function main(): Promise<void> {
 
   // Scan test files for annotations
   console.log(`${colors.yellow}Scanning test files...${colors.reset}`);
-  const annotations = scanTestFiles(testsDir);
+  const annotations = testScanner.scanTestFiles(testsDir);
   console.log(`  Found ${annotations.length} coverage annotations`);
 
   // Build report

--- a/scripts/coverage-parser.ts
+++ b/scripts/coverage-parser.ts
@@ -278,6 +278,14 @@ const coverageParser = {
   checkForDuplicates,
   generateCoverageId,
   toKebabCase,
+  // Exported for testing
+  extractSectionNumber,
+  extractSubsectionNumber,
+  extractSectionTitle,
+  extractSubsectionTitle,
+  extractTypeHeader,
+  parseTableRow,
+  shouldSkipSection,
 };
 
 export default coverageParser;

--- a/scripts/report-generator.ts
+++ b/scripts/report-generator.ts
@@ -372,6 +372,9 @@ const reportGenerator = {
   generateGapsReport,
   generateMarkdownReport,
   listAllIds,
+  // Exported for testing
+  getPercentageColor,
+  colors,
 };
 
 export default reportGenerator;

--- a/scripts/test-scanner.ts
+++ b/scripts/test-scanner.ts
@@ -94,4 +94,11 @@ function scanTestFiles(testsDir: string): ITestAnnotation[] {
   return annotations;
 }
 
-export default scanTestFiles;
+const testScanner = {
+  scanTestFiles,
+  // Exported for testing
+  findTestFiles,
+  extractAnnotations,
+};
+
+export default testScanner;


### PR DESCRIPTION
## Summary

Add 109 new unit tests for the coverage tracking scripts, improving test coverage from ~50 tests to 159 tests for the scripts directory.

### New Test Files

| File | Tests | Functions Covered |
|------|-------|-------------------|
| `coverage-parser.test.ts` | 67 | `toKebabCase`, `extractSectionNumber`, `extractSubsectionNumber`, `extractSectionTitle`, `extractSubsectionTitle`, `extractTypeHeader`, `parseTableRow`, `generateCoverageId`, `shouldSkipSection`, `checkForDuplicates`, `parseCoverageDocument` |
| `report-generator.test.ts` | 20 | `getPercentageColor`, `buildReport`, `generateMarkdownReport` |
| `test-scanner.test.ts` | 22 | `extractAnnotations`, `findTestFiles`, `scanTestFiles` |

### Source Modifications for Testability

- **coverage-parser.ts**: Export 7 internal parsing functions
- **report-generator.ts**: Export `getPercentageColor` and `colors`
- **test-scanner.ts**: Change from single function export to object with all functions
- **coverage-checker.ts**: Update import to match new test-scanner export

## Test Plan

- [x] All 1902 unit tests pass
- [x] All 159 script tests pass
- [x] Coverage-checker tool verified working
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.ai/code)