### PR TITLE
test: add unit tests for assignment handlers

### DIFF
--- a/src/transpiler/output/codegen/assignment/handlers/__tests__/AccessPatternHandlers.test.ts
+++ b/src/transpiler/output/codegen/assignment/handlers/__tests__/AccessPatternHandlers.test.ts
@@ -1,0 +1,547 @@
+/**
+ * Unit tests for AccessPatternHandlers.
+ * Tests global/this access and member chain handler functions.
+ */
+
+import { describe, expect, it, vi } from "vitest";
+import accessPatternHandlers from "../AccessPatternHandlers";
+import AssignmentKind from "../../AssignmentKind";
+import IAssignmentContext from "../../IAssignmentContext";
+import IHandlerDeps from "../IHandlerDeps";
+
+/**
+ * Create mock dependencies for testing.
+ */
+function createMockDeps(overrides: Record<string, unknown> = {}): IHandlerDeps {
+  const base = {
+    typeRegistry: new Map(),
+    symbols: {
+      structFields: new Map(),
+      structFieldDimensions: new Map(),
+      bitmapFields: new Map(),
+      registerMemberAccess: new Map(),
+      registerBaseAddresses: new Map(),
+      registerMemberOffsets: new Map(),
+      registerMemberTypes: new Map(),
+    },
+    currentScope: null,
+    currentParameters: new Map(),
+    targetCapabilities: { hasLDREX: false },
+    generateAssignmentTarget: vi.fn().mockReturnValue("target"),
+    generateExpression: vi
+      .fn()
+      .mockImplementation((ctx) => ctx?.mockValue ?? "0"),
+    markNeedsString: vi.fn(),
+    markClampOpUsed: vi.fn(),
+    isKnownScope: vi.fn().mockReturnValue(false),
+    isKnownStruct: vi.fn().mockReturnValue(false),
+    validateCrossScopeVisibility: vi.fn(),
+    validateBitmapFieldLiteral: vi.fn(),
+    checkArrayBounds: vi.fn(),
+    analyzeMemberChainForBitAccess: vi
+      .fn()
+      .mockReturnValue({ isBitAccess: false }),
+    tryEvaluateConstant: vi.fn().mockReturnValue(undefined),
+    getMemberTypeInfo: vi.fn().mockReturnValue(null),
+    generateFloatBitWrite: vi.fn().mockReturnValue(null),
+    foldBooleanToInt: vi.fn().mockImplementation((expr) => expr),
+    generateAtomicRMW: vi.fn().mockReturnValue("atomic_rmw"),
+    ...overrides,
+  };
+  return base as unknown as IHandlerDeps;
+}
+
+/**
+ * Create mock context for testing.
+ */
+function createMockContext(
+  overrides: Partial<IAssignmentContext> = {},
+): IAssignmentContext {
+  return {
+    identifiers: ["Counter", "value"],
+    subscripts: [],
+    isCompound: false,
+    cnextOp: "<-",
+    cOp: "=",
+    generatedValue: "5",
+    targetCtx: {} as never,
+    hasThis: false,
+    hasGlobal: true,
+    hasMemberAccess: true,
+    hasArrayAccess: false,
+    postfixOpsCount: 1,
+    memberAccessDepth: 1,
+    subscriptDepth: 0,
+    isSimpleIdentifier: false,
+    isSimpleThisAccess: false,
+    isSimpleGlobalAccess: false,
+    ...overrides,
+  } as IAssignmentContext;
+}
+
+describe("AccessPatternHandlers", () => {
+  describe("handler registration", () => {
+    it("registers all expected access pattern kinds", () => {
+      const kinds = accessPatternHandlers.map(([kind]) => kind);
+
+      expect(kinds).toContain(AssignmentKind.GLOBAL_MEMBER);
+      expect(kinds).toContain(AssignmentKind.GLOBAL_ARRAY);
+      expect(kinds).toContain(AssignmentKind.GLOBAL_REGISTER_BIT);
+      expect(kinds).toContain(AssignmentKind.THIS_MEMBER);
+      expect(kinds).toContain(AssignmentKind.THIS_ARRAY);
+      expect(kinds).toContain(AssignmentKind.MEMBER_CHAIN);
+    });
+
+    it("exports exactly 6 handlers", () => {
+      expect(accessPatternHandlers.length).toBe(6);
+    });
+
+    it("uses same handler for GLOBAL_MEMBER and GLOBAL_ARRAY", () => {
+      const globalMemberHandler = accessPatternHandlers.find(
+        ([kind]) => kind === AssignmentKind.GLOBAL_MEMBER,
+      )?.[1];
+      const globalArrayHandler = accessPatternHandlers.find(
+        ([kind]) => kind === AssignmentKind.GLOBAL_ARRAY,
+      )?.[1];
+
+      expect(globalMemberHandler).toBe(globalArrayHandler);
+    });
+
+    it("uses same handler for THIS_MEMBER and THIS_ARRAY", () => {
+      const thisMemberHandler = accessPatternHandlers.find(
+        ([kind]) => kind === AssignmentKind.THIS_MEMBER,
+      )?.[1];
+      const thisArrayHandler = accessPatternHandlers.find(
+        ([kind]) => kind === AssignmentKind.THIS_ARRAY,
+      )?.[1];
+
+      expect(thisMemberHandler).toBe(thisArrayHandler);
+    });
+  });
+
+  describe("handleGlobalAccess (GLOBAL_MEMBER)", () => {
+    const getHandler = () =>
+      accessPatternHandlers.find(
+        ([kind]) => kind === AssignmentKind.GLOBAL_MEMBER,
+      )?.[1];
+
+    it("generates standard assignment for global member", () => {
+      const generateAssignmentTarget = vi.fn().mockReturnValue("Counter_value");
+      const deps = createMockDeps({ generateAssignmentTarget });
+      const ctx = createMockContext();
+
+      const result = getHandler()!(ctx, deps);
+
+      expect(result).toBe("Counter_value = 5;");
+    });
+
+    it("validates cross-scope visibility when first id is a scope", () => {
+      const validateCrossScopeVisibility = vi.fn();
+      const deps = createMockDeps({
+        isKnownScope: vi.fn().mockReturnValue(true),
+        validateCrossScopeVisibility,
+        generateAssignmentTarget: vi.fn().mockReturnValue("Motor_speed"),
+      });
+      const ctx = createMockContext({
+        identifiers: ["Motor", "speed"],
+      });
+
+      getHandler()!(ctx, deps);
+
+      expect(validateCrossScopeVisibility).toHaveBeenCalledWith(
+        "Motor",
+        "speed",
+      );
+    });
+
+    it("does not validate when first id is not a scope", () => {
+      const validateCrossScopeVisibility = vi.fn();
+      const deps = createMockDeps({
+        isKnownScope: vi.fn().mockReturnValue(false),
+        validateCrossScopeVisibility,
+        generateAssignmentTarget: vi.fn().mockReturnValue("someVar"),
+      });
+      const ctx = createMockContext({
+        identifiers: ["someVar"],
+      });
+
+      getHandler()!(ctx, deps);
+
+      expect(validateCrossScopeVisibility).not.toHaveBeenCalled();
+    });
+
+    it("handles compound assignment", () => {
+      const deps = createMockDeps({
+        generateAssignmentTarget: vi.fn().mockReturnValue("Counter_value"),
+      });
+      const ctx = createMockContext({
+        isCompound: true,
+        cOp: "+=",
+      });
+
+      const result = getHandler()!(ctx, deps);
+
+      expect(result).toBe("Counter_value += 5;");
+    });
+  });
+
+  describe("handleGlobalAccess (GLOBAL_ARRAY)", () => {
+    const getHandler = () =>
+      accessPatternHandlers.find(
+        ([kind]) => kind === AssignmentKind.GLOBAL_ARRAY,
+      )?.[1];
+
+    it("generates array element assignment", () => {
+      const deps = createMockDeps({
+        generateAssignmentTarget: vi.fn().mockReturnValue("Buffer_data[i]"),
+      });
+      const ctx = createMockContext({
+        identifiers: ["Buffer", "data"],
+        subscripts: [{ mockValue: "i" } as never],
+        hasArrayAccess: true,
+      });
+
+      const result = getHandler()!(ctx, deps);
+
+      expect(result).toBe("Buffer_data[i] = 5;");
+    });
+  });
+
+  describe("handleThisAccess (THIS_MEMBER)", () => {
+    const getHandler = () =>
+      accessPatternHandlers.find(
+        ([kind]) => kind === AssignmentKind.THIS_MEMBER,
+      )?.[1];
+
+    it("generates scoped member assignment", () => {
+      const deps = createMockDeps({
+        currentScope: "Motor",
+        generateAssignmentTarget: vi.fn().mockReturnValue("Motor_speed"),
+      });
+      const ctx = createMockContext({
+        identifiers: ["speed"],
+        hasThis: true,
+        hasGlobal: false,
+      });
+
+      const result = getHandler()!(ctx, deps);
+
+      expect(result).toBe("Motor_speed = 5;");
+    });
+
+    it("throws when used outside scope", () => {
+      const deps = createMockDeps({ currentScope: null });
+      const ctx = createMockContext({ hasThis: true, hasGlobal: false });
+
+      expect(() => getHandler()!(ctx, deps)).toThrow(
+        "'this' can only be used inside a scope",
+      );
+    });
+
+    it("handles compound assignment", () => {
+      const deps = createMockDeps({
+        currentScope: "Motor",
+        generateAssignmentTarget: vi.fn().mockReturnValue("Motor_count"),
+      });
+      const ctx = createMockContext({
+        identifiers: ["count"],
+        hasThis: true,
+        hasGlobal: false,
+        isCompound: true,
+        cOp: "-=",
+      });
+
+      const result = getHandler()!(ctx, deps);
+
+      expect(result).toBe("Motor_count -= 5;");
+    });
+  });
+
+  describe("handleThisAccess (THIS_ARRAY)", () => {
+    const getHandler = () =>
+      accessPatternHandlers.find(
+        ([kind]) => kind === AssignmentKind.THIS_ARRAY,
+      )?.[1];
+
+    it("generates scoped array element assignment", () => {
+      const deps = createMockDeps({
+        currentScope: "Motor",
+        generateAssignmentTarget: vi.fn().mockReturnValue("Motor_items[0]"),
+      });
+      const ctx = createMockContext({
+        identifiers: ["items"],
+        subscripts: [{ mockValue: "0" } as never],
+        hasThis: true,
+        hasGlobal: false,
+        hasArrayAccess: true,
+      });
+
+      const result = getHandler()!(ctx, deps);
+
+      expect(result).toBe("Motor_items[0] = 5;");
+    });
+  });
+
+  describe("handleGlobalRegisterBit (GLOBAL_REGISTER_BIT)", () => {
+    const getHandler = () =>
+      accessPatternHandlers.find(
+        ([kind]) => kind === AssignmentKind.GLOBAL_REGISTER_BIT,
+      )?.[1];
+
+    it("generates read-modify-write for single bit", () => {
+      const deps = createMockDeps({
+        generateExpression: vi.fn().mockReturnValue("LED_BIT"),
+      });
+      const ctx = createMockContext({
+        identifiers: ["GPIO7", "DR_SET"],
+        subscripts: [{ mockValue: "LED_BIT" } as never],
+        generatedValue: "true",
+      });
+
+      const result = getHandler()!(ctx, deps);
+
+      expect(result).toContain("GPIO7_DR_SET =");
+      expect(result).toContain("& ~(1 <<");
+      expect(result).toContain("LED_BIT");
+    });
+
+    it("generates simple write for write-only register single bit", () => {
+      const registerMemberAccess = new Map([["GPIO7_DR_SET", "wo"]]);
+      const deps = createMockDeps({
+        generateExpression: vi.fn().mockReturnValue("LED_BIT"),
+        symbols: {
+          structFields: new Map(),
+          structFieldDimensions: new Map(),
+          bitmapFields: new Map(),
+          registerMemberAccess,
+          registerBaseAddresses: new Map(),
+          registerMemberOffsets: new Map(),
+          registerMemberTypes: new Map(),
+        },
+      });
+      const ctx = createMockContext({
+        identifiers: ["GPIO7", "DR_SET"],
+        subscripts: [{ mockValue: "LED_BIT" } as never],
+        generatedValue: "true",
+      });
+
+      const result = getHandler()!(ctx, deps);
+
+      expect(result).toBe("GPIO7_DR_SET = (1 << LED_BIT);");
+    });
+
+    it("throws on write-only register with false value", () => {
+      const registerMemberAccess = new Map([["GPIO7_DR_SET", "wo"]]);
+      const deps = createMockDeps({
+        generateExpression: vi.fn().mockReturnValue("LED_BIT"),
+        symbols: {
+          structFields: new Map(),
+          structFieldDimensions: new Map(),
+          bitmapFields: new Map(),
+          registerMemberAccess,
+          registerBaseAddresses: new Map(),
+          registerMemberOffsets: new Map(),
+          registerMemberTypes: new Map(),
+        },
+      });
+      const ctx = createMockContext({
+        identifiers: ["GPIO7", "DR_SET"],
+        subscripts: [{ mockValue: "LED_BIT" } as never],
+        generatedValue: "false",
+      });
+
+      expect(() => getHandler()!(ctx, deps)).toThrow(
+        "Cannot assign false to write-only register bit",
+      );
+    });
+
+    it("generates read-modify-write for bit range", () => {
+      const deps = createMockDeps({
+        generateExpression: vi
+          .fn()
+          .mockReturnValueOnce("0")
+          .mockReturnValueOnce("8"),
+      });
+      const ctx = createMockContext({
+        identifiers: ["GPIO7", "DR_SET"],
+        subscripts: [{ mockValue: "0" } as never, { mockValue: "8" } as never],
+        generatedValue: "value",
+      });
+
+      const result = getHandler()!(ctx, deps);
+
+      expect(result).toContain("GPIO7_DR_SET =");
+      expect(result).toContain("& ~(");
+      expect(result).toContain("<< 0");
+    });
+
+    it("generates simple write for write-only bit range", () => {
+      const registerMemberAccess = new Map([["GPIO7_DR_SET", "w1s"]]);
+      const deps = createMockDeps({
+        generateExpression: vi
+          .fn()
+          .mockReturnValueOnce("0")
+          .mockReturnValueOnce("8"),
+        symbols: {
+          structFields: new Map(),
+          structFieldDimensions: new Map(),
+          bitmapFields: new Map(),
+          registerMemberAccess,
+          registerBaseAddresses: new Map(),
+          registerMemberOffsets: new Map(),
+          registerMemberTypes: new Map(),
+        },
+      });
+      const ctx = createMockContext({
+        identifiers: ["GPIO7", "DR_SET"],
+        subscripts: [{ mockValue: "0" } as never, { mockValue: "8" } as never],
+        generatedValue: "value",
+      });
+
+      const result = getHandler()!(ctx, deps);
+
+      expect(result).not.toContain("& ~");
+    });
+
+    it("throws on write-only bit range with 0 value", () => {
+      const registerMemberAccess = new Map([["GPIO7_DR_SET", "w1c"]]);
+      const deps = createMockDeps({
+        generateExpression: vi
+          .fn()
+          .mockReturnValueOnce("0")
+          .mockReturnValueOnce("8"),
+        symbols: {
+          structFields: new Map(),
+          structFieldDimensions: new Map(),
+          bitmapFields: new Map(),
+          registerMemberAccess,
+          registerBaseAddresses: new Map(),
+          registerMemberOffsets: new Map(),
+          registerMemberTypes: new Map(),
+        },
+      });
+      const ctx = createMockContext({
+        identifiers: ["GPIO7", "DR_SET"],
+        subscripts: [{ mockValue: "0" } as never, { mockValue: "8" } as never],
+        generatedValue: "0",
+      });
+
+      expect(() => getHandler()!(ctx, deps)).toThrow(
+        "Cannot assign 0 to write-only register bits",
+      );
+    });
+
+    it("throws on compound assignment", () => {
+      const deps = createMockDeps();
+      const ctx = createMockContext({
+        identifiers: ["GPIO7", "DR_SET"],
+        subscripts: [{ mockValue: "LED_BIT" } as never],
+        isCompound: true,
+        cnextOp: "+<-",
+      });
+
+      expect(() => getHandler()!(ctx, deps)).toThrow(
+        "Compound assignment operators not supported for bit field access",
+      );
+    });
+  });
+
+  describe("handleMemberChain (MEMBER_CHAIN)", () => {
+    const getHandler = () =>
+      accessPatternHandlers.find(
+        ([kind]) => kind === AssignmentKind.MEMBER_CHAIN,
+      )?.[1];
+
+    it("generates standard member chain assignment", () => {
+      const deps = createMockDeps({
+        generateAssignmentTarget: vi
+          .fn()
+          .mockReturnValue("device.config.value"),
+      });
+      const ctx = createMockContext({
+        identifiers: ["device", "config", "value"],
+        memberAccessDepth: 2,
+      });
+
+      const result = getHandler()!(ctx, deps);
+
+      expect(result).toBe("device.config.value = 5;");
+    });
+
+    it("generates bit access when detected in member chain", () => {
+      const deps = createMockDeps({
+        analyzeMemberChainForBitAccess: vi.fn().mockReturnValue({
+          isBitAccess: true,
+          baseTarget: "grid[2][3].flags",
+          bitIndex: "0",
+          baseType: "u32",
+        }),
+      });
+      const ctx = createMockContext({
+        identifiers: ["grid", "flags"],
+        subscripts: [{ mockValue: "0" } as never],
+        generatedValue: "true",
+      });
+
+      const result = getHandler()!(ctx, deps);
+
+      expect(result).toContain("grid[2][3].flags =");
+      expect(result).toContain("& ~(1 << 0)");
+      expect(result).toContain("1 << 0");
+    });
+
+    it("uses 1ULL for 64-bit bit access", () => {
+      const deps = createMockDeps({
+        analyzeMemberChainForBitAccess: vi.fn().mockReturnValue({
+          isBitAccess: true,
+          baseTarget: "data.flags",
+          bitIndex: "bit",
+          baseType: "u64",
+        }),
+      });
+      const ctx = createMockContext({
+        identifiers: ["data", "flags"],
+        subscripts: [{ mockValue: "bit" } as never],
+        generatedValue: "false",
+      });
+
+      const result = getHandler()!(ctx, deps);
+
+      expect(result).toContain("1ULL << bit");
+    });
+
+    it("throws on compound assignment for bit access in member chain", () => {
+      const deps = createMockDeps({
+        analyzeMemberChainForBitAccess: vi.fn().mockReturnValue({
+          isBitAccess: true,
+          baseTarget: "data.flags",
+          bitIndex: "0",
+          baseType: "u32",
+        }),
+      });
+      const ctx = createMockContext({
+        isCompound: true,
+        cnextOp: "+<-",
+      });
+
+      expect(() => getHandler()!(ctx, deps)).toThrow(
+        "Compound assignment operators not supported for bit field access",
+      );
+    });
+
+    it("handles compound assignment for normal member chain", () => {
+      const deps = createMockDeps({
+        generateAssignmentTarget: vi.fn().mockReturnValue("obj.field"),
+      });
+      const ctx = createMockContext({
+        identifiers: ["obj", "field"],
+        isCompound: true,
+        cOp: "*=",
+      });
+
+      const result = getHandler()!(ctx, deps);
+
+      expect(result).toBe("obj.field *= 5;");
+    });
+  });
+});

--- a/src/transpiler/output/codegen/assignment/handlers/__tests__/ArrayHandlers.test.ts
+++ b/src/transpiler/output/codegen/assignment/handlers/__tests__/ArrayHandlers.test.ts
@@ -1,0 +1,518 @@
+/**
+ * Unit tests for ArrayHandlers.
+ * Tests array assignment handler functions.
+ */
+
+import { describe, expect, it, vi } from "vitest";
+import arrayHandlers from "../ArrayHandlers";
+import AssignmentKind from "../../AssignmentKind";
+import IAssignmentContext from "../../IAssignmentContext";
+import IHandlerDeps from "../IHandlerDeps";
+
+/**
+ * Create mock dependencies for testing.
+ */
+function createMockDeps(overrides: Record<string, unknown> = {}): IHandlerDeps {
+  const base = {
+    typeRegistry: new Map(),
+    symbols: {
+      structFields: new Map(),
+      structFieldDimensions: new Map(),
+      bitmapFields: new Map(),
+      registerMemberAccess: new Map(),
+      registerBaseAddresses: new Map(),
+      registerMemberOffsets: new Map(),
+      registerMemberTypes: new Map(),
+    },
+    currentScope: null,
+    currentParameters: new Map(),
+    targetCapabilities: { hasLDREX: false },
+    generateAssignmentTarget: vi.fn().mockReturnValue("target"),
+    generateExpression: vi
+      .fn()
+      .mockImplementation((ctx) => ctx?.mockValue ?? "0"),
+    markNeedsString: vi.fn(),
+    markClampOpUsed: vi.fn(),
+    isKnownScope: vi.fn().mockReturnValue(false),
+    isKnownStruct: vi.fn().mockReturnValue(false),
+    validateCrossScopeVisibility: vi.fn(),
+    validateBitmapFieldLiteral: vi.fn(),
+    checkArrayBounds: vi.fn(),
+    analyzeMemberChainForBitAccess: vi
+      .fn()
+      .mockReturnValue({ isBitAccess: false }),
+    tryEvaluateConstant: vi.fn().mockReturnValue(undefined),
+    getMemberTypeInfo: vi.fn().mockReturnValue(null),
+    generateFloatBitWrite: vi.fn().mockReturnValue(null),
+    foldBooleanToInt: vi.fn().mockImplementation((expr) => expr),
+    generateAtomicRMW: vi.fn().mockReturnValue("atomic_rmw"),
+    ...overrides,
+  };
+  return base as unknown as IHandlerDeps;
+}
+
+/**
+ * Create mock context for testing.
+ */
+function createMockContext(
+  overrides: Partial<IAssignmentContext> = {},
+): IAssignmentContext {
+  return {
+    identifiers: ["arr"],
+    subscripts: [{ mockValue: "i", start: { line: 1 } } as never],
+    isCompound: false,
+    cnextOp: "<-",
+    cOp: "=",
+    generatedValue: "value",
+    targetCtx: {} as never,
+    hasThis: false,
+    hasGlobal: false,
+    hasMemberAccess: false,
+    hasArrayAccess: true,
+    postfixOpsCount: 1,
+    memberAccessDepth: 0,
+    subscriptDepth: 1,
+    isSimpleIdentifier: false,
+    isSimpleThisAccess: false,
+    isSimpleGlobalAccess: false,
+    ...overrides,
+  } as IAssignmentContext;
+}
+
+describe("ArrayHandlers", () => {
+  describe("handler registration", () => {
+    it("registers all expected array assignment kinds", () => {
+      const kinds = arrayHandlers.map(([kind]) => kind);
+
+      expect(kinds).toContain(AssignmentKind.ARRAY_ELEMENT);
+      expect(kinds).toContain(AssignmentKind.MULTI_DIM_ARRAY_ELEMENT);
+      expect(kinds).toContain(AssignmentKind.ARRAY_SLICE);
+    });
+
+    it("exports exactly 3 handlers", () => {
+      expect(arrayHandlers.length).toBe(3);
+    });
+  });
+
+  describe("handleArrayElement (ARRAY_ELEMENT)", () => {
+    const getHandler = () =>
+      arrayHandlers.find(
+        ([kind]) => kind === AssignmentKind.ARRAY_ELEMENT,
+      )?.[1];
+
+    it("generates simple array element assignment", () => {
+      const deps = createMockDeps({
+        generateExpression: vi.fn().mockReturnValue("i"),
+      });
+      const ctx = createMockContext();
+
+      const result = getHandler()!(ctx, deps);
+
+      expect(result).toBe("arr[i] = value;");
+    });
+
+    it("handles compound assignment", () => {
+      const deps = createMockDeps({
+        generateExpression: vi.fn().mockReturnValue("0"),
+      });
+      const ctx = createMockContext({
+        isCompound: true,
+        cnextOp: "+<-",
+        cOp: "+=",
+      });
+
+      const result = getHandler()!(ctx, deps);
+
+      expect(result).toBe("arr[0] += value;");
+    });
+
+    it("uses correct identifier", () => {
+      const deps = createMockDeps({
+        generateExpression: vi.fn().mockReturnValue("idx"),
+      });
+      const ctx = createMockContext({
+        identifiers: ["buffer"],
+      });
+
+      const result = getHandler()!(ctx, deps);
+
+      expect(result).toBe("buffer[idx] = value;");
+    });
+  });
+
+  describe("handleMultiDimArrayElement (MULTI_DIM_ARRAY_ELEMENT)", () => {
+    const getHandler = () =>
+      arrayHandlers.find(
+        ([kind]) => kind === AssignmentKind.MULTI_DIM_ARRAY_ELEMENT,
+      )?.[1];
+
+    it("generates multi-dimensional array access", () => {
+      const deps = createMockDeps({
+        generateExpression: vi
+          .fn()
+          .mockReturnValueOnce("i")
+          .mockReturnValueOnce("j"),
+      });
+      const ctx = createMockContext({
+        identifiers: ["matrix"],
+        subscripts: [
+          { mockValue: "i", start: { line: 1 } } as never,
+          { mockValue: "j", start: { line: 1 } } as never,
+        ],
+        subscriptDepth: 2,
+      });
+
+      const result = getHandler()!(ctx, deps);
+
+      expect(result).toBe("matrix[i][j] = value;");
+    });
+
+    it("handles 3D array access", () => {
+      const deps = createMockDeps({
+        generateExpression: vi
+          .fn()
+          .mockReturnValueOnce("x")
+          .mockReturnValueOnce("y")
+          .mockReturnValueOnce("z"),
+      });
+      const ctx = createMockContext({
+        identifiers: ["cube"],
+        subscripts: [
+          { mockValue: "x", start: { line: 1 } } as never,
+          { mockValue: "y", start: { line: 1 } } as never,
+          { mockValue: "z", start: { line: 1 } } as never,
+        ],
+        subscriptDepth: 3,
+      });
+
+      const result = getHandler()!(ctx, deps);
+
+      expect(result).toBe("cube[x][y][z] = value;");
+    });
+
+    it("performs bounds checking when type info available", () => {
+      const typeRegistry = new Map([
+        ["matrix", { arrayDimensions: [10, 10], baseType: "i32" }],
+      ]);
+      const checkArrayBounds = vi.fn();
+      const deps = createMockDeps({
+        typeRegistry,
+        checkArrayBounds,
+        generateExpression: vi
+          .fn()
+          .mockReturnValueOnce("5")
+          .mockReturnValueOnce("3"),
+      });
+      const ctx = createMockContext({
+        identifiers: ["matrix"],
+        subscripts: [
+          { mockValue: "5", start: { line: 10 } } as never,
+          { mockValue: "3", start: { line: 10 } } as never,
+        ],
+      });
+
+      getHandler()!(ctx, deps);
+
+      expect(checkArrayBounds).toHaveBeenCalledWith(
+        "matrix",
+        [10, 10],
+        ctx.subscripts,
+        10,
+      );
+    });
+
+    it("handles compound assignment", () => {
+      const deps = createMockDeps({
+        generateExpression: vi
+          .fn()
+          .mockReturnValueOnce("0")
+          .mockReturnValueOnce("1"),
+      });
+      const ctx = createMockContext({
+        identifiers: ["grid"],
+        subscripts: [
+          { mockValue: "0", start: { line: 1 } } as never,
+          { mockValue: "1", start: { line: 1 } } as never,
+        ],
+        isCompound: true,
+        cOp: "-=",
+      });
+
+      const result = getHandler()!(ctx, deps);
+
+      expect(result).toBe("grid[0][1] -= value;");
+    });
+  });
+
+  describe("handleArraySlice (ARRAY_SLICE)", () => {
+    const getHandler = () =>
+      arrayHandlers.find(([kind]) => kind === AssignmentKind.ARRAY_SLICE)?.[1];
+
+    it("generates memcpy for valid slice assignment", () => {
+      const typeRegistry = new Map([
+        ["buffer", { arrayDimensions: [100], baseType: "u8" }],
+      ]);
+      const markNeedsString = vi.fn();
+      const deps = createMockDeps({
+        typeRegistry,
+        markNeedsString,
+        tryEvaluateConstant: vi
+          .fn()
+          .mockReturnValueOnce(0)
+          .mockReturnValueOnce(10),
+      });
+      const ctx = createMockContext({
+        identifiers: ["buffer"],
+        subscripts: [
+          { mockValue: "0", start: { line: 1 } } as never,
+          { mockValue: "10", start: { line: 1 } } as never,
+        ],
+        generatedValue: "source",
+      });
+
+      const result = getHandler()!(ctx, deps);
+
+      expect(result).toBe("memcpy(&buffer[0], &source, 10);");
+      expect(markNeedsString).toHaveBeenCalled();
+    });
+
+    it("generates memcpy for string slice", () => {
+      const typeRegistry = new Map([
+        [
+          "str",
+          {
+            isString: true,
+            stringCapacity: 32,
+            isArray: false,
+            baseType: "string",
+          },
+        ],
+      ]);
+      const deps = createMockDeps({
+        typeRegistry,
+        tryEvaluateConstant: vi
+          .fn()
+          .mockReturnValueOnce(5)
+          .mockReturnValueOnce(10),
+      });
+      const ctx = createMockContext({
+        identifiers: ["str"],
+        subscripts: [
+          { mockValue: "5", start: { line: 1 } } as never,
+          { mockValue: "10", start: { line: 1 } } as never,
+        ],
+        generatedValue: "data",
+      });
+
+      const result = getHandler()!(ctx, deps);
+
+      expect(result).toBe("memcpy(&str[5], &data, 10);");
+    });
+
+    it("throws on compound assignment", () => {
+      const typeRegistry = new Map([
+        ["buffer", { arrayDimensions: [100], baseType: "u8" }],
+      ]);
+      const deps = createMockDeps({
+        typeRegistry,
+        tryEvaluateConstant: vi
+          .fn()
+          .mockReturnValueOnce(0)
+          .mockReturnValueOnce(10),
+      });
+      const ctx = createMockContext({
+        isCompound: true,
+        cnextOp: "+<-",
+        subscripts: [
+          { mockValue: "0", start: { line: 1 } } as never,
+          { mockValue: "10", start: { line: 1 } } as never,
+        ],
+      });
+
+      expect(() => getHandler()!(ctx, deps)).toThrow(
+        "Compound assignment operators not supported for slice assignment",
+      );
+    });
+
+    it("throws on multi-dimensional array", () => {
+      const typeRegistry = new Map([
+        ["matrix", { arrayDimensions: [10, 10], baseType: "u8" }],
+      ]);
+      const deps = createMockDeps({
+        typeRegistry,
+      });
+      const ctx = createMockContext({
+        identifiers: ["matrix"],
+        subscripts: [
+          { mockValue: "0", start: { line: 5 } } as never,
+          { mockValue: "10", start: { line: 5 } } as never,
+        ],
+      });
+
+      expect(() => getHandler()!(ctx, deps)).toThrow(
+        "Slice assignment is only valid on one-dimensional arrays",
+      );
+    });
+
+    it("throws on non-constant offset", () => {
+      const typeRegistry = new Map([
+        ["buffer", { arrayDimensions: [100], baseType: "u8" }],
+      ]);
+      const deps = createMockDeps({
+        typeRegistry,
+        tryEvaluateConstant: vi.fn().mockReturnValue(undefined),
+      });
+      const ctx = createMockContext({
+        subscripts: [
+          { mockValue: "i", start: { line: 3 } } as never,
+          { mockValue: "10", start: { line: 3 } } as never,
+        ],
+      });
+
+      expect(() => getHandler()!(ctx, deps)).toThrow(
+        "Slice assignment offset must be a compile-time constant",
+      );
+    });
+
+    it("throws on non-constant length", () => {
+      const typeRegistry = new Map([
+        ["buffer", { arrayDimensions: [100], baseType: "u8" }],
+      ]);
+      const deps = createMockDeps({
+        typeRegistry,
+        tryEvaluateConstant: vi
+          .fn()
+          .mockReturnValueOnce(0)
+          .mockReturnValueOnce(undefined),
+      });
+      const ctx = createMockContext({
+        subscripts: [
+          { mockValue: "0", start: { line: 3 } } as never,
+          { mockValue: "len", start: { line: 3 } } as never,
+        ],
+      });
+
+      expect(() => getHandler()!(ctx, deps)).toThrow(
+        "Slice assignment length must be a compile-time constant",
+      );
+    });
+
+    it("throws on out of bounds access", () => {
+      const typeRegistry = new Map([
+        ["buffer", { arrayDimensions: [50], baseType: "u8" }],
+      ]);
+      const deps = createMockDeps({
+        typeRegistry,
+        tryEvaluateConstant: vi
+          .fn()
+          .mockReturnValueOnce(40)
+          .mockReturnValueOnce(20),
+      });
+      const ctx = createMockContext({
+        identifiers: ["buffer"],
+        subscripts: [
+          { mockValue: "40", start: { line: 7 } } as never,
+          { mockValue: "20", start: { line: 7 } } as never,
+        ],
+      });
+
+      expect(() => getHandler()!(ctx, deps)).toThrow(
+        "Slice assignment out of bounds",
+      );
+    });
+
+    it("throws on negative offset", () => {
+      const typeRegistry = new Map([
+        ["buffer", { arrayDimensions: [100], baseType: "u8" }],
+      ]);
+      const deps = createMockDeps({
+        typeRegistry,
+        tryEvaluateConstant: vi
+          .fn()
+          .mockReturnValueOnce(-1)
+          .mockReturnValueOnce(10),
+      });
+      const ctx = createMockContext({
+        identifiers: ["buffer"],
+        subscripts: [
+          { mockValue: "-1", start: { line: 2 } } as never,
+          { mockValue: "10", start: { line: 2 } } as never,
+        ],
+      });
+
+      expect(() => getHandler()!(ctx, deps)).toThrow(
+        "Slice assignment offset cannot be negative",
+      );
+    });
+
+    it("throws on zero length", () => {
+      const typeRegistry = new Map([
+        ["buffer", { arrayDimensions: [100], baseType: "u8" }],
+      ]);
+      const deps = createMockDeps({
+        typeRegistry,
+        tryEvaluateConstant: vi
+          .fn()
+          .mockReturnValueOnce(0)
+          .mockReturnValueOnce(0),
+      });
+      const ctx = createMockContext({
+        identifiers: ["buffer"],
+        subscripts: [
+          { mockValue: "0", start: { line: 2 } } as never,
+          { mockValue: "0", start: { line: 2 } } as never,
+        ],
+      });
+
+      expect(() => getHandler()!(ctx, deps)).toThrow(
+        "Slice assignment length must be positive",
+      );
+    });
+
+    it("throws on negative length", () => {
+      const typeRegistry = new Map([
+        ["buffer", { arrayDimensions: [100], baseType: "u8" }],
+      ]);
+      const deps = createMockDeps({
+        typeRegistry,
+        tryEvaluateConstant: vi
+          .fn()
+          .mockReturnValueOnce(0)
+          .mockReturnValueOnce(-5),
+      });
+      const ctx = createMockContext({
+        identifiers: ["buffer"],
+        subscripts: [
+          { mockValue: "0", start: { line: 2 } } as never,
+          { mockValue: "-5", start: { line: 2 } } as never,
+        ],
+      });
+
+      expect(() => getHandler()!(ctx, deps)).toThrow(
+        "Slice assignment length must be positive",
+      );
+    });
+
+    it("throws when buffer size cannot be determined", () => {
+      const typeRegistry = new Map([["unknown", { baseType: "u8" }]]);
+      const deps = createMockDeps({
+        typeRegistry,
+        tryEvaluateConstant: vi
+          .fn()
+          .mockReturnValueOnce(0)
+          .mockReturnValueOnce(10),
+      });
+      const ctx = createMockContext({
+        identifiers: ["unknown"],
+        subscripts: [
+          { mockValue: "0", start: { line: 2 } } as never,
+          { mockValue: "10", start: { line: 2 } } as never,
+        ],
+      });
+
+      expect(() => getHandler()!(ctx, deps)).toThrow(
+        "Cannot determine buffer size",
+      );
+    });
+  });
+});

--- a/src/transpiler/output/codegen/assignment/handlers/__tests__/BitAccessHandlers.test.ts
+++ b/src/transpiler/output/codegen/assignment/handlers/__tests__/BitAccessHandlers.test.ts
@@ -1,0 +1,473 @@
+/**
+ * Unit tests for BitAccessHandlers.
+ * Tests integer bit access assignment handler functions.
+ */
+
+import { describe, expect, it, vi } from "vitest";
+import bitAccessHandlers from "../BitAccessHandlers";
+import AssignmentKind from "../../AssignmentKind";
+import IAssignmentContext from "../../IAssignmentContext";
+import IHandlerDeps from "../IHandlerDeps";
+
+/**
+ * Create mock dependencies for testing.
+ */
+function createMockDeps(overrides: Record<string, unknown> = {}): IHandlerDeps {
+  const base = {
+    typeRegistry: new Map(),
+    symbols: {
+      structFields: new Map(),
+      structFieldDimensions: new Map(),
+      bitmapFields: new Map(),
+      registerMemberAccess: new Map(),
+      registerBaseAddresses: new Map(),
+      registerMemberOffsets: new Map(),
+      registerMemberTypes: new Map(),
+    },
+    currentScope: null,
+    currentParameters: new Map(),
+    targetCapabilities: { hasLDREX: false },
+    generateAssignmentTarget: vi.fn().mockReturnValue("target"),
+    generateExpression: vi
+      .fn()
+      .mockImplementation((ctx) => ctx?.mockValue ?? "0"),
+    markNeedsString: vi.fn(),
+    markClampOpUsed: vi.fn(),
+    isKnownScope: vi.fn().mockReturnValue(false),
+    isKnownStruct: vi.fn().mockReturnValue(false),
+    validateCrossScopeVisibility: vi.fn(),
+    validateBitmapFieldLiteral: vi.fn(),
+    checkArrayBounds: vi.fn(),
+    analyzeMemberChainForBitAccess: vi
+      .fn()
+      .mockReturnValue({ isBitAccess: false }),
+    tryEvaluateConstant: vi.fn().mockReturnValue(undefined),
+    getMemberTypeInfo: vi.fn().mockReturnValue(null),
+    generateFloatBitWrite: vi.fn().mockReturnValue(null),
+    foldBooleanToInt: vi.fn().mockImplementation((expr) => expr),
+    generateAtomicRMW: vi.fn().mockReturnValue("atomic_rmw"),
+    ...overrides,
+  };
+  return base as unknown as IHandlerDeps;
+}
+
+/**
+ * Create mock context for testing.
+ */
+function createMockContext(
+  overrides: Partial<IAssignmentContext> = {},
+): IAssignmentContext {
+  return {
+    identifiers: ["flags"],
+    subscripts: [{ mockValue: "3" } as never],
+    isCompound: false,
+    cnextOp: "<-",
+    cOp: "=",
+    generatedValue: "true",
+    targetCtx: {} as never,
+    hasThis: false,
+    hasGlobal: false,
+    hasMemberAccess: false,
+    hasArrayAccess: true,
+    postfixOpsCount: 1,
+    memberAccessDepth: 0,
+    subscriptDepth: 1,
+    isSimpleIdentifier: false,
+    isSimpleThisAccess: false,
+    isSimpleGlobalAccess: false,
+    ...overrides,
+  } as IAssignmentContext;
+}
+
+describe("BitAccessHandlers", () => {
+  describe("handler registration", () => {
+    it("registers all expected bit access kinds", () => {
+      const kinds = bitAccessHandlers.map(([kind]) => kind);
+
+      expect(kinds).toContain(AssignmentKind.INTEGER_BIT);
+      expect(kinds).toContain(AssignmentKind.INTEGER_BIT_RANGE);
+      expect(kinds).toContain(AssignmentKind.STRUCT_MEMBER_BIT);
+      expect(kinds).toContain(AssignmentKind.ARRAY_ELEMENT_BIT);
+    });
+
+    it("exports exactly 4 handlers", () => {
+      expect(bitAccessHandlers.length).toBe(4);
+    });
+  });
+
+  describe("handleIntegerBit (INTEGER_BIT)", () => {
+    const getHandler = () =>
+      bitAccessHandlers.find(
+        ([kind]) => kind === AssignmentKind.INTEGER_BIT,
+      )?.[1];
+
+    it("generates single bit read-modify-write", () => {
+      const typeRegistry = new Map([["flags", { baseType: "u32" }]]);
+      const deps = createMockDeps({
+        typeRegistry,
+        generateExpression: vi.fn().mockReturnValue("3"),
+      });
+      const ctx = createMockContext();
+
+      const result = getHandler()!(ctx, deps);
+
+      expect(result).toContain("flags =");
+      expect(result).toContain("& ~(1 << 3)");
+      expect(result).toContain("1 << 3");
+    });
+
+    it("uses 1ULL for 64-bit types", () => {
+      const typeRegistry = new Map([["flags", { baseType: "u64" }]]);
+      const deps = createMockDeps({
+        typeRegistry,
+        generateExpression: vi.fn().mockReturnValue("32"),
+      });
+      const ctx = createMockContext({
+        subscripts: [{ mockValue: "32" } as never],
+      });
+
+      const result = getHandler()!(ctx, deps);
+
+      expect(result).toContain("1ULL << 32");
+    });
+
+    it("uses 1ULL for signed 64-bit types", () => {
+      const typeRegistry = new Map([["flags", { baseType: "i64" }]]);
+      const deps = createMockDeps({
+        typeRegistry,
+        generateExpression: vi.fn().mockReturnValue("bit"),
+      });
+      const ctx = createMockContext();
+
+      const result = getHandler()!(ctx, deps);
+
+      // i64 uses 1ULL for the mask and cast for the value
+      expect(result).toContain("1ULL << bit");
+    });
+
+    it("converts true to 1", () => {
+      const typeRegistry = new Map([["flags", { baseType: "u8" }]]);
+      const deps = createMockDeps({
+        typeRegistry,
+        generateExpression: vi.fn().mockReturnValue("0"),
+      });
+      const ctx = createMockContext({
+        generatedValue: "true",
+      });
+
+      const result = getHandler()!(ctx, deps);
+
+      expect(result).toContain("| (1 << 0)");
+    });
+
+    it("converts false to 0", () => {
+      const typeRegistry = new Map([["flags", { baseType: "u8" }]]);
+      const deps = createMockDeps({
+        typeRegistry,
+        generateExpression: vi.fn().mockReturnValue("0"),
+      });
+      const ctx = createMockContext({
+        generatedValue: "false",
+      });
+
+      const result = getHandler()!(ctx, deps);
+
+      expect(result).toContain("| (0 << 0)");
+    });
+
+    it("delegates to float bit write for float types", () => {
+      const typeRegistry = new Map([["f", { baseType: "f32" }]]);
+      const generateFloatBitWrite = vi
+        .fn()
+        .mockReturnValue("float_bit_write_result");
+      const deps = createMockDeps({
+        typeRegistry,
+        generateFloatBitWrite,
+        generateExpression: vi.fn().mockReturnValue("3"),
+      });
+      const ctx = createMockContext({
+        identifiers: ["f"],
+      });
+
+      const result = getHandler()!(ctx, deps);
+
+      expect(generateFloatBitWrite).toHaveBeenCalled();
+      expect(result).toBe("float_bit_write_result");
+    });
+
+    it("throws on compound assignment", () => {
+      const deps = createMockDeps();
+      const ctx = createMockContext({
+        isCompound: true,
+        cnextOp: "+<-",
+      });
+
+      expect(() => getHandler()!(ctx, deps)).toThrow(
+        "Compound assignment operators not supported for bit field access",
+      );
+    });
+  });
+
+  describe("handleIntegerBitRange (INTEGER_BIT_RANGE)", () => {
+    const getHandler = () =>
+      bitAccessHandlers.find(
+        ([kind]) => kind === AssignmentKind.INTEGER_BIT_RANGE,
+      )?.[1];
+
+    it("generates bit range read-modify-write", () => {
+      const typeRegistry = new Map([["flags", { baseType: "u32" }]]);
+      const deps = createMockDeps({
+        typeRegistry,
+        generateExpression: vi
+          .fn()
+          .mockReturnValueOnce("0")
+          .mockReturnValueOnce("4"),
+      });
+      const ctx = createMockContext({
+        subscripts: [{ mockValue: "0" } as never, { mockValue: "4" } as never],
+        generatedValue: "5",
+      });
+
+      const result = getHandler()!(ctx, deps);
+
+      expect(result).toContain("flags =");
+      expect(result).toContain("& ~(");
+      expect(result).toContain("<< 0");
+    });
+
+    it("uses correct mask for bit range", () => {
+      const typeRegistry = new Map([["data", { baseType: "u16" }]]);
+      const deps = createMockDeps({
+        typeRegistry,
+        generateExpression: vi
+          .fn()
+          .mockReturnValueOnce("4")
+          .mockReturnValueOnce("8"),
+      });
+      const ctx = createMockContext({
+        identifiers: ["data"],
+        subscripts: [{ mockValue: "4" } as never, { mockValue: "8" } as never],
+        generatedValue: "value",
+      });
+
+      const result = getHandler()!(ctx, deps);
+
+      // For constant width, BitUtils generates hex mask
+      expect(result).toContain("0xFFU");
+      expect(result).toContain("<< 4");
+    });
+
+    it("uses ULL suffix for 64-bit bit range mask", () => {
+      const typeRegistry = new Map([["flags", { baseType: "u64" }]]);
+      const deps = createMockDeps({
+        typeRegistry,
+        generateExpression: vi
+          .fn()
+          .mockReturnValueOnce("32")
+          .mockReturnValueOnce("16"),
+      });
+      const ctx = createMockContext({
+        subscripts: [
+          { mockValue: "32" } as never,
+          { mockValue: "16" } as never,
+        ],
+        generatedValue: "value",
+      });
+
+      const result = getHandler()!(ctx, deps);
+
+      // 64-bit type uses ULL suffix on the hex mask
+      expect(result).toContain("0xFFFFULL");
+    });
+
+    it("delegates to float bit write for float types", () => {
+      const typeRegistry = new Map([["f", { baseType: "f32" }]]);
+      const generateFloatBitWrite = vi
+        .fn()
+        .mockReturnValue("float_range_write_result");
+      const deps = createMockDeps({
+        typeRegistry,
+        generateFloatBitWrite,
+        generateExpression: vi
+          .fn()
+          .mockReturnValueOnce("0")
+          .mockReturnValueOnce("8"),
+      });
+      const ctx = createMockContext({
+        identifiers: ["f"],
+        subscripts: [{ mockValue: "0" } as never, { mockValue: "8" } as never],
+      });
+
+      const result = getHandler()!(ctx, deps);
+
+      expect(generateFloatBitWrite).toHaveBeenCalledWith(
+        "f",
+        expect.anything(),
+        "0",
+        "8",
+        "true",
+      );
+      expect(result).toBe("float_range_write_result");
+    });
+
+    it("throws on compound assignment", () => {
+      const deps = createMockDeps();
+      const ctx = createMockContext({
+        isCompound: true,
+        cnextOp: "+<-",
+        subscripts: [{ mockValue: "0" } as never, { mockValue: "8" } as never],
+      });
+
+      expect(() => getHandler()!(ctx, deps)).toThrow(
+        "Compound assignment operators not supported for bit field access",
+      );
+    });
+  });
+
+  describe("handleStructMemberBit (STRUCT_MEMBER_BIT)", () => {
+    const getHandler = () =>
+      bitAccessHandlers.find(
+        ([kind]) => kind === AssignmentKind.STRUCT_MEMBER_BIT,
+      )?.[1];
+
+    it("generates struct member bit assignment", () => {
+      const deps = createMockDeps({
+        generateAssignmentTarget: vi.fn().mockReturnValue("item.byte"),
+        generateExpression: vi.fn().mockReturnValue("7"),
+      });
+      const ctx = createMockContext({
+        identifiers: ["item", "byte"],
+        subscripts: [{ mockValue: "7" } as never],
+      });
+
+      const result = getHandler()!(ctx, deps);
+
+      expect(result).toContain("item.byte =");
+      expect(result).toContain("& ~(1 << 7)");
+      expect(result).toContain("1 << 7");
+    });
+
+    it("throws on compound assignment", () => {
+      const deps = createMockDeps();
+      const ctx = createMockContext({
+        isCompound: true,
+        cnextOp: "+<-",
+      });
+
+      expect(() => getHandler()!(ctx, deps)).toThrow(
+        "Compound assignment operators not supported for bit field access",
+      );
+    });
+  });
+
+  describe("handleArrayElementBit (ARRAY_ELEMENT_BIT)", () => {
+    const getHandler = () =>
+      bitAccessHandlers.find(
+        ([kind]) => kind === AssignmentKind.ARRAY_ELEMENT_BIT,
+      )?.[1];
+
+    it("generates array element bit assignment for 1D array", () => {
+      const typeRegistry = new Map([
+        ["arr", { baseType: "u32", arrayDimensions: [10] }],
+      ]);
+      const deps = createMockDeps({
+        typeRegistry,
+        generateExpression: vi
+          .fn()
+          .mockReturnValueOnce("i")
+          .mockReturnValueOnce("BIT"),
+      });
+      const ctx = createMockContext({
+        identifiers: ["arr"],
+        subscripts: [
+          { mockValue: "i" } as never,
+          { mockValue: "BIT" } as never,
+        ],
+      });
+
+      const result = getHandler()!(ctx, deps);
+
+      expect(result).toContain("arr[i] =");
+      expect(result).toContain("& ~(1 << BIT)");
+    });
+
+    it("generates array element bit assignment for 2D array", () => {
+      const typeRegistry = new Map([
+        ["matrix", { baseType: "u16", arrayDimensions: [10, 10] }],
+      ]);
+      const deps = createMockDeps({
+        typeRegistry,
+        generateExpression: vi
+          .fn()
+          .mockReturnValueOnce("i")
+          .mockReturnValueOnce("j")
+          .mockReturnValueOnce("FIELD_BIT"),
+      });
+      const ctx = createMockContext({
+        identifiers: ["matrix"],
+        subscripts: [
+          { mockValue: "i" } as never,
+          { mockValue: "j" } as never,
+          { mockValue: "FIELD_BIT" } as never,
+        ],
+      });
+
+      const result = getHandler()!(ctx, deps);
+
+      expect(result).toContain("matrix[i][j] =");
+      expect(result).toContain("& ~(1 << FIELD_BIT)");
+    });
+
+    it("uses 1ULL for 64-bit array element", () => {
+      const typeRegistry = new Map([
+        ["arr", { baseType: "u64", arrayDimensions: [5] }],
+      ]);
+      const deps = createMockDeps({
+        typeRegistry,
+        generateExpression: vi
+          .fn()
+          .mockReturnValueOnce("0")
+          .mockReturnValueOnce("40"),
+      });
+      const ctx = createMockContext({
+        identifiers: ["arr"],
+        subscripts: [{ mockValue: "0" } as never, { mockValue: "40" } as never],
+      });
+
+      const result = getHandler()!(ctx, deps);
+
+      expect(result).toContain("1ULL << 40");
+    });
+
+    it("throws when variable is not an array", () => {
+      const typeRegistry = new Map([["notArray", { baseType: "u32" }]]);
+      const deps = createMockDeps({
+        typeRegistry,
+      });
+      const ctx = createMockContext({
+        identifiers: ["notArray"],
+      });
+
+      expect(() => getHandler()!(ctx, deps)).toThrow(
+        "notArray is not an array",
+      );
+    });
+
+    it("throws on compound assignment", () => {
+      const typeRegistry = new Map([
+        ["arr", { baseType: "u32", arrayDimensions: [10] }],
+      ]);
+      const deps = createMockDeps({
+        typeRegistry,
+      });
+      const ctx = createMockContext({
+        isCompound: true,
+        cnextOp: "+<-",
+      });
+
+      expect(() => getHandler()!(ctx, deps)).toThrow(
+        "Compound assignment operators not supported for bit field access",
+      );
+    });
+  });
+});

--- a/src/transpiler/output/codegen/assignment/handlers/__tests__/BitmapHandlers.test.ts
+++ b/src/transpiler/output/codegen/assignment/handlers/__tests__/BitmapHandlers.test.ts
@@ -1,0 +1,595 @@
+/**
+ * Unit tests for BitmapHandlers.
+ * Tests bitmap field assignment handler functions.
+ */
+
+import { describe, expect, it, vi } from "vitest";
+import bitmapHandlers from "../BitmapHandlers";
+import AssignmentKind from "../../AssignmentKind";
+import IAssignmentContext from "../../IAssignmentContext";
+import IHandlerDeps from "../IHandlerDeps";
+
+/**
+ * Create mock dependencies for testing.
+ */
+function createMockDeps(overrides: Record<string, unknown> = {}): IHandlerDeps {
+  const base = {
+    typeRegistry: new Map(),
+    symbols: {
+      structFields: new Map(),
+      structFieldDimensions: new Map(),
+      bitmapFields: new Map(),
+      registerMemberAccess: new Map(),
+      registerBaseAddresses: new Map(),
+      registerMemberOffsets: new Map(),
+      registerMemberTypes: new Map(),
+    },
+    currentScope: null,
+    currentParameters: new Map(),
+    targetCapabilities: { hasLDREX: false },
+    generateAssignmentTarget: vi.fn().mockReturnValue("target"),
+    generateExpression: vi
+      .fn()
+      .mockImplementation((ctx) => ctx?.mockValue ?? "0"),
+    markNeedsString: vi.fn(),
+    markClampOpUsed: vi.fn(),
+    isKnownScope: vi.fn().mockReturnValue(false),
+    isKnownStruct: vi.fn().mockReturnValue(false),
+    validateCrossScopeVisibility: vi.fn(),
+    validateBitmapFieldLiteral: vi.fn(),
+    checkArrayBounds: vi.fn(),
+    analyzeMemberChainForBitAccess: vi
+      .fn()
+      .mockReturnValue({ isBitAccess: false }),
+    tryEvaluateConstant: vi.fn().mockReturnValue(undefined),
+    getMemberTypeInfo: vi.fn().mockReturnValue(null),
+    generateFloatBitWrite: vi.fn().mockReturnValue(null),
+    foldBooleanToInt: vi.fn().mockImplementation((expr) => expr),
+    generateAtomicRMW: vi.fn().mockReturnValue("atomic_rmw"),
+    ...overrides,
+  };
+  return base as unknown as IHandlerDeps;
+}
+
+/**
+ * Create mock context for testing.
+ */
+function createMockContext(
+  overrides: Partial<IAssignmentContext> = {},
+): IAssignmentContext {
+  return {
+    identifiers: ["flags", "Running"],
+    subscripts: [],
+    isCompound: false,
+    cnextOp: "<-",
+    cOp: "=",
+    generatedValue: "true",
+    targetCtx: {} as never,
+    valueCtx: {} as never,
+    hasThis: false,
+    hasGlobal: false,
+    hasMemberAccess: true,
+    hasArrayAccess: false,
+    postfixOpsCount: 1,
+    memberAccessDepth: 1,
+    subscriptDepth: 0,
+    isSimpleIdentifier: false,
+    isSimpleThisAccess: false,
+    isSimpleGlobalAccess: false,
+    ...overrides,
+  } as IAssignmentContext;
+}
+
+describe("BitmapHandlers", () => {
+  describe("handler registration", () => {
+    it("registers all expected bitmap assignment kinds", () => {
+      const kinds = bitmapHandlers.map(([kind]) => kind);
+
+      expect(kinds).toContain(AssignmentKind.BITMAP_FIELD_SINGLE_BIT);
+      expect(kinds).toContain(AssignmentKind.BITMAP_FIELD_MULTI_BIT);
+      expect(kinds).toContain(AssignmentKind.BITMAP_ARRAY_ELEMENT_FIELD);
+      expect(kinds).toContain(AssignmentKind.STRUCT_MEMBER_BITMAP_FIELD);
+      expect(kinds).toContain(AssignmentKind.REGISTER_MEMBER_BITMAP_FIELD);
+      expect(kinds).toContain(
+        AssignmentKind.SCOPED_REGISTER_MEMBER_BITMAP_FIELD,
+      );
+    });
+
+    it("exports exactly 6 handlers", () => {
+      expect(bitmapHandlers.length).toBe(6);
+    });
+  });
+
+  describe("handleBitmapFieldSingleBit (BITMAP_FIELD_SINGLE_BIT)", () => {
+    const getHandler = () =>
+      bitmapHandlers.find(
+        ([kind]) => kind === AssignmentKind.BITMAP_FIELD_SINGLE_BIT,
+      )?.[1];
+
+    it("generates single-bit read-modify-write", () => {
+      const typeRegistry = new Map([
+        ["flags", { bitmapTypeName: "StatusFlags", baseType: "u8" }],
+      ]);
+      const bitmapFields = new Map([
+        ["StatusFlags", new Map([["Running", { offset: 0, width: 1 }]])],
+      ]);
+      const deps = createMockDeps({
+        typeRegistry,
+        symbols: {
+          structFields: new Map(),
+          structFieldDimensions: new Map(),
+          bitmapFields,
+          registerMemberAccess: new Map(),
+          registerBaseAddresses: new Map(),
+          registerMemberOffsets: new Map(),
+          registerMemberTypes: new Map(),
+        },
+      });
+      const ctx = createMockContext();
+
+      const result = getHandler()!(ctx, deps);
+
+      expect(result).toContain("flags =");
+      expect(result).toContain("& ~(1 << 0)");
+      expect(result).toContain("<< 0");
+    });
+
+    it("generates single-bit write with correct offset", () => {
+      const typeRegistry = new Map([
+        ["flags", { bitmapTypeName: "StatusFlags", baseType: "u8" }],
+      ]);
+      const bitmapFields = new Map([
+        ["StatusFlags", new Map([["Active", { offset: 3, width: 1 }]])],
+      ]);
+      const deps = createMockDeps({
+        typeRegistry,
+        symbols: {
+          structFields: new Map(),
+          structFieldDimensions: new Map(),
+          bitmapFields,
+          registerMemberAccess: new Map(),
+          registerBaseAddresses: new Map(),
+          registerMemberOffsets: new Map(),
+          registerMemberTypes: new Map(),
+        },
+      });
+      const ctx = createMockContext({
+        identifiers: ["flags", "Active"],
+      });
+
+      const result = getHandler()!(ctx, deps);
+
+      expect(result).toContain("<< 3");
+    });
+
+    it("throws on unknown bitmap field", () => {
+      const typeRegistry = new Map([
+        ["flags", { bitmapTypeName: "StatusFlags", baseType: "u8" }],
+      ]);
+      const bitmapFields = new Map([["StatusFlags", new Map()]]);
+      const deps = createMockDeps({
+        typeRegistry,
+        symbols: {
+          structFields: new Map(),
+          structFieldDimensions: new Map(),
+          bitmapFields,
+          registerMemberAccess: new Map(),
+          registerBaseAddresses: new Map(),
+          registerMemberOffsets: new Map(),
+          registerMemberTypes: new Map(),
+        },
+      });
+      const ctx = createMockContext({
+        identifiers: ["flags", "Unknown"],
+      });
+
+      expect(() => getHandler()!(ctx, deps)).toThrow(
+        "Unknown bitmap field 'Unknown' on type 'StatusFlags'",
+      );
+    });
+
+    it("throws on compound assignment", () => {
+      const typeRegistry = new Map([
+        ["flags", { bitmapTypeName: "StatusFlags", baseType: "u8" }],
+      ]);
+      const bitmapFields = new Map([
+        ["StatusFlags", new Map([["Running", { offset: 0, width: 1 }]])],
+      ]);
+      const deps = createMockDeps({
+        typeRegistry,
+        symbols: {
+          structFields: new Map(),
+          structFieldDimensions: new Map(),
+          bitmapFields,
+          registerMemberAccess: new Map(),
+          registerBaseAddresses: new Map(),
+          registerMemberOffsets: new Map(),
+          registerMemberTypes: new Map(),
+        },
+      });
+      const ctx = createMockContext({
+        isCompound: true,
+        cnextOp: "+<-",
+      });
+
+      expect(() => getHandler()!(ctx, deps)).toThrow(
+        "Compound assignment operators not supported for bitmap field access",
+      );
+    });
+
+    it("validates bitmap field literal", () => {
+      const typeRegistry = new Map([
+        ["flags", { bitmapTypeName: "StatusFlags", baseType: "u8" }],
+      ]);
+      const bitmapFields = new Map([
+        ["StatusFlags", new Map([["Running", { offset: 0, width: 1 }]])],
+      ]);
+      const validateBitmapFieldLiteral = vi.fn();
+      const deps = createMockDeps({
+        typeRegistry,
+        validateBitmapFieldLiteral,
+        symbols: {
+          structFields: new Map(),
+          structFieldDimensions: new Map(),
+          bitmapFields,
+          registerMemberAccess: new Map(),
+          registerBaseAddresses: new Map(),
+          registerMemberOffsets: new Map(),
+          registerMemberTypes: new Map(),
+        },
+      });
+      const ctx = createMockContext();
+
+      getHandler()!(ctx, deps);
+
+      expect(validateBitmapFieldLiteral).toHaveBeenCalledWith(
+        ctx.valueCtx,
+        1,
+        "Running",
+      );
+    });
+  });
+
+  describe("handleBitmapFieldMultiBit (BITMAP_FIELD_MULTI_BIT)", () => {
+    const getHandler = () =>
+      bitmapHandlers.find(
+        ([kind]) => kind === AssignmentKind.BITMAP_FIELD_MULTI_BIT,
+      )?.[1];
+
+    it("generates multi-bit read-modify-write with mask", () => {
+      const typeRegistry = new Map([
+        ["flags", { bitmapTypeName: "StatusFlags", baseType: "u8" }],
+      ]);
+      const bitmapFields = new Map([
+        ["StatusFlags", new Map([["Mode", { offset: 4, width: 3 }]])],
+      ]);
+      const deps = createMockDeps({
+        typeRegistry,
+        symbols: {
+          structFields: new Map(),
+          structFieldDimensions: new Map(),
+          bitmapFields,
+          registerMemberAccess: new Map(),
+          registerBaseAddresses: new Map(),
+          registerMemberOffsets: new Map(),
+          registerMemberTypes: new Map(),
+        },
+      });
+      const ctx = createMockContext({
+        identifiers: ["flags", "Mode"],
+        generatedValue: "3",
+      });
+
+      const result = getHandler()!(ctx, deps);
+
+      expect(result).toContain("flags =");
+      expect(result).toContain("& ~(0x7 << 4)");
+      expect(result).toContain("(3 & 0x7)");
+      expect(result).toContain("<< 4");
+    });
+
+    it("generates correct mask for 2-bit field", () => {
+      const typeRegistry = new Map([
+        ["config", { bitmapTypeName: "Config", baseType: "u8" }],
+      ]);
+      const bitmapFields = new Map([
+        ["Config", new Map([["Priority", { offset: 0, width: 2 }]])],
+      ]);
+      const deps = createMockDeps({
+        typeRegistry,
+        symbols: {
+          structFields: new Map(),
+          structFieldDimensions: new Map(),
+          bitmapFields,
+          registerMemberAccess: new Map(),
+          registerBaseAddresses: new Map(),
+          registerMemberOffsets: new Map(),
+          registerMemberTypes: new Map(),
+        },
+      });
+      const ctx = createMockContext({
+        identifiers: ["config", "Priority"],
+        generatedValue: "2",
+      });
+
+      const result = getHandler()!(ctx, deps);
+
+      expect(result).toContain("0x3");
+    });
+  });
+
+  describe("handleBitmapArrayElementField (BITMAP_ARRAY_ELEMENT_FIELD)", () => {
+    const getHandler = () =>
+      bitmapHandlers.find(
+        ([kind]) => kind === AssignmentKind.BITMAP_ARRAY_ELEMENT_FIELD,
+      )?.[1];
+
+    it("generates array element bitmap field assignment", () => {
+      const typeRegistry = new Map([
+        ["flagsArray", { bitmapTypeName: "StatusFlags", baseType: "u8" }],
+      ]);
+      const bitmapFields = new Map([
+        ["StatusFlags", new Map([["Active", { offset: 0, width: 1 }]])],
+      ]);
+      const deps = createMockDeps({
+        typeRegistry,
+        generateExpression: vi.fn().mockReturnValue("i"),
+        symbols: {
+          structFields: new Map(),
+          structFieldDimensions: new Map(),
+          bitmapFields,
+          registerMemberAccess: new Map(),
+          registerBaseAddresses: new Map(),
+          registerMemberOffsets: new Map(),
+          registerMemberTypes: new Map(),
+        },
+      });
+      const ctx = createMockContext({
+        identifiers: ["flagsArray", "Active"],
+        subscripts: [{ mockValue: "i" } as never],
+      });
+
+      const result = getHandler()!(ctx, deps);
+
+      expect(result).toContain("flagsArray[i] =");
+      expect(result).toContain("& ~(1 << 0)");
+    });
+  });
+
+  describe("handleStructMemberBitmapField (STRUCT_MEMBER_BITMAP_FIELD)", () => {
+    const getHandler = () =>
+      bitmapHandlers.find(
+        ([kind]) => kind === AssignmentKind.STRUCT_MEMBER_BITMAP_FIELD,
+      )?.[1];
+
+    it("generates struct member bitmap field assignment", () => {
+      const typeRegistry = new Map([["device", { baseType: "Device" }]]);
+      const bitmapFields = new Map([
+        ["StatusFlags", new Map([["Active", { offset: 2, width: 1 }]])],
+      ]);
+      const deps = createMockDeps({
+        typeRegistry,
+        getMemberTypeInfo: vi.fn().mockReturnValue({ baseType: "StatusFlags" }),
+        symbols: {
+          structFields: new Map(),
+          structFieldDimensions: new Map(),
+          bitmapFields,
+          registerMemberAccess: new Map(),
+          registerBaseAddresses: new Map(),
+          registerMemberOffsets: new Map(),
+          registerMemberTypes: new Map(),
+        },
+      });
+      const ctx = createMockContext({
+        identifiers: ["device", "flags", "Active"],
+      });
+
+      const result = getHandler()!(ctx, deps);
+
+      expect(result).toContain("device.flags =");
+      expect(result).toContain("<< 2");
+    });
+  });
+
+  describe("handleRegisterMemberBitmapField (REGISTER_MEMBER_BITMAP_FIELD)", () => {
+    const getHandler = () =>
+      bitmapHandlers.find(
+        ([kind]) => kind === AssignmentKind.REGISTER_MEMBER_BITMAP_FIELD,
+      )?.[1];
+
+    it("generates register member bitmap field assignment", () => {
+      const bitmapFields = new Map([
+        ["MotorCtrl", new Map([["Running", { offset: 0, width: 1 }]])],
+      ]);
+      const registerMemberTypes = new Map([["MOTOR_CTRL", "MotorCtrl"]]);
+      const deps = createMockDeps({
+        symbols: {
+          structFields: new Map(),
+          structFieldDimensions: new Map(),
+          bitmapFields,
+          registerMemberAccess: new Map(),
+          registerBaseAddresses: new Map(),
+          registerMemberOffsets: new Map(),
+          registerMemberTypes,
+        },
+      });
+      const ctx = createMockContext({
+        identifiers: ["MOTOR", "CTRL", "Running"],
+      });
+
+      const result = getHandler()!(ctx, deps);
+
+      expect(result).toContain("MOTOR_CTRL =");
+      expect(result).toContain("& ~(1 << 0)");
+    });
+  });
+
+  describe("handleScopedRegisterMemberBitmapField (SCOPED_REGISTER_MEMBER_BITMAP_FIELD)", () => {
+    const getHandler = () =>
+      bitmapHandlers.find(
+        ([kind]) => kind === AssignmentKind.SCOPED_REGISTER_MEMBER_BITMAP_FIELD,
+      )?.[1];
+
+    it("generates this-prefixed scoped register bitmap field", () => {
+      const bitmapFields = new Map([
+        ["ICR1Bits", new Map([["LED", { offset: 6, width: 2 }]])],
+      ]);
+      const registerMemberTypes = new Map([["Motor_GPIO7_ICR1", "ICR1Bits"]]);
+      const deps = createMockDeps({
+        currentScope: "Motor",
+        symbols: {
+          structFields: new Map(),
+          structFieldDimensions: new Map(),
+          bitmapFields,
+          registerMemberAccess: new Map(),
+          registerBaseAddresses: new Map(),
+          registerMemberOffsets: new Map(),
+          registerMemberTypes,
+        },
+      });
+      const ctx = createMockContext({
+        identifiers: ["GPIO7", "ICR1", "LED"],
+        hasThis: true,
+        generatedValue: "value",
+      });
+
+      const result = getHandler()!(ctx, deps);
+
+      expect(result).toContain("Motor_GPIO7_ICR1 =");
+      expect(result).toContain("<< 6");
+    });
+
+    it("generates scope-prefixed register bitmap field", () => {
+      const bitmapFields = new Map([
+        ["ICR1Bits", new Map([["LED", { offset: 6, width: 2 }]])],
+      ]);
+      const registerMemberTypes = new Map([["Motor_GPIO7_ICR1", "ICR1Bits"]]);
+      const validateCrossScopeVisibility = vi.fn();
+      const deps = createMockDeps({
+        validateCrossScopeVisibility,
+        symbols: {
+          structFields: new Map(),
+          structFieldDimensions: new Map(),
+          bitmapFields,
+          registerMemberAccess: new Map(),
+          registerBaseAddresses: new Map(),
+          registerMemberOffsets: new Map(),
+          registerMemberTypes,
+        },
+      });
+      const ctx = createMockContext({
+        identifiers: ["Motor", "GPIO7", "ICR1", "LED"],
+        hasThis: false,
+        generatedValue: "value",
+      });
+
+      const result = getHandler()!(ctx, deps);
+
+      expect(result).toContain("Motor_GPIO7_ICR1 =");
+      expect(validateCrossScopeVisibility).toHaveBeenCalledWith(
+        "Motor",
+        "GPIO7",
+      );
+    });
+
+    it("throws when 'this' used outside scope", () => {
+      const deps = createMockDeps({ currentScope: null });
+      const ctx = createMockContext({
+        identifiers: ["GPIO7", "ICR1", "LED"],
+        hasThis: true,
+      });
+
+      expect(() => getHandler()!(ctx, deps)).toThrow(
+        "'this' can only be used inside a scope",
+      );
+    });
+
+    it("generates write-only pattern for wo register", () => {
+      const bitmapFields = new Map([
+        ["SetBits", new Map([["LED", { offset: 0, width: 1 }]])],
+      ]);
+      const registerMemberTypes = new Map([["Motor_GPIO7_SET", "SetBits"]]);
+      const registerMemberAccess = new Map([["Motor_GPIO7_SET", "wo"]]);
+      const deps = createMockDeps({
+        currentScope: "Motor",
+        symbols: {
+          structFields: new Map(),
+          structFieldDimensions: new Map(),
+          bitmapFields,
+          registerMemberAccess,
+          registerBaseAddresses: new Map(),
+          registerMemberOffsets: new Map(),
+          registerMemberTypes,
+        },
+      });
+      const ctx = createMockContext({
+        identifiers: ["GPIO7", "SET", "LED"],
+        hasThis: true,
+      });
+
+      const result = getHandler()!(ctx, deps);
+
+      // Write-only should not use RMW pattern
+      expect(result).not.toContain("& ~");
+      expect(result).toContain("Motor_GPIO7_SET =");
+    });
+
+    it("generates write-only pattern for w1s register", () => {
+      const bitmapFields = new Map([
+        ["SetBits", new Map([["LED", { offset: 3, width: 1 }]])],
+      ]);
+      const registerMemberTypes = new Map([["Motor_GPIO7_SET", "SetBits"]]);
+      const registerMemberAccess = new Map([["Motor_GPIO7_SET", "w1s"]]);
+      const deps = createMockDeps({
+        currentScope: "Motor",
+        symbols: {
+          structFields: new Map(),
+          structFieldDimensions: new Map(),
+          bitmapFields,
+          registerMemberAccess,
+          registerBaseAddresses: new Map(),
+          registerMemberOffsets: new Map(),
+          registerMemberTypes,
+        },
+      });
+      const ctx = createMockContext({
+        identifiers: ["GPIO7", "SET", "LED"],
+        hasThis: true,
+      });
+
+      const result = getHandler()!(ctx, deps);
+
+      expect(result).not.toContain("& ~");
+      expect(result).toContain("<< 3");
+    });
+
+    it("generates write-only pattern for w1c register", () => {
+      const bitmapFields = new Map([
+        ["ClearBits", new Map([["LED", { offset: 5, width: 1 }]])],
+      ]);
+      const registerMemberTypes = new Map([["Motor_GPIO7_CLR", "ClearBits"]]);
+      const registerMemberAccess = new Map([["Motor_GPIO7_CLR", "w1c"]]);
+      const deps = createMockDeps({
+        currentScope: "Motor",
+        symbols: {
+          structFields: new Map(),
+          structFieldDimensions: new Map(),
+          bitmapFields,
+          registerMemberAccess,
+          registerBaseAddresses: new Map(),
+          registerMemberOffsets: new Map(),
+          registerMemberTypes,
+        },
+      });
+      const ctx = createMockContext({
+        identifiers: ["GPIO7", "CLR", "LED"],
+        hasThis: true,
+      });
+
+      const result = getHandler()!(ctx, deps);
+
+      expect(result).not.toContain("& ~");
+      expect(result).toContain("<< 5");
+    });
+  });
+});

--- a/src/transpiler/output/codegen/assignment/handlers/__tests__/RegisterHandlers.test.ts
+++ b/src/transpiler/output/codegen/assignment/handlers/__tests__/RegisterHandlers.test.ts
@@ -1,0 +1,614 @@
+/**
+ * Unit tests for RegisterHandlers.
+ * Tests register bit assignment handler functions.
+ */
+
+import { describe, expect, it, vi } from "vitest";
+import registerHandlers from "../RegisterHandlers";
+import AssignmentKind from "../../AssignmentKind";
+import IAssignmentContext from "../../IAssignmentContext";
+import IHandlerDeps from "../IHandlerDeps";
+
+/**
+ * Create mock dependencies for testing.
+ */
+function createMockDeps(overrides: Record<string, unknown> = {}): IHandlerDeps {
+  const base = {
+    typeRegistry: new Map(),
+    symbols: {
+      structFields: new Map(),
+      structFieldDimensions: new Map(),
+      bitmapFields: new Map(),
+      registerMemberAccess: new Map(),
+      registerBaseAddresses: new Map(),
+      registerMemberOffsets: new Map(),
+      registerMemberTypes: new Map(),
+    },
+    currentScope: null,
+    currentParameters: new Map(),
+    targetCapabilities: { hasLDREX: false },
+    generateAssignmentTarget: vi.fn().mockReturnValue("target"),
+    generateExpression: vi
+      .fn()
+      .mockImplementation((ctx) => ctx?.mockValue ?? "0"),
+    markNeedsString: vi.fn(),
+    markClampOpUsed: vi.fn(),
+    isKnownScope: vi.fn().mockReturnValue(false),
+    isKnownStruct: vi.fn().mockReturnValue(false),
+    validateCrossScopeVisibility: vi.fn(),
+    validateBitmapFieldLiteral: vi.fn(),
+    checkArrayBounds: vi.fn(),
+    analyzeMemberChainForBitAccess: vi
+      .fn()
+      .mockReturnValue({ isBitAccess: false }),
+    tryEvaluateConstant: vi.fn().mockReturnValue(undefined),
+    getMemberTypeInfo: vi.fn().mockReturnValue(null),
+    generateFloatBitWrite: vi.fn().mockReturnValue(null),
+    foldBooleanToInt: vi.fn().mockImplementation((expr) => expr),
+    generateAtomicRMW: vi.fn().mockReturnValue("atomic_rmw"),
+    ...overrides,
+  };
+  return base as unknown as IHandlerDeps;
+}
+
+/**
+ * Create mock context for testing.
+ */
+function createMockContext(
+  overrides: Partial<IAssignmentContext> = {},
+): IAssignmentContext {
+  return {
+    identifiers: ["GPIO7", "DR_SET"],
+    subscripts: [{ mockValue: "LED_BIT" } as never],
+    isCompound: false,
+    cnextOp: "<-",
+    cOp: "=",
+    generatedValue: "true",
+    targetCtx: {} as never,
+    hasThis: false,
+    hasGlobal: false,
+    hasMemberAccess: true,
+    hasArrayAccess: true,
+    postfixOpsCount: 2,
+    memberAccessDepth: 1,
+    subscriptDepth: 1,
+    isSimpleIdentifier: false,
+    isSimpleThisAccess: false,
+    isSimpleGlobalAccess: false,
+    ...overrides,
+  } as IAssignmentContext;
+}
+
+describe("RegisterHandlers", () => {
+  describe("handler registration", () => {
+    it("registers all expected register assignment kinds", () => {
+      const kinds = registerHandlers.map(([kind]) => kind);
+
+      expect(kinds).toContain(AssignmentKind.REGISTER_BIT);
+      expect(kinds).toContain(AssignmentKind.REGISTER_BIT_RANGE);
+      expect(kinds).toContain(AssignmentKind.SCOPED_REGISTER_BIT);
+      expect(kinds).toContain(AssignmentKind.SCOPED_REGISTER_BIT_RANGE);
+    });
+
+    it("exports exactly 4 handlers", () => {
+      expect(registerHandlers.length).toBe(4);
+    });
+  });
+
+  describe("handleRegisterBit (REGISTER_BIT)", () => {
+    const getHandler = () =>
+      registerHandlers.find(
+        ([kind]) => kind === AssignmentKind.REGISTER_BIT,
+      )?.[1];
+
+    it("generates read-modify-write for read-write register", () => {
+      const deps = createMockDeps({
+        generateExpression: vi.fn().mockReturnValue("LED_BIT"),
+      });
+      const ctx = createMockContext();
+
+      const result = getHandler()!(ctx, deps);
+
+      expect(result).toContain("GPIO7_DR_SET");
+      expect(result).toContain("& ~(1 <<");
+      expect(result).toContain("LED_BIT");
+    });
+
+    it("generates simple write for write-only register", () => {
+      const registerMemberAccess = new Map([["GPIO7_DR_SET", "wo"]]);
+      const deps = createMockDeps({
+        generateExpression: vi.fn().mockReturnValue("LED_BIT"),
+        symbols: {
+          structFields: new Map(),
+          structFieldDimensions: new Map(),
+          bitmapFields: new Map(),
+          registerMemberAccess,
+          registerBaseAddresses: new Map(),
+          registerMemberOffsets: new Map(),
+          registerMemberTypes: new Map(),
+        },
+      });
+      const ctx = createMockContext();
+
+      const result = getHandler()!(ctx, deps);
+
+      expect(result).toBe("GPIO7_DR_SET = (1 << LED_BIT);");
+    });
+
+    it("throws on write-only register with false value", () => {
+      const registerMemberAccess = new Map([["GPIO7_DR_SET", "wo"]]);
+      const deps = createMockDeps({
+        generateExpression: vi.fn().mockReturnValue("LED_BIT"),
+        symbols: {
+          structFields: new Map(),
+          structFieldDimensions: new Map(),
+          bitmapFields: new Map(),
+          registerMemberAccess,
+          registerBaseAddresses: new Map(),
+          registerMemberOffsets: new Map(),
+          registerMemberTypes: new Map(),
+        },
+      });
+      const ctx = createMockContext({ generatedValue: "false" });
+
+      expect(() => getHandler()!(ctx, deps)).toThrow(
+        "Cannot assign false to write-only register bit",
+      );
+    });
+
+    it("throws on write-only register with 0 value", () => {
+      const registerMemberAccess = new Map([["GPIO7_DR_SET", "w1s"]]);
+      const deps = createMockDeps({
+        generateExpression: vi.fn().mockReturnValue("0"),
+        symbols: {
+          structFields: new Map(),
+          structFieldDimensions: new Map(),
+          bitmapFields: new Map(),
+          registerMemberAccess,
+          registerBaseAddresses: new Map(),
+          registerMemberOffsets: new Map(),
+          registerMemberTypes: new Map(),
+        },
+      });
+      const ctx = createMockContext({ generatedValue: "0" });
+
+      expect(() => getHandler()!(ctx, deps)).toThrow(
+        "Cannot assign false to write-only register bit",
+      );
+    });
+
+    it("throws on compound assignment", () => {
+      const deps = createMockDeps();
+      const ctx = createMockContext({ isCompound: true, cnextOp: "+<-" });
+
+      expect(() => getHandler()!(ctx, deps)).toThrow(
+        "Compound assignment operators not supported for bit field access",
+      );
+    });
+
+    it("handles scoped register prefix correctly", () => {
+      const deps = createMockDeps({
+        generateExpression: vi.fn().mockReturnValue("5"),
+        isKnownScope: vi.fn().mockReturnValue(true),
+      });
+      const ctx = createMockContext({
+        identifiers: ["Motor", "GPIO7", "DR_SET"],
+      });
+
+      const result = getHandler()!(ctx, deps);
+
+      expect(result).toContain("Motor_GPIO7_DR_SET");
+    });
+  });
+
+  describe("handleRegisterBitRange (REGISTER_BIT_RANGE)", () => {
+    const getHandler = () =>
+      registerHandlers.find(
+        ([kind]) => kind === AssignmentKind.REGISTER_BIT_RANGE,
+      )?.[1];
+
+    it("generates read-modify-write for bit range", () => {
+      const deps = createMockDeps({
+        generateExpression: vi
+          .fn()
+          .mockReturnValueOnce("0")
+          .mockReturnValueOnce("8"),
+      });
+      const ctx = createMockContext({
+        subscripts: [{ mockValue: "0" } as never, { mockValue: "8" } as never],
+        generatedValue: "value",
+      });
+
+      const result = getHandler()!(ctx, deps);
+
+      expect(result).toContain("GPIO7_DR_SET");
+      expect(result).toContain("& ~(");
+      expect(result).toContain("<< 0");
+    });
+
+    it("generates simple write for write-only bit range", () => {
+      const registerMemberAccess = new Map([["GPIO7_DR_SET", "wo"]]);
+      const deps = createMockDeps({
+        generateExpression: vi
+          .fn()
+          .mockReturnValueOnce("0")
+          .mockReturnValueOnce("8"),
+        symbols: {
+          structFields: new Map(),
+          structFieldDimensions: new Map(),
+          bitmapFields: new Map(),
+          registerMemberAccess,
+          registerBaseAddresses: new Map(),
+          registerMemberOffsets: new Map(),
+          registerMemberTypes: new Map(),
+        },
+      });
+      const ctx = createMockContext({
+        subscripts: [{ mockValue: "0" } as never, { mockValue: "8" } as never],
+        generatedValue: "value",
+      });
+
+      const result = getHandler()!(ctx, deps);
+
+      expect(result).toContain("GPIO7_DR_SET =");
+      expect(result).toContain("value");
+      expect(result).not.toContain("& ~");
+    });
+
+    it("throws on write-only bit range with 0 value", () => {
+      const registerMemberAccess = new Map([["GPIO7_DR_SET", "w1c"]]);
+      const deps = createMockDeps({
+        generateExpression: vi
+          .fn()
+          .mockReturnValueOnce("0")
+          .mockReturnValueOnce("8"),
+        symbols: {
+          structFields: new Map(),
+          structFieldDimensions: new Map(),
+          bitmapFields: new Map(),
+          registerMemberAccess,
+          registerBaseAddresses: new Map(),
+          registerMemberOffsets: new Map(),
+          registerMemberTypes: new Map(),
+        },
+      });
+      const ctx = createMockContext({
+        subscripts: [{ mockValue: "0" } as never, { mockValue: "8" } as never],
+        generatedValue: "0",
+      });
+
+      expect(() => getHandler()!(ctx, deps)).toThrow(
+        "Cannot assign 0 to write-only register bits",
+      );
+    });
+
+    it("generates MMIO optimization for byte-aligned access", () => {
+      const registerMemberAccess = new Map([["GPIO7_DR_SET", "wo"]]);
+      const registerBaseAddresses = new Map([["GPIO7", "0x40000000"]]);
+      const registerMemberOffsets = new Map([["GPIO7_DR_SET", "0x04"]]);
+
+      const deps = createMockDeps({
+        generateExpression: vi
+          .fn()
+          .mockReturnValueOnce("0")
+          .mockReturnValueOnce("8"),
+        tryEvaluateConstant: vi
+          .fn()
+          .mockReturnValueOnce(0)
+          .mockReturnValueOnce(8),
+        symbols: {
+          structFields: new Map(),
+          structFieldDimensions: new Map(),
+          bitmapFields: new Map(),
+          registerMemberAccess,
+          registerBaseAddresses,
+          registerMemberOffsets,
+          registerMemberTypes: new Map(),
+        },
+      });
+      const ctx = createMockContext({
+        subscripts: [{ mockValue: "0" } as never, { mockValue: "8" } as never],
+        generatedValue: "value",
+      });
+
+      const result = getHandler()!(ctx, deps);
+
+      expect(result).toContain("volatile uint8_t*");
+      expect(result).toContain("0x40000000");
+      expect(result).toContain("0x04");
+    });
+
+    it("generates MMIO with byte offset for non-zero start", () => {
+      const registerMemberAccess = new Map([["GPIO7_DR_SET", "wo"]]);
+      const registerBaseAddresses = new Map([["GPIO7", "0x40000000"]]);
+      const registerMemberOffsets = new Map([["GPIO7_DR_SET", "0x04"]]);
+
+      const deps = createMockDeps({
+        generateExpression: vi
+          .fn()
+          .mockReturnValueOnce("8")
+          .mockReturnValueOnce("16"),
+        tryEvaluateConstant: vi
+          .fn()
+          .mockReturnValueOnce(8)
+          .mockReturnValueOnce(16),
+        symbols: {
+          structFields: new Map(),
+          structFieldDimensions: new Map(),
+          bitmapFields: new Map(),
+          registerMemberAccess,
+          registerBaseAddresses,
+          registerMemberOffsets,
+          registerMemberTypes: new Map(),
+        },
+      });
+      const ctx = createMockContext({
+        subscripts: [{ mockValue: "8" } as never, { mockValue: "16" } as never],
+        generatedValue: "value",
+      });
+
+      const result = getHandler()!(ctx, deps);
+
+      expect(result).toContain("volatile uint16_t*");
+      expect(result).toContain("0x04 + 1");
+    });
+
+    it("throws on compound assignment", () => {
+      const deps = createMockDeps();
+      const ctx = createMockContext({
+        isCompound: true,
+        cnextOp: "+<-",
+        subscripts: [{ mockValue: "0" } as never, { mockValue: "8" } as never],
+      });
+
+      expect(() => getHandler()!(ctx, deps)).toThrow(
+        "Compound assignment operators not supported for bit field access",
+      );
+    });
+  });
+
+  describe("handleScopedRegisterBit (SCOPED_REGISTER_BIT)", () => {
+    const getHandler = () =>
+      registerHandlers.find(
+        ([kind]) => kind === AssignmentKind.SCOPED_REGISTER_BIT,
+      )?.[1];
+
+    it("generates read-modify-write for scoped register bit", () => {
+      const deps = createMockDeps({
+        currentScope: "Motor",
+        generateExpression: vi.fn().mockReturnValue("LED_BIT"),
+      });
+      const ctx = createMockContext({
+        identifiers: ["GPIO7", "DR_SET"],
+        hasThis: true,
+      });
+
+      const result = getHandler()!(ctx, deps);
+
+      expect(result).toContain("Motor_GPIO7_DR_SET");
+      expect(result).toContain("& ~(1 <<");
+    });
+
+    it("generates simple write for write-only scoped register", () => {
+      const registerMemberAccess = new Map([["Motor_GPIO7_DR_SET", "wo"]]);
+      const deps = createMockDeps({
+        currentScope: "Motor",
+        generateExpression: vi.fn().mockReturnValue("LED_BIT"),
+        symbols: {
+          structFields: new Map(),
+          structFieldDimensions: new Map(),
+          bitmapFields: new Map(),
+          registerMemberAccess,
+          registerBaseAddresses: new Map(),
+          registerMemberOffsets: new Map(),
+          registerMemberTypes: new Map(),
+        },
+      });
+      const ctx = createMockContext({
+        identifiers: ["GPIO7", "DR_SET"],
+        hasThis: true,
+      });
+
+      const result = getHandler()!(ctx, deps);
+
+      expect(result).toBe("Motor_GPIO7_DR_SET = (1 << LED_BIT);");
+    });
+
+    it("throws when used outside scope", () => {
+      const deps = createMockDeps({ currentScope: null });
+      const ctx = createMockContext({ hasThis: true });
+
+      expect(() => getHandler()!(ctx, deps)).toThrow(
+        "'this' can only be used inside a scope",
+      );
+    });
+
+    it("throws on compound assignment", () => {
+      const deps = createMockDeps({ currentScope: "Motor" });
+      const ctx = createMockContext({ isCompound: true, cnextOp: "+<-" });
+
+      expect(() => getHandler()!(ctx, deps)).toThrow(
+        "Compound assignment operators not supported for bit field access",
+      );
+    });
+
+    it("throws on write-only register with false value", () => {
+      const registerMemberAccess = new Map([["Motor_GPIO7_DR_SET", "w1s"]]);
+      const deps = createMockDeps({
+        currentScope: "Motor",
+        generateExpression: vi.fn().mockReturnValue("LED_BIT"),
+        symbols: {
+          structFields: new Map(),
+          structFieldDimensions: new Map(),
+          bitmapFields: new Map(),
+          registerMemberAccess,
+          registerBaseAddresses: new Map(),
+          registerMemberOffsets: new Map(),
+          registerMemberTypes: new Map(),
+        },
+      });
+      const ctx = createMockContext({
+        identifiers: ["GPIO7", "DR_SET"],
+        hasThis: true,
+        generatedValue: "false",
+      });
+
+      expect(() => getHandler()!(ctx, deps)).toThrow(
+        "Cannot assign false to write-only register bit",
+      );
+    });
+  });
+
+  describe("handleScopedRegisterBitRange (SCOPED_REGISTER_BIT_RANGE)", () => {
+    const getHandler = () =>
+      registerHandlers.find(
+        ([kind]) => kind === AssignmentKind.SCOPED_REGISTER_BIT_RANGE,
+      )?.[1];
+
+    it("generates read-modify-write for scoped register bit range", () => {
+      const deps = createMockDeps({
+        currentScope: "Motor",
+        generateExpression: vi
+          .fn()
+          .mockReturnValueOnce("6")
+          .mockReturnValueOnce("2"),
+      });
+      const ctx = createMockContext({
+        identifiers: ["GPIO7", "ICR1"],
+        subscripts: [{ mockValue: "6" } as never, { mockValue: "2" } as never],
+        hasThis: true,
+        generatedValue: "value",
+      });
+
+      const result = getHandler()!(ctx, deps);
+
+      expect(result).toContain("Motor_GPIO7_ICR1");
+      expect(result).toContain("& ~(");
+      expect(result).toContain("<< 6");
+    });
+
+    it("generates simple write for write-only scoped register bit range", () => {
+      const registerMemberAccess = new Map([["Motor_GPIO7_ICR1", "wo"]]);
+      const deps = createMockDeps({
+        currentScope: "Motor",
+        generateExpression: vi
+          .fn()
+          .mockReturnValueOnce("6")
+          .mockReturnValueOnce("2"),
+        symbols: {
+          structFields: new Map(),
+          structFieldDimensions: new Map(),
+          bitmapFields: new Map(),
+          registerMemberAccess,
+          registerBaseAddresses: new Map(),
+          registerMemberOffsets: new Map(),
+          registerMemberTypes: new Map(),
+        },
+      });
+      const ctx = createMockContext({
+        identifiers: ["GPIO7", "ICR1"],
+        subscripts: [{ mockValue: "6" } as never, { mockValue: "2" } as never],
+        hasThis: true,
+        generatedValue: "value",
+      });
+
+      const result = getHandler()!(ctx, deps);
+
+      expect(result).toContain("Motor_GPIO7_ICR1 =");
+      expect(result).not.toContain("& ~");
+    });
+
+    it("generates MMIO optimization for byte-aligned scoped access", () => {
+      const registerMemberAccess = new Map([["Motor_GPIO7_ICR1", "wo"]]);
+      const registerBaseAddresses = new Map([["Motor_GPIO7", "0x40000000"]]);
+      const registerMemberOffsets = new Map([["Motor_GPIO7_ICR1", "0x08"]]);
+
+      const deps = createMockDeps({
+        currentScope: "Motor",
+        generateExpression: vi
+          .fn()
+          .mockReturnValueOnce("0")
+          .mockReturnValueOnce("32"),
+        tryEvaluateConstant: vi
+          .fn()
+          .mockReturnValueOnce(0)
+          .mockReturnValueOnce(32),
+        symbols: {
+          structFields: new Map(),
+          structFieldDimensions: new Map(),
+          bitmapFields: new Map(),
+          registerMemberAccess,
+          registerBaseAddresses,
+          registerMemberOffsets,
+          registerMemberTypes: new Map(),
+        },
+      });
+      const ctx = createMockContext({
+        identifiers: ["GPIO7", "ICR1"],
+        subscripts: [{ mockValue: "0" } as never, { mockValue: "32" } as never],
+        hasThis: true,
+        generatedValue: "value",
+      });
+
+      const result = getHandler()!(ctx, deps);
+
+      expect(result).toContain("volatile uint32_t*");
+      expect(result).toContain("0x40000000");
+    });
+
+    it("throws when used outside scope", () => {
+      const deps = createMockDeps({ currentScope: null });
+      const ctx = createMockContext({
+        subscripts: [{ mockValue: "6" } as never, { mockValue: "2" } as never],
+        hasThis: true,
+      });
+
+      expect(() => getHandler()!(ctx, deps)).toThrow(
+        "'this' can only be used inside a scope",
+      );
+    });
+
+    it("throws on compound assignment", () => {
+      const deps = createMockDeps({ currentScope: "Motor" });
+      const ctx = createMockContext({
+        isCompound: true,
+        cnextOp: "+<-",
+        subscripts: [{ mockValue: "6" } as never, { mockValue: "2" } as never],
+      });
+
+      expect(() => getHandler()!(ctx, deps)).toThrow(
+        "Compound assignment operators not supported for bit field access",
+      );
+    });
+
+    it("throws on write-only bit range with 0 value", () => {
+      const registerMemberAccess = new Map([["Motor_GPIO7_ICR1", "w1c"]]);
+      const deps = createMockDeps({
+        currentScope: "Motor",
+        generateExpression: vi
+          .fn()
+          .mockReturnValueOnce("6")
+          .mockReturnValueOnce("2"),
+        symbols: {
+          structFields: new Map(),
+          structFieldDimensions: new Map(),
+          bitmapFields: new Map(),
+          registerMemberAccess,
+          registerBaseAddresses: new Map(),
+          registerMemberOffsets: new Map(),
+          registerMemberTypes: new Map(),
+        },
+      });
+      const ctx = createMockContext({
+        identifiers: ["GPIO7", "ICR1"],
+        subscripts: [{ mockValue: "6" } as never, { mockValue: "2" } as never],
+        hasThis: true,
+        generatedValue: "0",
+      });
+
+      expect(() => getHandler()!(ctx, deps)).toThrow(
+        "Cannot assign 0 to write-only register bits",
+      );
+    });
+  });
+});

--- a/src/transpiler/output/codegen/assignment/handlers/__tests__/SpecialHandlers.test.ts
+++ b/src/transpiler/output/codegen/assignment/handlers/__tests__/SpecialHandlers.test.ts
@@ -1,0 +1,389 @@
+/**
+ * Unit tests for SpecialHandlers.
+ * Tests atomic RMW and overflow clamp handler functions.
+ */
+
+import { describe, expect, it, vi } from "vitest";
+import specialHandlers from "../SpecialHandlers";
+import AssignmentKind from "../../AssignmentKind";
+import IAssignmentContext from "../../IAssignmentContext";
+import IHandlerDeps from "../IHandlerDeps";
+
+/**
+ * Create mock dependencies for testing.
+ */
+function createMockDeps(overrides: Record<string, unknown> = {}): IHandlerDeps {
+  const base = {
+    typeRegistry: new Map(),
+    symbols: {
+      structFields: new Map(),
+      structFieldDimensions: new Map(),
+      bitmapFields: new Map(),
+      registerMemberAccess: new Map(),
+      registerBaseAddresses: new Map(),
+      registerMemberOffsets: new Map(),
+      registerMemberTypes: new Map(),
+    },
+    currentScope: null,
+    currentParameters: new Map(),
+    targetCapabilities: { hasLDREX: false },
+    generateAssignmentTarget: vi.fn().mockReturnValue("target"),
+    generateExpression: vi
+      .fn()
+      .mockImplementation((ctx) => ctx?.mockValue ?? "0"),
+    markNeedsString: vi.fn(),
+    markClampOpUsed: vi.fn(),
+    isKnownScope: vi.fn().mockReturnValue(false),
+    isKnownStruct: vi.fn().mockReturnValue(false),
+    validateCrossScopeVisibility: vi.fn(),
+    validateBitmapFieldLiteral: vi.fn(),
+    checkArrayBounds: vi.fn(),
+    analyzeMemberChainForBitAccess: vi
+      .fn()
+      .mockReturnValue({ isBitAccess: false }),
+    tryEvaluateConstant: vi.fn().mockReturnValue(undefined),
+    getMemberTypeInfo: vi.fn().mockReturnValue(null),
+    generateFloatBitWrite: vi.fn().mockReturnValue(null),
+    foldBooleanToInt: vi.fn().mockImplementation((expr) => expr),
+    generateAtomicRMW: vi.fn().mockReturnValue("atomic_rmw_result"),
+    ...overrides,
+  };
+  return base as unknown as IHandlerDeps;
+}
+
+/**
+ * Create mock context for testing.
+ */
+function createMockContext(
+  overrides: Partial<IAssignmentContext> = {},
+): IAssignmentContext {
+  return {
+    identifiers: ["counter"],
+    subscripts: [],
+    isCompound: true,
+    cnextOp: "+<-",
+    cOp: "+=",
+    generatedValue: "1",
+    targetCtx: {} as never,
+    hasThis: false,
+    hasGlobal: false,
+    hasMemberAccess: false,
+    hasArrayAccess: false,
+    postfixOpsCount: 0,
+    memberAccessDepth: 0,
+    subscriptDepth: 0,
+    isSimpleIdentifier: true,
+    isSimpleThisAccess: false,
+    isSimpleGlobalAccess: false,
+    ...overrides,
+  } as IAssignmentContext;
+}
+
+describe("SpecialHandlers", () => {
+  describe("handler registration", () => {
+    it("registers all expected special assignment kinds", () => {
+      const kinds = specialHandlers.map(([kind]) => kind);
+
+      expect(kinds).toContain(AssignmentKind.ATOMIC_RMW);
+      expect(kinds).toContain(AssignmentKind.OVERFLOW_CLAMP);
+    });
+
+    it("exports exactly 2 handlers", () => {
+      expect(specialHandlers.length).toBe(2);
+    });
+  });
+
+  describe("handleAtomicRMW (ATOMIC_RMW)", () => {
+    const getHandler = () =>
+      specialHandlers.find(([kind]) => kind === AssignmentKind.ATOMIC_RMW)?.[1];
+
+    it("delegates to generateAtomicRMW for simple identifier", () => {
+      const typeRegistry = new Map([
+        ["counter", { baseType: "u32", isAtomic: true }],
+      ]);
+      const generateAtomicRMW = vi.fn().mockReturnValue("LDREX/STREX pattern");
+      const generateAssignmentTarget = vi.fn().mockReturnValue("counter");
+      const deps = createMockDeps({
+        typeRegistry,
+        generateAtomicRMW,
+        generateAssignmentTarget,
+      });
+      const ctx = createMockContext();
+
+      const result = getHandler()!(ctx, deps);
+
+      expect(generateAtomicRMW).toHaveBeenCalledWith("counter", "+=", "1", {
+        baseType: "u32",
+        isAtomic: true,
+      });
+      expect(result).toBe("LDREX/STREX pattern");
+    });
+
+    it("handles this.member atomic variable", () => {
+      const typeRegistry = new Map([
+        ["Motor_count", { baseType: "u32", isAtomic: true }],
+      ]);
+      const generateAtomicRMW = vi.fn().mockReturnValue("atomic result");
+      const generateAssignmentTarget = vi.fn().mockReturnValue("Motor_count");
+      const deps = createMockDeps({
+        typeRegistry,
+        generateAtomicRMW,
+        generateAssignmentTarget,
+        currentScope: "Motor",
+      });
+      const ctx = createMockContext({
+        identifiers: ["count"],
+        isSimpleIdentifier: false,
+        isSimpleThisAccess: true,
+      });
+
+      const result = getHandler()!(ctx, deps);
+
+      expect(generateAtomicRMW).toHaveBeenCalledWith("Motor_count", "+=", "1", {
+        baseType: "u32",
+        isAtomic: true,
+      });
+      expect(result).toBe("atomic result");
+    });
+
+    it("handles global.member atomic variable", () => {
+      const typeRegistry = new Map([
+        ["globalCounter", { baseType: "u32", isAtomic: true }],
+      ]);
+      const generateAtomicRMW = vi.fn().mockReturnValue("global atomic result");
+      const generateAssignmentTarget = vi.fn().mockReturnValue("globalCounter");
+      const deps = createMockDeps({
+        typeRegistry,
+        generateAtomicRMW,
+        generateAssignmentTarget,
+      });
+      const ctx = createMockContext({
+        identifiers: ["globalCounter"],
+        isSimpleIdentifier: false,
+        isSimpleGlobalAccess: true,
+      });
+
+      const result = getHandler()!(ctx, deps);
+
+      expect(result).toBe("global atomic result");
+    });
+
+    it("handles subtract operation", () => {
+      const typeRegistry = new Map([
+        ["counter", { baseType: "u32", isAtomic: true }],
+      ]);
+      const generateAtomicRMW = vi.fn().mockReturnValue("atomic sub");
+      const generateAssignmentTarget = vi.fn().mockReturnValue("counter");
+      const deps = createMockDeps({
+        typeRegistry,
+        generateAtomicRMW,
+        generateAssignmentTarget,
+      });
+      const ctx = createMockContext({
+        cnextOp: "-<-",
+        cOp: "-=",
+      });
+
+      getHandler()!(ctx, deps);
+
+      expect(generateAtomicRMW).toHaveBeenCalledWith(
+        "counter",
+        "-=",
+        "1",
+        expect.anything(),
+      );
+    });
+  });
+
+  describe("handleOverflowClamp (OVERFLOW_CLAMP)", () => {
+    const getHandler = () =>
+      specialHandlers.find(
+        ([kind]) => kind === AssignmentKind.OVERFLOW_CLAMP,
+      )?.[1];
+
+    it("generates clamp add helper for u8", () => {
+      const typeRegistry = new Map([
+        ["saturated", { baseType: "u8", overflowBehavior: "clamp" }],
+      ]);
+      const markClampOpUsed = vi.fn();
+      const generateAssignmentTarget = vi.fn().mockReturnValue("saturated");
+      const deps = createMockDeps({
+        typeRegistry,
+        markClampOpUsed,
+        generateAssignmentTarget,
+      });
+      const ctx = createMockContext({
+        identifiers: ["saturated"],
+        generatedValue: "200",
+      });
+
+      const result = getHandler()!(ctx, deps);
+
+      expect(markClampOpUsed).toHaveBeenCalledWith("add", "u8");
+      expect(result).toBe("saturated = cnx_clamp_add_u8(saturated, 200);");
+    });
+
+    it("generates clamp sub helper for u16", () => {
+      const typeRegistry = new Map([
+        ["value", { baseType: "u16", overflowBehavior: "clamp" }],
+      ]);
+      const markClampOpUsed = vi.fn();
+      const generateAssignmentTarget = vi.fn().mockReturnValue("value");
+      const deps = createMockDeps({
+        typeRegistry,
+        markClampOpUsed,
+        generateAssignmentTarget,
+      });
+      const ctx = createMockContext({
+        identifiers: ["value"],
+        cnextOp: "-<-",
+        cOp: "-=",
+        generatedValue: "100",
+      });
+
+      const result = getHandler()!(ctx, deps);
+
+      expect(markClampOpUsed).toHaveBeenCalledWith("sub", "u16");
+      expect(result).toBe("value = cnx_clamp_sub_u16(value, 100);");
+    });
+
+    it("generates clamp mul helper for u32", () => {
+      const typeRegistry = new Map([
+        ["result", { baseType: "u32", overflowBehavior: "clamp" }],
+      ]);
+      const markClampOpUsed = vi.fn();
+      const generateAssignmentTarget = vi.fn().mockReturnValue("result");
+      const deps = createMockDeps({
+        typeRegistry,
+        markClampOpUsed,
+        generateAssignmentTarget,
+      });
+      const ctx = createMockContext({
+        identifiers: ["result"],
+        cnextOp: "*<-",
+        cOp: "*=",
+        generatedValue: "2",
+      });
+
+      const result = getHandler()!(ctx, deps);
+
+      expect(markClampOpUsed).toHaveBeenCalledWith("mul", "u32");
+      expect(result).toBe("result = cnx_clamp_mul_u32(result, 2);");
+    });
+
+    it("uses native arithmetic for float types", () => {
+      const typeRegistry = new Map([
+        ["f", { baseType: "f32", overflowBehavior: "clamp" }],
+      ]);
+      const markClampOpUsed = vi.fn();
+      const generateAssignmentTarget = vi.fn().mockReturnValue("f");
+      const deps = createMockDeps({
+        typeRegistry,
+        markClampOpUsed,
+        generateAssignmentTarget,
+      });
+      const ctx = createMockContext({
+        identifiers: ["f"],
+        generatedValue: "1000.0",
+      });
+
+      const result = getHandler()!(ctx, deps);
+
+      expect(markClampOpUsed).not.toHaveBeenCalled();
+      expect(result).toBe("f += 1000.0;");
+    });
+
+    it("uses native arithmetic for f64 type", () => {
+      const typeRegistry = new Map([
+        ["d", { baseType: "f64", overflowBehavior: "clamp" }],
+      ]);
+      const generateAssignmentTarget = vi.fn().mockReturnValue("d");
+      const deps = createMockDeps({
+        typeRegistry,
+        generateAssignmentTarget,
+      });
+      const ctx = createMockContext({
+        identifiers: ["d"],
+        cOp: "-=",
+        generatedValue: "0.5",
+      });
+
+      const result = getHandler()!(ctx, deps);
+
+      expect(result).toBe("d -= 0.5;");
+    });
+
+    it("falls back to native for unsupported operators", () => {
+      const typeRegistry = new Map([
+        ["value", { baseType: "u32", overflowBehavior: "clamp" }],
+      ]);
+      const markClampOpUsed = vi.fn();
+      const generateAssignmentTarget = vi.fn().mockReturnValue("value");
+      const deps = createMockDeps({
+        typeRegistry,
+        markClampOpUsed,
+        generateAssignmentTarget,
+      });
+      const ctx = createMockContext({
+        identifiers: ["value"],
+        cnextOp: "/<-",
+        cOp: "/=",
+        generatedValue: "2",
+      });
+
+      const result = getHandler()!(ctx, deps);
+
+      expect(markClampOpUsed).not.toHaveBeenCalled();
+      expect(result).toBe("value /= 2;");
+    });
+
+    it("handles this.member with clamp", () => {
+      const typeRegistry = new Map([
+        ["Motor_speed", { baseType: "u8", overflowBehavior: "clamp" }],
+      ]);
+      const markClampOpUsed = vi.fn();
+      const generateAssignmentTarget = vi.fn().mockReturnValue("Motor_speed");
+      const deps = createMockDeps({
+        typeRegistry,
+        markClampOpUsed,
+        generateAssignmentTarget,
+        currentScope: "Motor",
+      });
+      const ctx = createMockContext({
+        identifiers: ["speed"],
+        isSimpleIdentifier: false,
+        isSimpleThisAccess: true,
+        generatedValue: "10",
+      });
+
+      const result = getHandler()!(ctx, deps);
+
+      expect(markClampOpUsed).toHaveBeenCalledWith("add", "u8");
+      expect(result).toBe("Motor_speed = cnx_clamp_add_u8(Motor_speed, 10);");
+    });
+
+    it("handles global.member with clamp", () => {
+      const typeRegistry = new Map([
+        ["globalValue", { baseType: "i16", overflowBehavior: "clamp" }],
+      ]);
+      const markClampOpUsed = vi.fn();
+      const generateAssignmentTarget = vi.fn().mockReturnValue("globalValue");
+      const deps = createMockDeps({
+        typeRegistry,
+        markClampOpUsed,
+        generateAssignmentTarget,
+      });
+      const ctx = createMockContext({
+        identifiers: ["globalValue"],
+        isSimpleIdentifier: false,
+        isSimpleGlobalAccess: true,
+        generatedValue: "50",
+      });
+
+      const result = getHandler()!(ctx, deps);
+
+      expect(markClampOpUsed).toHaveBeenCalledWith("add", "i16");
+      expect(result).toBe("globalValue = cnx_clamp_add_i16(globalValue, 50);");
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add comprehensive unit tests for assignment handler modules
- Increases handlers/ directory coverage from ~26% to 98.36%
- Adds 123 new unit tests to the test suite

## Test Files Added
| File | Tests |
|------|-------|
| `RegisterHandlers.test.ts` | 25 |
| `ArrayHandlers.test.ts` | 20 |
| `BitmapHandlers.test.ts` | 18 |
| `AccessPatternHandlers.test.ts` | 25 |
| `BitAccessHandlers.test.ts` | 21 |
| `SpecialHandlers.test.ts` | 14 |

## Coverage Improvements
| File | Before | After |
|------|--------|-------|
| `RegisterHandlers.ts` | 5.44% | 99% |
| `ArrayHandlers.ts` | 7.95% | 100% |
| `AccessPatternHandlers.ts` | 8.91% | 100% |
| `BitmapHandlers.ts` | 10.36% | 98.78% |
| `BitAccessHandlers.ts` | 14.77% | 100% |
| `SpecialHandlers.ts` | 24% | 96% |

## Test plan
- [x] All new tests pass (`npm run unit`)
- [x] Full test suite passes (2090 tests)
- [x] Pre-commit hooks pass (prettier, oxlint)

🤖 Generated with [Claude Code](https://claude.com/claude-code)