### PR TITLE
fix: deploy coverage to /coverage/ subdirectory

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -321,7 +321,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: coverage-report
-          path: ./coverage
+          path: ./pages/coverage
 
       - name: Setup Pages
         uses: actions/configure-pages@v4
@@ -329,7 +329,7 @@ jobs:
       - name: Upload coverage to Pages
         uses: actions/upload-pages-artifact@v3
         with:
-          path: ./coverage
+          path: ./pages
 
       - name: Deploy to GitHub Pages
         id: deployment


### PR DESCRIPTION
## Summary

Deploy coverage reports to `/coverage/` path instead of the root, fixing the broken README badge link.

**Before:** Coverage deployed to `https://jlaustill.github.io/c-next/` (root)
**After:** Coverage deployed to `https://jlaustill.github.io/c-next/coverage/`

This also leaves room for other content at the root in the future (docs, API reference, etc.).

## Changes

- Download coverage artifact to `./pages/coverage` instead of `./coverage`
- Upload `./pages` directory to GitHub Pages (which contains `coverage/` subdirectory)

## Test plan

- [x] Workflow syntax is valid
- [ ] After merge, verify https://jlaustill.github.io/c-next/coverage/ loads correctly

🤖 Generated with [Claude Code](https://claude.ai/claude-code)