### PR TITLE
docs: add float bit indexing documentation

### DIFF
--- a/docs/learn-cnext-in-y-minutes.md
+++ b/docs/learn-cnext-in-y-minutes.md
@@ -793,6 +793,16 @@ u8 field <- flags[4, 3];    // Read 3-bit field
 // .length on integers gives bit width
 u8 width8 <- flags.length;  // 8
 u32 width32 <- counter.length;  // 32
+
+// Float bit indexing (IEEE-754 byte access via memcpy)
+// Useful for serialization, CAN bus protocols, etc.
+f32 value <- 0.0;
+value[0, 8] <- 0x00;   // Write byte 0 (LSB)
+value[8, 8] <- 0x00;   // Write byte 1
+value[16, 8] <- 0x80;  // Write byte 2
+value[24, 8] <- 0x3F;  // Write byte 3 (MSB) → value is now 1.0f
+
+u8 byte <- value[24, 8];  // Read high byte from float
 ```
 
 ## Bitmap Types


### PR DESCRIPTION
## Summary

Document the f32/f64 bit indexing feature that was added in PR #490 but missing from the main documentation.

## Changes

### ADR-007 (Type-Aware Bit Indexing)
- Added new "Float Bit Indexing (IEEE-754 Byte Access)" section
- Documents the memcpy-based implementation for type-safe bit manipulation
- Includes example C-Next code and generated C output
- Type mapping table (f32 → uint32_t, f64 → uint64_t)
- Use cases (serialization, CAN bus, network byte order)

### learn-cnext-in-y-minutes.md
- Added float bit indexing example in the Bit Manipulation section
- Shows both write and read operations

## Test plan

- [x] Documentation builds correctly (no broken markdown)
- [x] Examples match actual transpiler output

🤖 Generated with [Claude Code](https://claude.ai/claude-code)