### PR TITLE
Add unit tests for Preprocessor and ToolchainDetector

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -321,7 +321,10 @@
     "unqual",
     "Mtimes",
     "mtimes",
-    "scandir"
+    "scandir",
+    "DDEBUG",
+    "DVERSION",
+    "DDISABLED"
   ],
   "ignorePaths": [
     "node_modules/**",

--- a/package-lock.json
+++ b/package-lock.json
@@ -274,7 +274,6 @@
       "integrity": "sha512-RsUFrSB0oQHEBnR8yarKIReUPwSu2ROpbjhdVKi4T/nQhMaS+TnIQPBwkMtb2r8A1KS2Hijw4D/4bV/XHoFQWw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20"
       }
@@ -356,8 +355,7 @@
       "resolved": "https://registry.npmjs.org/@cspell/dict-css/-/dict-css-4.0.19.tgz",
       "integrity": "sha512-VYHtPnZt/Zd/ATbW3rtexWpBnHUohUrQOHff/2JBhsVgxOrksAxJnLAO43Q1ayLJBJUUwNVo+RU0sx0aaysZfg==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@cspell/dict-dart": {
       "version": "2.3.2",
@@ -497,16 +495,14 @@
       "resolved": "https://registry.npmjs.org/@cspell/dict-html/-/dict-html-4.0.14.tgz",
       "integrity": "sha512-2bf7n+kS92g+cMKV0wr9o/Oq9n8JzU7CcrB96gIh2GHgnF+0xDOqO2W/1KeFAqOfqosoOVE48t+4dnEMkkoJ2Q==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@cspell/dict-html-symbol-entities": {
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/@cspell/dict-html-symbol-entities/-/dict-html-symbol-entities-4.0.5.tgz",
       "integrity": "sha512-429alTD4cE0FIwpMucvSN35Ld87HCyuM8mF731KU5Rm4Je2SG6hmVx7nkBsLyrmH3sQukTcr1GaiZsiEg8svPA==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@cspell/dict-java": {
       "version": "5.0.12",
@@ -704,8 +700,7 @@
       "resolved": "https://registry.npmjs.org/@cspell/dict-typescript/-/dict-typescript-3.2.3.tgz",
       "integrity": "sha512-zXh1wYsNljQZfWWdSPYwQhpwiuW0KPW1dSd8idjMRvSD0aSvWWHoWlrMsmZeRl4qM4QCEAjua8+cjflm41cQBg==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@cspell/dict-vue": {
       "version": "3.0.5",
@@ -2117,7 +2112,6 @@
       "integrity": "sha512-DZ8VwRFUNzuqJ5khrvwMXHmvPe+zGayJhr2CDNiKB1WBE1ST8Djl00D0IC4vvNmHMdj6DlbYRIaFE7WHjlDl5w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -2287,7 +2281,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3640,7 +3633,6 @@
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-5.6.0.tgz",
       "integrity": "sha512-CYDD3SOtsHtyXeEORYRx2qBtpDJFjRTGXUtmNEMGyzYOKj1TE3tycdlho7kA1Ufx9OYWZzg52QFBGALTirzDSw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@keyv/serialize": "^1.1.1"
       }
@@ -4669,7 +4661,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -4776,7 +4767,6 @@
       "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
       "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "~0.27.0",
         "get-tsconfig": "^4.7.5"
@@ -4796,7 +4786,6 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -4818,7 +4807,6 @@
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -4912,7 +4900,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -4926,7 +4913,6 @@
       "integrity": "sha512-hOQuK7h0FGKgBAas7v0mSAsnvrIgAvWmRFjmzpJ7SwFHH3g1k2u37JtYwOwmEKhK6ZO3v9ggDBBm0La1LCK4uQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.0.18",
         "@vitest/mocker": "4.0.18",

--- a/src/transpiler/logic/preprocessor/__tests__/Preprocessor.test.ts
+++ b/src/transpiler/logic/preprocessor/__tests__/Preprocessor.test.ts
@@ -1,0 +1,540 @@
+/**
+ * Unit tests for Preprocessor
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import IToolchain from "../types/IToolchain";
+import ISourceMapping from "../types/ISourceMapping";
+
+// We need to define our mock functions before vi.mock calls
+const mockExec = vi.fn();
+const mockWriteFile = vi.fn().mockResolvedValue(undefined);
+const mockMkdtemp = vi.fn().mockResolvedValue("/tmp/cnext-abc123");
+const mockRm = vi.fn().mockResolvedValue(undefined);
+const mockDetect = vi.fn().mockReturnValue(null);
+const mockGetDefaultIncludePaths = vi.fn().mockReturnValue([]);
+
+// Type for exec callback
+type ExecCallback = (
+  err: Error | null,
+  result: { stdout: string; stderr: string },
+) => void;
+
+// Mock child_process - exec is promisified, so we mock it to work with promisify
+vi.mock("node:child_process", () => ({
+  exec: (cmd: string, opts: unknown, cb?: ExecCallback) => {
+    // promisify converts callback-based to promise-based
+    // We handle both forms (2-arg and 3-arg)
+    let callback: ExecCallback | undefined = cb;
+    if (typeof opts === "function") {
+      callback = opts as ExecCallback;
+    }
+    const result = mockExec(cmd, opts);
+    if (result instanceof Promise) {
+      result
+        .then((r: { stdout: string; stderr: string }) => callback?.(null, r))
+        .catch((e: Error) => callback?.(e, { stdout: "", stderr: "" }));
+    } else if (result && typeof result.then === "function") {
+      result
+        .then((r: { stdout: string; stderr: string }) => callback?.(null, r))
+        .catch((e: Error) => callback?.(e, { stdout: "", stderr: "" }));
+    } else {
+      // Immediate value
+      if (result instanceof Error) {
+        callback?.(result, { stdout: "", stderr: "" });
+      } else {
+        callback?.(null, result || { stdout: "", stderr: "" });
+      }
+    }
+  },
+}));
+
+// Mock fs/promises
+vi.mock("node:fs/promises", () => ({
+  writeFile: (...args: unknown[]) => mockWriteFile(...args),
+  mkdtemp: (...args: unknown[]) => mockMkdtemp(...args),
+  rm: (...args: unknown[]) => mockRm(...args),
+}));
+
+// Mock ToolchainDetector
+vi.mock("../ToolchainDetector", () => ({
+  default: {
+    detect: () => mockDetect(),
+    getDefaultIncludePaths: (t: IToolchain) => mockGetDefaultIncludePaths(t),
+  },
+}));
+
+// Import after mocks are set up
+import Preprocessor from "../Preprocessor";
+
+describe("Preprocessor", () => {
+  const mockToolchain: IToolchain = {
+    name: "gcc",
+    cc: "/usr/bin/gcc",
+    cxx: "/usr/bin/g++",
+    cpp: "/usr/bin/gcc",
+    version: "11.4.0",
+    isCrossCompiler: false,
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockDetect.mockReturnValue(null);
+    mockGetDefaultIncludePaths.mockReturnValue([]);
+    mockExec.mockReturnValue({ stdout: "", stderr: "" });
+    mockWriteFile.mockResolvedValue(undefined);
+    mockMkdtemp.mockResolvedValue("/tmp/cnext-abc123");
+    mockRm.mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe("constructor", () => {
+    it("uses provided toolchain", () => {
+      const preprocessor = new Preprocessor(mockToolchain);
+
+      expect(preprocessor.isAvailable()).toBe(true);
+      expect(preprocessor.getToolchain()).toEqual(mockToolchain);
+    });
+
+    it("uses ToolchainDetector when no toolchain provided", () => {
+      mockDetect.mockReturnValue(mockToolchain);
+      mockGetDefaultIncludePaths.mockReturnValue(["/usr/include"]);
+
+      const preprocessor = new Preprocessor();
+
+      expect(mockDetect).toHaveBeenCalled();
+      expect(mockGetDefaultIncludePaths).toHaveBeenCalledWith(mockToolchain);
+      expect(preprocessor.isAvailable()).toBe(true);
+    });
+
+    it("handles no available toolchain", () => {
+      mockDetect.mockReturnValue(null);
+
+      const preprocessor = new Preprocessor();
+
+      expect(preprocessor.isAvailable()).toBe(false);
+      expect(preprocessor.getToolchain()).toBeNull();
+    });
+  });
+
+  describe("isAvailable", () => {
+    it("returns true when toolchain is set", () => {
+      const preprocessor = new Preprocessor(mockToolchain);
+      expect(preprocessor.isAvailable()).toBe(true);
+    });
+
+    it("returns false when no toolchain", () => {
+      mockDetect.mockReturnValue(null);
+      const preprocessor = new Preprocessor();
+      expect(preprocessor.isAvailable()).toBe(false);
+    });
+  });
+
+  describe("getToolchain", () => {
+    it("returns the toolchain", () => {
+      const preprocessor = new Preprocessor(mockToolchain);
+      expect(preprocessor.getToolchain()).toEqual(mockToolchain);
+    });
+
+    it("returns null when no toolchain", () => {
+      mockDetect.mockReturnValue(null);
+      const preprocessor = new Preprocessor();
+      expect(preprocessor.getToolchain()).toBeNull();
+    });
+  });
+
+  describe("preprocess", () => {
+    it("returns error when no toolchain available", async () => {
+      mockDetect.mockReturnValue(null);
+      const preprocessor = new Preprocessor();
+
+      const result = await preprocessor.preprocess("/path/to/file.h");
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("No C/C++ toolchain available");
+      expect(result.content).toBe("");
+      expect(result.sourceMappings).toEqual([]);
+      expect(result.originalFile).toBe("/path/to/file.h");
+    });
+
+    it("calls preprocessor with correct arguments", async () => {
+      mockExec.mockReturnValue({
+        stdout: "preprocessed content",
+        stderr: "",
+      });
+
+      const preprocessor = new Preprocessor(mockToolchain);
+      await preprocessor.preprocess("/path/to/file.h");
+
+      expect(mockExec).toHaveBeenCalled();
+      const command = mockExec.mock.calls[0][0];
+      expect(command).toContain("/usr/bin/gcc");
+      expect(command).toContain("-E");
+      expect(command).toContain("/path/to/file.h");
+      expect(command).toContain("-I/path/to");
+    });
+
+    it("includes custom include paths", async () => {
+      mockExec.mockReturnValue({
+        stdout: "content",
+        stderr: "",
+      });
+
+      const preprocessor = new Preprocessor(mockToolchain);
+      await preprocessor.preprocess("/path/to/file.h", {
+        includePaths: ["/custom/include", "/another/path"],
+      });
+
+      const command = mockExec.mock.calls[0][0];
+      expect(command).toContain("-I/custom/include");
+      expect(command).toContain("-I/another/path");
+    });
+
+    it("includes defines", async () => {
+      mockExec.mockReturnValue({
+        stdout: "content",
+        stderr: "",
+      });
+
+      const preprocessor = new Preprocessor(mockToolchain);
+      await preprocessor.preprocess("/path/to/file.h", {
+        defines: {
+          DEBUG: true,
+          VERSION: "1.0",
+          DISABLED: false,
+        },
+      });
+
+      const command = mockExec.mock.calls[0][0];
+      expect(command).toContain("-DDEBUG");
+      expect(command).toContain("-DVERSION=1.0");
+      expect(command).not.toContain("-DDISABLED");
+    });
+
+    it("returns success result with content", async () => {
+      mockExec.mockReturnValue({
+        stdout: "int x = 5;\n",
+        stderr: "",
+      });
+
+      const preprocessor = new Preprocessor(mockToolchain);
+      const result = await preprocessor.preprocess("/path/to/file.h");
+
+      expect(result.success).toBe(true);
+      expect(result.content).toBe("int x = 5;\n");
+      expect(result.originalFile).toBe("/path/to/file.h");
+      expect(result.toolchain).toBe("gcc");
+    });
+
+    it("parses line directives for source mappings", async () => {
+      const preprocessedContent = `# 1 "test.h"
+# 1 "<built-in>"
+# 1 "<command-line>"
+# 1 "test.h"
+int x = 5;
+# 10 "other.h"
+int y = 10;
+`;
+      mockExec.mockReturnValue({
+        stdout: preprocessedContent,
+        stderr: "",
+      });
+
+      const preprocessor = new Preprocessor(mockToolchain);
+      const result = await preprocessor.preprocess("/path/to/test.h");
+
+      expect(result.success).toBe(true);
+      expect(result.sourceMappings.length).toBeGreaterThan(0);
+
+      // Find mapping for test.h
+      const testMapping = result.sourceMappings.find(
+        (m) => m.originalFile === "test.h" && m.originalLine === 1,
+      );
+      expect(testMapping).toBeDefined();
+    });
+
+    it("strips line directives when keepLineDirectives is false", async () => {
+      const preprocessedContent = `# 1 "test.h"
+int x = 5;
+# 10 "other.h"
+int y = 10;
+`;
+      mockExec.mockReturnValue({
+        stdout: preprocessedContent,
+        stderr: "",
+      });
+
+      const preprocessor = new Preprocessor(mockToolchain);
+      const result = await preprocessor.preprocess("/path/to/test.h", {
+        keepLineDirectives: false,
+      });
+
+      expect(result.content).not.toContain("# 1");
+      expect(result.content).not.toContain("# 10");
+      expect(result.content).toContain("int x = 5;");
+      expect(result.content).toContain("int y = 10;");
+      expect(result.sourceMappings).toEqual([]);
+    });
+
+    it("uses -P flag when keepLineDirectives is false", async () => {
+      mockExec.mockReturnValue({
+        stdout: "content",
+        stderr: "",
+      });
+
+      const preprocessor = new Preprocessor(mockToolchain);
+      await preprocessor.preprocess("/path/to/file.h", {
+        keepLineDirectives: false,
+      });
+
+      const command = mockExec.mock.calls[0][0];
+      expect(command).toContain("-P");
+    });
+
+    it("handles preprocessor errors", async () => {
+      const error = new Error("compilation error");
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (error as any).stderr = "file.h:5: error: unknown type";
+      mockExec.mockReturnValue(Promise.reject(error));
+
+      const preprocessor = new Preprocessor(mockToolchain);
+      const result = await preprocessor.preprocess("/path/to/file.h");
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("Preprocessor failed");
+    });
+
+    it("logs warnings to console but succeeds", async () => {
+      const consoleWarnSpy = vi
+        .spyOn(console, "warn")
+        .mockImplementation(() => {});
+      mockExec.mockReturnValue({
+        stdout: "int x = 5;\n",
+        stderr: "warning: implicit declaration\n",
+      });
+
+      const preprocessor = new Preprocessor(mockToolchain);
+      const result = await preprocessor.preprocess("/path/to/file.h");
+
+      expect(result.success).toBe(true);
+      expect(consoleWarnSpy).toHaveBeenCalledWith(
+        expect.stringContaining("Preprocessor warnings"),
+      );
+
+      consoleWarnSpy.mockRestore();
+    });
+  });
+
+  describe("preprocessString", () => {
+    it("creates temp file and preprocesses", async () => {
+      mockExec.mockReturnValue({
+        stdout: "processed",
+        stderr: "",
+      });
+
+      const preprocessor = new Preprocessor(mockToolchain);
+      const result = await preprocessor.preprocessString(
+        "#define FOO 1\nint x = FOO;",
+        "test.h",
+      );
+
+      expect(mockMkdtemp).toHaveBeenCalled();
+      expect(mockWriteFile).toHaveBeenCalledWith(
+        "/tmp/cnext-abc123/test.h",
+        "#define FOO 1\nint x = FOO;",
+        "utf-8",
+      );
+      expect(result.originalFile).toBe("test.h");
+    });
+
+    it("cleans up temp directory after success", async () => {
+      mockExec.mockReturnValue({
+        stdout: "processed",
+        stderr: "",
+      });
+
+      const preprocessor = new Preprocessor(mockToolchain);
+      await preprocessor.preprocessString("content", "test.h");
+
+      expect(mockRm).toHaveBeenCalledWith("/tmp/cnext-abc123", {
+        recursive: true,
+      });
+    });
+
+    it("cleans up temp directory after failure", async () => {
+      mockExec.mockReturnValue(Promise.reject(new Error("failed")));
+
+      const preprocessor = new Preprocessor(mockToolchain);
+      await preprocessor.preprocessString("content", "test.h");
+
+      expect(mockRm).toHaveBeenCalledWith("/tmp/cnext-abc123", {
+        recursive: true,
+      });
+    });
+
+    it("ignores cleanup errors", async () => {
+      mockExec.mockReturnValue({
+        stdout: "processed",
+        stderr: "",
+      });
+      mockRm.mockRejectedValue(new Error("cleanup failed"));
+
+      const preprocessor = new Preprocessor(mockToolchain);
+
+      // Should not throw
+      const result = await preprocessor.preprocessString("content", "test.h");
+      expect(result.success).toBe(true);
+    });
+  });
+
+  describe("mapToOriginal (static)", () => {
+    it("returns null for empty mappings", () => {
+      const result = Preprocessor.mapToOriginal([], 5);
+      expect(result).toBeNull();
+    });
+
+    it("returns null when no mapping before target line", () => {
+      const mappings: ISourceMapping[] = [
+        { preprocessedLine: 10, originalFile: "test.h", originalLine: 1 },
+      ];
+
+      const result = Preprocessor.mapToOriginal(mappings, 5);
+      expect(result).toBeNull();
+    });
+
+    it("maps exact line match", () => {
+      const mappings: ISourceMapping[] = [
+        { preprocessedLine: 5, originalFile: "test.h", originalLine: 10 },
+      ];
+
+      const result = Preprocessor.mapToOriginal(mappings, 5);
+
+      expect(result).toEqual({ file: "test.h", line: 10 });
+    });
+
+    it("calculates offset from nearest mapping", () => {
+      const mappings: ISourceMapping[] = [
+        { preprocessedLine: 5, originalFile: "test.h", originalLine: 10 },
+      ];
+
+      const result = Preprocessor.mapToOriginal(mappings, 8);
+
+      expect(result).toEqual({ file: "test.h", line: 13 });
+    });
+
+    it("finds closest previous mapping", () => {
+      const mappings: ISourceMapping[] = [
+        { preprocessedLine: 1, originalFile: "a.h", originalLine: 1 },
+        { preprocessedLine: 10, originalFile: "b.h", originalLine: 50 },
+        { preprocessedLine: 20, originalFile: "c.h", originalLine: 100 },
+      ];
+
+      const result = Preprocessor.mapToOriginal(mappings, 15);
+
+      expect(result).toEqual({ file: "b.h", line: 55 });
+    });
+
+    it("handles unsorted mappings", () => {
+      const mappings: ISourceMapping[] = [
+        { preprocessedLine: 20, originalFile: "c.h", originalLine: 100 },
+        { preprocessedLine: 1, originalFile: "a.h", originalLine: 1 },
+        { preprocessedLine: 10, originalFile: "b.h", originalLine: 50 },
+      ];
+
+      const result = Preprocessor.mapToOriginal(mappings, 15);
+
+      expect(result).toEqual({ file: "b.h", line: 55 });
+    });
+  });
+
+  describe("line directive parsing", () => {
+    it("parses standard # linenum format", async () => {
+      const content = `# 1 "test.h"
+int x;
+# 5 "other.h"
+int y;
+`;
+      mockExec.mockReturnValue({
+        stdout: content,
+        stderr: "",
+      });
+
+      const preprocessor = new Preprocessor(mockToolchain);
+      const result = await preprocessor.preprocess("/test.h");
+
+      expect(result.sourceMappings).toContainEqual({
+        preprocessedLine: 2,
+        originalFile: "test.h",
+        originalLine: 1,
+      });
+    });
+
+    it("parses #line linenum format", async () => {
+      const content = `#line 10 "test.h"
+int x;
+`;
+      mockExec.mockReturnValue({
+        stdout: content,
+        stderr: "",
+      });
+
+      const preprocessor = new Preprocessor(mockToolchain);
+      const result = await preprocessor.preprocess("/test.h");
+
+      expect(result.sourceMappings).toContainEqual({
+        preprocessedLine: 2,
+        originalFile: "test.h",
+        originalLine: 10,
+      });
+    });
+
+    it("handles flags after filename", async () => {
+      const content = `# 1 "test.h" 1 2
+int x;
+`;
+      mockExec.mockReturnValue({
+        stdout: content,
+        stderr: "",
+      });
+
+      const preprocessor = new Preprocessor(mockToolchain);
+      const result = await preprocessor.preprocess("/test.h");
+
+      expect(result.sourceMappings).toContainEqual({
+        preprocessedLine: 2,
+        originalFile: "test.h",
+        originalLine: 1,
+      });
+    });
+
+    it("tracks line numbers across multiple directives", async () => {
+      const content = `# 1 "test.h"
+line1
+line2
+# 10 "other.h"
+line10
+`;
+      mockExec.mockReturnValue({
+        stdout: content,
+        stderr: "",
+      });
+
+      const preprocessor = new Preprocessor(mockToolchain);
+      const result = await preprocessor.preprocess("/test.h");
+
+      // Line numbers increment after each content line
+      const line1Mapping = result.sourceMappings.find(
+        (m) => m.preprocessedLine === 2,
+      );
+      const line2Mapping = result.sourceMappings.find(
+        (m) => m.preprocessedLine === 3,
+      );
+
+      expect(line1Mapping?.originalLine).toBe(1);
+      expect(line2Mapping?.originalLine).toBe(2);
+    });
+  });
+});

--- a/src/transpiler/logic/preprocessor/__tests__/ToolchainDetector.test.ts
+++ b/src/transpiler/logic/preprocessor/__tests__/ToolchainDetector.test.ts
@@ -1,0 +1,370 @@
+/**
+ * Unit tests for ToolchainDetector
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import ToolchainDetector from "../ToolchainDetector";
+
+// Mock child_process
+vi.mock("node:child_process", () => ({
+  execSync: vi.fn(),
+}));
+
+// Mock fs
+vi.mock("node:fs", () => ({
+  existsSync: vi.fn(),
+}));
+
+import { execSync } from "node:child_process";
+import { existsSync } from "node:fs";
+
+describe("ToolchainDetector", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe("detect", () => {
+    it("returns null when no toolchain is available", () => {
+      vi.mocked(execSync).mockImplementation(() => {
+        throw new Error("not found");
+      });
+
+      const result = ToolchainDetector.detect();
+      expect(result).toBeNull();
+    });
+
+    it("detects ARM toolchain with highest priority", () => {
+      vi.mocked(execSync).mockImplementation((cmd: string) => {
+        if (cmd === "which arm-none-eabi-gcc") {
+          return "/usr/bin/arm-none-eabi-gcc";
+        }
+        if (cmd === "which arm-none-eabi-g++") {
+          return "/usr/bin/arm-none-eabi-g++";
+        }
+        if (cmd.includes("--version")) {
+          return "arm-none-eabi-gcc (GNU Arm) 10.3.1\n";
+        }
+        throw new Error("not found");
+      });
+      vi.mocked(existsSync).mockReturnValue(true);
+
+      const result = ToolchainDetector.detect();
+
+      expect(result).not.toBeNull();
+      expect(result!.name).toBe("arm-none-eabi-gcc");
+      expect(result!.cc).toBe("/usr/bin/arm-none-eabi-gcc");
+      expect(result!.cxx).toBe("/usr/bin/arm-none-eabi-g++");
+      expect(result!.isCrossCompiler).toBe(true);
+      expect(result!.target).toBe("arm-none-eabi");
+    });
+
+    it("detects clang when ARM is not available", () => {
+      vi.mocked(execSync).mockImplementation((cmd: string) => {
+        if (cmd.includes("arm-none-eabi")) {
+          throw new Error("not found");
+        }
+        if (cmd === "which clang") {
+          return "/usr/bin/clang";
+        }
+        if (cmd === "which clang++") {
+          return "/usr/bin/clang++";
+        }
+        if (cmd.includes("--version")) {
+          return "clang version 14.0.0\n";
+        }
+        throw new Error("not found");
+      });
+      vi.mocked(existsSync).mockReturnValue(true);
+
+      const result = ToolchainDetector.detect();
+
+      expect(result).not.toBeNull();
+      expect(result!.name).toBe("clang");
+      expect(result!.cc).toBe("/usr/bin/clang");
+      expect(result!.cxx).toBe("/usr/bin/clang++");
+      expect(result!.isCrossCompiler).toBe(false);
+    });
+
+    it("detects gcc when ARM and clang are not available", () => {
+      vi.mocked(execSync).mockImplementation((cmd: string) => {
+        if (cmd.includes("arm-none-eabi") || cmd.includes("clang")) {
+          throw new Error("not found");
+        }
+        if (cmd === "which gcc") {
+          return "/usr/bin/gcc";
+        }
+        if (cmd === "which g++") {
+          return "/usr/bin/g++";
+        }
+        if (cmd.includes("--version")) {
+          return "gcc (Ubuntu 11.4.0) 11.4.0\n";
+        }
+        throw new Error("not found");
+      });
+      vi.mocked(existsSync).mockReturnValue(true);
+
+      const result = ToolchainDetector.detect();
+
+      expect(result).not.toBeNull();
+      expect(result!.name).toBe("gcc");
+      expect(result!.cc).toBe("/usr/bin/gcc");
+      expect(result!.cxx).toBe("/usr/bin/g++");
+      expect(result!.isCrossCompiler).toBe(false);
+    });
+
+    it("uses cc for cxx when c++ compiler not found", () => {
+      vi.mocked(execSync).mockImplementation((cmd: string) => {
+        if (cmd.includes("arm-none-eabi") || cmd.includes("clang")) {
+          throw new Error("not found");
+        }
+        if (cmd === "which gcc") {
+          return "/usr/bin/gcc";
+        }
+        if (cmd === "which g++") {
+          throw new Error("not found");
+        }
+        if (cmd.includes("--version")) {
+          return "gcc 11.4.0\n";
+        }
+        throw new Error("not found");
+      });
+      vi.mocked(existsSync).mockReturnValue(true);
+
+      const result = ToolchainDetector.detect();
+
+      expect(result!.cxx).toBe("/usr/bin/gcc");
+    });
+
+    it("returns null when executable path does not exist", () => {
+      vi.mocked(execSync).mockImplementation((cmd: string) => {
+        if (cmd === "which gcc") {
+          return "/usr/bin/gcc";
+        }
+        throw new Error("not found");
+      });
+      vi.mocked(existsSync).mockReturnValue(false);
+
+      const result = ToolchainDetector.detect();
+      expect(result).toBeNull();
+    });
+  });
+
+  describe("detectAll", () => {
+    it("returns empty array when no toolchains available", () => {
+      vi.mocked(execSync).mockImplementation(() => {
+        throw new Error("not found");
+      });
+
+      const result = ToolchainDetector.detectAll();
+      expect(result).toEqual([]);
+    });
+
+    it("returns all available toolchains", () => {
+      vi.mocked(execSync).mockImplementation((cmd: string) => {
+        if (cmd === "which arm-none-eabi-gcc") {
+          return "/usr/bin/arm-none-eabi-gcc";
+        }
+        if (cmd === "which arm-none-eabi-g++") {
+          return "/usr/bin/arm-none-eabi-g++";
+        }
+        if (cmd === "which clang") {
+          return "/usr/bin/clang";
+        }
+        if (cmd === "which clang++") {
+          return "/usr/bin/clang++";
+        }
+        if (cmd === "which gcc") {
+          return "/usr/bin/gcc";
+        }
+        if (cmd === "which g++") {
+          return "/usr/bin/g++";
+        }
+        if (cmd.includes("--version")) {
+          return "version 1.0\n";
+        }
+        throw new Error("not found");
+      });
+      vi.mocked(existsSync).mockReturnValue(true);
+
+      const result = ToolchainDetector.detectAll();
+
+      expect(result).toHaveLength(3);
+      expect(result.map((t) => t.name)).toEqual([
+        "arm-none-eabi-gcc",
+        "clang",
+        "gcc",
+      ]);
+    });
+  });
+
+  describe("getDefaultIncludePaths", () => {
+    it("parses include paths from compiler output", () => {
+      const compilerOutput = `Using built-in specs.
+#include "..." search starts here:
+#include <...> search starts here:
+ /usr/lib/gcc/x86_64-linux-gnu/11/include
+ /usr/local/include
+ /usr/include/x86_64-linux-gnu
+ /usr/include
+End of search list.
+`;
+      vi.mocked(execSync).mockReturnValue(compilerOutput);
+
+      const toolchain = {
+        name: "gcc",
+        cc: "/usr/bin/gcc",
+        cxx: "/usr/bin/g++",
+        cpp: "/usr/bin/gcc",
+        isCrossCompiler: false,
+      };
+
+      const paths = ToolchainDetector.getDefaultIncludePaths(toolchain);
+
+      expect(paths).toEqual([
+        "/usr/lib/gcc/x86_64-linux-gnu/11/include",
+        "/usr/local/include",
+        "/usr/include/x86_64-linux-gnu",
+        "/usr/include",
+      ]);
+    });
+
+    it("returns empty array when command fails", () => {
+      vi.mocked(execSync).mockImplementation(() => {
+        throw new Error("command failed");
+      });
+
+      const toolchain = {
+        name: "gcc",
+        cc: "/usr/bin/gcc",
+        cxx: "/usr/bin/g++",
+        cpp: "/usr/bin/gcc",
+        isCrossCompiler: false,
+      };
+
+      const paths = ToolchainDetector.getDefaultIncludePaths(toolchain);
+      expect(paths).toEqual([]);
+    });
+
+    it("returns empty array when no include section found", () => {
+      vi.mocked(execSync).mockReturnValue("Some other output\n");
+
+      const toolchain = {
+        name: "gcc",
+        cc: "/usr/bin/gcc",
+        cxx: "/usr/bin/g++",
+        cpp: "/usr/bin/gcc",
+        isCrossCompiler: false,
+      };
+
+      const paths = ToolchainDetector.getDefaultIncludePaths(toolchain);
+      expect(paths).toEqual([]);
+    });
+  });
+
+  describe("getPlatformIOIncludePaths", () => {
+    it("returns empty array when platformio.ini does not exist", () => {
+      vi.mocked(existsSync).mockReturnValue(false);
+
+      const paths = ToolchainDetector.getPlatformIOIncludePaths("/project");
+      expect(paths).toEqual([]);
+    });
+
+    it("parses include paths from PlatformIO config", () => {
+      vi.mocked(existsSync).mockReturnValue(true);
+      vi.mocked(execSync).mockReturnValue(
+        JSON.stringify({
+          env_esp32: {
+            build_flags: ["-DDEBUG", "-I/path/to/include", "-I/another/path"],
+          },
+        }),
+      );
+
+      const paths = ToolchainDetector.getPlatformIOIncludePaths("/project");
+
+      expect(paths).toEqual(["/path/to/include", "/another/path"]);
+    });
+
+    it("returns empty array when pio command fails", () => {
+      vi.mocked(existsSync).mockReturnValue(true);
+      vi.mocked(execSync).mockImplementation(() => {
+        throw new Error("pio not found");
+      });
+
+      const paths = ToolchainDetector.getPlatformIOIncludePaths("/project");
+      expect(paths).toEqual([]);
+    });
+
+    it("handles multiple environments", () => {
+      vi.mocked(existsSync).mockReturnValue(true);
+      vi.mocked(execSync).mockReturnValue(
+        JSON.stringify({
+          env_esp32: {
+            build_flags: ["-I/esp32/include"],
+          },
+          env_stm32: {
+            build_flags: ["-I/stm32/include"],
+          },
+        }),
+      );
+
+      const paths = ToolchainDetector.getPlatformIOIncludePaths("/project");
+
+      expect(paths).toContain("/esp32/include");
+      expect(paths).toContain("/stm32/include");
+    });
+
+    it("handles environment without build_flags", () => {
+      vi.mocked(existsSync).mockReturnValue(true);
+      vi.mocked(execSync).mockReturnValue(
+        JSON.stringify({
+          env_esp32: {
+            platform: "espressif32",
+          },
+        }),
+      );
+
+      const paths = ToolchainDetector.getPlatformIOIncludePaths("/project");
+      expect(paths).toEqual([]);
+    });
+  });
+
+  describe("version extraction", () => {
+    it("extracts version from first line of output", () => {
+      vi.mocked(execSync).mockImplementation((cmd: string) => {
+        if (cmd === "which gcc") {
+          return "/usr/bin/gcc";
+        }
+        if (cmd.includes("--version")) {
+          return "gcc (Ubuntu 11.4.0-1ubuntu1~22.04) 11.4.0\nCopyright (C) 2021\nMore lines...\n";
+        }
+        throw new Error("not found");
+      });
+      vi.mocked(existsSync).mockReturnValue(true);
+
+      const result = ToolchainDetector.detect();
+
+      expect(result!.version).toBe("gcc (Ubuntu 11.4.0-1ubuntu1~22.04) 11.4.0");
+    });
+
+    it("handles missing version gracefully", () => {
+      vi.mocked(execSync).mockImplementation((cmd: string) => {
+        if (cmd === "which gcc") {
+          return "/usr/bin/gcc";
+        }
+        if (cmd.includes("--version")) {
+          throw new Error("version failed");
+        }
+        throw new Error("not found");
+      });
+      vi.mocked(existsSync).mockReturnValue(true);
+
+      const result = ToolchainDetector.detect();
+
+      expect(result!.version).toBeUndefined();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Add 18 unit tests for `ToolchainDetector` covering detection priority (ARM > clang > gcc), include path parsing, and PlatformIO integration
- Add 31 unit tests for `Preprocessor` covering preprocessing, source mapping, line directive parsing, and error handling
- Mock `child_process` and `fs/promises` to avoid real filesystem and subprocess calls
- Add GCC define patterns (`DDEBUG`, `DVERSION`, `DDISABLED`) to cspell dictionary

## Test plan

- [x] All 49 new tests pass
- [x] Full unit test suite passes (2460 tests)
- [x] TypeScript type checking passes
- [x] All quality checks pass

🤖 Generated with [Claude Code](https://claude.ai/code)