### PR TITLE
Add unit tests for statement generators and fix negative binary bug

### DIFF
--- a/src/transpiler/output/codegen/generators/statements/SwitchGenerator.ts
+++ b/src/transpiler/output/codegen/generators/statements/SwitchGenerator.ts
@@ -111,7 +111,8 @@ const generateCaseLabel = (
     // Check if minus token exists (first child would be '-')
     const hasNeg = node.children && node.children[0]?.getText() === "-";
     const value = BigInt(binText); // BigInt handles 0b prefix natively
-    const hexStr = (hasNeg ? -value : value).toString(16).toUpperCase();
+    // Use positive value for hex string - hasNeg handles the sign prefix separately
+    const hexStr = value.toString(16).toUpperCase();
     // Add ULL suffix for values that exceed 32-bit range
     const needsULL = value > 0xffffffffn;
     return {

--- a/src/transpiler/output/codegen/generators/statements/__tests__/ControlFlowGenerator.test.ts
+++ b/src/transpiler/output/codegen/generators/statements/__tests__/ControlFlowGenerator.test.ts
@@ -1,0 +1,1016 @@
+import { describe, it, expect, vi } from "vitest";
+import controlFlowGenerators from "../ControlFlowGenerator";
+import IGeneratorInput from "../../IGeneratorInput";
+import IGeneratorState from "../../IGeneratorState";
+import IOrchestrator from "../../IOrchestrator";
+import * as Parser from "../../../../../logic/parser/grammar/CNextParser";
+
+const {
+  generateReturn,
+  generateIf,
+  generateWhile,
+  generateDoWhile,
+  generateFor,
+  generateForVarDecl,
+  generateForAssignment,
+} = controlFlowGenerators;
+
+// ========================================================================
+// Test Helpers - Mock Contexts
+// ========================================================================
+
+/**
+ * Create a mock expression context. Can be configured to be "simple" or "complex".
+ * For simple: navigates down the chain to a simple identifier
+ */
+function createMockExpression(options?: {
+  text?: string;
+  isSimple?: boolean;
+  identifier?: string;
+  hasPostfixOp?: boolean;
+  line?: number;
+  col?: number;
+}): Parser.ExpressionContext {
+  const text = options?.text ?? "x";
+  const isSimple = options?.isSimple ?? true;
+  const identifier = options?.identifier ?? text;
+
+  // Build a mock expression tree that the isSimpleExpression/getSimpleIdentifier functions can navigate
+  if (isSimple) {
+    const primaryExpr = {
+      IDENTIFIER: () => ({ getText: () => identifier }),
+      getText: () => text,
+    };
+    const postfixExpr = {
+      primaryExpression: () => primaryExpr,
+      postfixOp: () => (options?.hasPostfixOp ? [{}] : []),
+    };
+    const unaryExpr = { postfixExpression: () => postfixExpr };
+    const mulExpr = { unaryExpression: () => [unaryExpr] };
+    const addExpr = { multiplicativeExpression: () => [mulExpr] };
+    const shiftExpr = { additiveExpression: () => [addExpr] };
+    const bandExpr = { shiftExpression: () => [shiftExpr] };
+    const bxorExpr = { bitwiseAndExpression: () => [bandExpr] };
+    const borExpr = { bitwiseXorExpression: () => [bxorExpr] };
+    const relExpr = { bitwiseOrExpression: () => [borExpr] };
+    const eqExpr = { relationalExpression: () => [relExpr] };
+    const andExpr = { equalityExpression: () => [eqExpr] };
+    const orExpr = { andExpression: () => [andExpr] };
+    const ternaryExpr = { orExpression: () => [orExpr] };
+
+    return {
+      ternaryExpression: () => ternaryExpr,
+      getText: () => text,
+      start: { line: options?.line ?? 1, column: options?.col ?? 0 },
+    } as unknown as Parser.ExpressionContext;
+  }
+
+  // Complex expression - multiple operands at some level
+  const mulExpr1 = { unaryExpression: () => [{}, {}] }; // Two operands = complex
+  const addExpr = { multiplicativeExpression: () => [mulExpr1] };
+  const shiftExpr = { additiveExpression: () => [addExpr] };
+  const bandExpr = { shiftExpression: () => [shiftExpr] };
+  const bxorExpr = { bitwiseAndExpression: () => [bandExpr] };
+  const borExpr = { bitwiseXorExpression: () => [bxorExpr] };
+  const relExpr = { bitwiseOrExpression: () => [borExpr] };
+  const eqExpr = { relationalExpression: () => [relExpr] };
+  const andExpr = { equalityExpression: () => [eqExpr] };
+  const orExpr = { andExpression: () => [andExpr] };
+  const ternaryExpr = { orExpression: () => [orExpr] };
+
+  return {
+    ternaryExpression: () => ternaryExpr,
+    getText: () => text,
+    start: { line: options?.line ?? 1, column: options?.col ?? 0 },
+  } as unknown as Parser.ExpressionContext;
+}
+
+/**
+ * Create a mock return statement context
+ */
+function createMockReturnStatement(
+  expr?: Parser.ExpressionContext,
+): Parser.ReturnStatementContext {
+  return {
+    expression: () => expr ?? null,
+  } as unknown as Parser.ReturnStatementContext;
+}
+
+/**
+ * Create a mock statement context
+ */
+function createMockStatement(
+  blockCtx?: Parser.BlockContext,
+): Parser.StatementContext {
+  return {
+    block: () => blockCtx ?? null,
+  } as unknown as Parser.StatementContext;
+}
+
+/**
+ * Create a mock block context
+ */
+function createMockBlock(): Parser.BlockContext {
+  return {
+    statement: () => [],
+  } as unknown as Parser.BlockContext;
+}
+
+/**
+ * Create a mock if statement context
+ */
+function createMockIfStatement(options?: {
+  expr?: Parser.ExpressionContext;
+  thenStmt?: Parser.StatementContext;
+  elseStmt?: Parser.StatementContext;
+}): Parser.IfStatementContext {
+  const statements = [options?.thenStmt ?? createMockStatement()];
+  if (options?.elseStmt) {
+    statements.push(options.elseStmt);
+  }
+  return {
+    expression: () => options?.expr ?? createMockExpression(),
+    statement: () => statements,
+  } as unknown as Parser.IfStatementContext;
+}
+
+/**
+ * Create a mock while statement context
+ */
+function createMockWhileStatement(options?: {
+  expr?: Parser.ExpressionContext;
+  stmt?: Parser.StatementContext;
+}): Parser.WhileStatementContext {
+  return {
+    expression: () => options?.expr ?? createMockExpression(),
+    statement: () => options?.stmt ?? createMockStatement(),
+  } as unknown as Parser.WhileStatementContext;
+}
+
+/**
+ * Create a mock do-while statement context
+ */
+function createMockDoWhileStatement(options?: {
+  expr?: Parser.ExpressionContext;
+  block?: Parser.BlockContext;
+}): Parser.DoWhileStatementContext {
+  return {
+    expression: () => options?.expr ?? createMockExpression(),
+    block: () => options?.block ?? createMockBlock(),
+  } as unknown as Parser.DoWhileStatementContext;
+}
+
+/**
+ * Create a mock type context
+ */
+function createMockType(typeName: string): Parser.TypeContext {
+  return {
+    getText: () => typeName,
+  } as unknown as Parser.TypeContext;
+}
+
+/**
+ * Create a mock for variable declaration context
+ */
+function createMockForVarDecl(options?: {
+  type?: Parser.TypeContext;
+  identifier?: string;
+  expr?: Parser.ExpressionContext;
+  atomicMod?: boolean;
+  volatileMod?: boolean;
+  arrayDims?: Parser.ArrayDimensionContext[];
+}): Parser.ForVarDeclContext {
+  return {
+    atomicModifier: () => (options?.atomicMod ? {} : null),
+    volatileModifier: () => (options?.volatileMod ? {} : null),
+    type: () => options?.type ?? createMockType("i32"),
+    IDENTIFIER: () => ({ getText: () => options?.identifier ?? "i" }),
+    arrayDimension: () => options?.arrayDims ?? [],
+    expression: () => options?.expr ?? null,
+  } as unknown as Parser.ForVarDeclContext;
+}
+
+/**
+ * Create a mock assignment target context
+ */
+function createMockAssignmentTarget(
+  text: string,
+): Parser.AssignmentTargetContext {
+  return {
+    getText: () => text,
+  } as unknown as Parser.AssignmentTargetContext;
+}
+
+/**
+ * Create a mock assignment operator context
+ */
+function createMockAssignmentOperator(
+  op: string,
+): Parser.AssignmentOperatorContext {
+  return {
+    getText: () => op,
+  } as unknown as Parser.AssignmentOperatorContext;
+}
+
+/**
+ * Create a mock for assignment context
+ */
+function createMockForAssignment(options?: {
+  target?: Parser.AssignmentTargetContext;
+  operator?: Parser.AssignmentOperatorContext;
+  expr?: Parser.ExpressionContext;
+}): Parser.ForAssignmentContext {
+  return {
+    assignmentTarget: () => options?.target ?? createMockAssignmentTarget("i"),
+    assignmentOperator: () =>
+      options?.operator ?? createMockAssignmentOperator("<-"),
+    expression: () => options?.expr ?? createMockExpression(),
+  } as unknown as Parser.ForAssignmentContext;
+}
+
+/**
+ * Create a mock for init context
+ */
+function createMockForInit(options?: {
+  varDecl?: Parser.ForVarDeclContext;
+  assignment?: Parser.ForAssignmentContext;
+}): Parser.ForInitContext {
+  return {
+    forVarDecl: () => options?.varDecl ?? null,
+    forAssignment: () => options?.assignment ?? null,
+  } as unknown as Parser.ForInitContext;
+}
+
+/**
+ * Create a mock for update context
+ */
+function createMockForUpdate(options?: {
+  target?: Parser.AssignmentTargetContext;
+  operator?: Parser.AssignmentOperatorContext;
+  expr?: Parser.ExpressionContext;
+}): Parser.ForUpdateContext {
+  return {
+    assignmentTarget: () => options?.target ?? createMockAssignmentTarget("i"),
+    assignmentOperator: () =>
+      options?.operator ?? createMockAssignmentOperator("+<-"),
+    expression: () => options?.expr ?? createMockExpression({ text: "1" }),
+  } as unknown as Parser.ForUpdateContext;
+}
+
+/**
+ * Create a mock for statement context
+ */
+function createMockForStatement(options?: {
+  init?: Parser.ForInitContext;
+  expr?: Parser.ExpressionContext;
+  update?: Parser.ForUpdateContext;
+  stmt?: Parser.StatementContext;
+}): Parser.ForStatementContext {
+  return {
+    forInit: () => options?.init ?? null,
+    expression: () => options?.expr ?? null,
+    forUpdate: () => options?.update ?? null,
+    statement: () => options?.stmt ?? createMockStatement(),
+  } as unknown as Parser.ForStatementContext;
+}
+
+// ========================================================================
+// Test Helpers - Mock Input/State/Orchestrator
+// ========================================================================
+
+/**
+ * Create minimal mock input.
+ */
+function createMockInput(options?: {
+  enumMembers?: Map<string, Map<string, number>>;
+}): IGeneratorInput {
+  const enumMembers = options?.enumMembers ?? new Map();
+  return {
+    symbols: {
+      enumMembers,
+      knownScopes: new Set(),
+      knownStructs: new Set(),
+      knownRegisters: new Set(),
+      knownEnums: new Set(enumMembers.keys()),
+      knownBitmaps: new Set(),
+      scopeMembers: new Map(),
+      scopeMemberVisibility: new Map(),
+      structFields: new Map(),
+      structFieldArrays: new Map(),
+      structFieldDimensions: new Map(),
+      bitmapFields: new Map(),
+      bitmapBackingType: new Map(),
+      bitmapBitWidth: new Map(),
+      scopedRegisters: new Map(),
+      registerMemberAccess: new Map(),
+      registerMemberTypes: new Map(),
+      scopePrivateConstValues: new Map(),
+    },
+    symbolTable: null,
+    typeRegistry: new Map(),
+    functionSignatures: new Map(),
+    knownFunctions: new Set(),
+    knownStructs: new Set(),
+    constValues: new Map(),
+    callbackTypes: new Map(),
+    callbackFieldTypes: new Map(),
+    targetCapabilities: { hasAtomicSupport: false },
+    debugMode: false,
+  } as unknown as IGeneratorInput;
+}
+
+/**
+ * Create minimal mock state.
+ */
+function createMockState(): IGeneratorState {
+  return {
+    currentScope: null,
+    indentLevel: 0,
+    inFunctionBody: true,
+    currentParameters: new Map(),
+    localVariables: new Set(),
+    localArrays: new Set(),
+    expectedType: null,
+    selfIncludeAdded: false,
+  };
+}
+
+/**
+ * Create mock orchestrator for control flow generators.
+ */
+function createMockOrchestrator(options?: {
+  returnType?: string | null;
+  exprCode?: string;
+  statementCode?: string;
+  blockCode?: string;
+  typeCode?: string;
+  tempDeclarations?: string;
+  lengthCacheDecls?: string;
+}): IOrchestrator {
+  return {
+    getCurrentFunctionReturnType: vi.fn(() => options?.returnType ?? null),
+    generateExpression: vi.fn(() => options?.exprCode ?? "x"),
+    generateExpressionWithExpectedType: vi.fn(() => options?.exprCode ?? "x"),
+    generateStatement: vi.fn(() => options?.statementCode ?? "{}"),
+    generateBlock: vi.fn(() => options?.blockCode ?? "{ }"),
+    generateType: vi.fn(() => options?.typeCode ?? "int"),
+    generateAssignmentTarget: vi.fn((ctx) => ctx.getText?.() ?? "target"),
+    generateArrayDimensions: vi.fn(() => "[10]"),
+    registerLocalVariable: vi.fn(),
+    flushPendingTempDeclarations: vi.fn(() => options?.tempDeclarations ?? ""),
+    validateConditionNoFunctionCall: vi.fn(),
+    validateDoWhileCondition: vi.fn(),
+    countStringLengthAccesses: vi.fn(() => new Map()),
+    countBlockLengthAccesses: vi.fn(),
+    setupLengthCache: vi.fn(() => options?.lengthCacheDecls ?? ""),
+    clearLengthCache: vi.fn(),
+  } as unknown as IOrchestrator;
+}
+
+// ========================================================================
+// Tests - generateReturn
+// ========================================================================
+
+describe("ControlFlowGenerator", () => {
+  describe("generateReturn", () => {
+    it("generates simple return without expression", () => {
+      const ctx = createMockReturnStatement();
+      const input = createMockInput();
+      const state = createMockState();
+      const orchestrator = createMockOrchestrator();
+
+      const result = generateReturn(ctx, input, state, orchestrator);
+
+      expect(result.code).toBe("return;");
+      expect(result.effects).toEqual([]);
+    });
+
+    it("generates return with expression", () => {
+      const ctx = createMockReturnStatement(
+        createMockExpression({ text: "42" }),
+      );
+      const input = createMockInput();
+      const state = createMockState();
+      const orchestrator = createMockOrchestrator({ exprCode: "42" });
+
+      const result = generateReturn(ctx, input, state, orchestrator);
+
+      expect(result.code).toBe("return 42;");
+    });
+
+    it("uses expectedType when returning enum value (Issue #477)", () => {
+      const ctx = createMockReturnStatement(
+        createMockExpression({ text: "IDLE" }),
+      );
+      const input = createMockInput({
+        enumMembers: new Map([["State", new Map([["IDLE", 0]])]]),
+      });
+      const state = createMockState();
+      const generateExpressionWithExpectedType = vi.fn(() => "State_IDLE");
+      const orchestrator = {
+        ...createMockOrchestrator({ returnType: "State" }),
+        generateExpressionWithExpectedType,
+      } as unknown as IOrchestrator;
+
+      const result = generateReturn(ctx, input, state, orchestrator);
+
+      expect(generateExpressionWithExpectedType).toHaveBeenCalledWith(
+        expect.anything(),
+        "State",
+      );
+      expect(result.code).toBe("return State_IDLE;");
+    });
+
+    it("throws for unqualified enum member in non-enum return (Issue #477)", () => {
+      const ctx = createMockReturnStatement(
+        createMockExpression({ identifier: "IDLE", line: 10, col: 5 }),
+      );
+      const input = createMockInput({
+        enumMembers: new Map([["State", new Map([["IDLE", 0]])]]),
+      });
+      const state = createMockState();
+      const orchestrator = createMockOrchestrator({ returnType: "u8" }); // non-enum
+
+      expect(() => generateReturn(ctx, input, state, orchestrator)).toThrow(
+        "10:5 error[E0424]: 'IDLE' is not defined; did you mean 'State.IDLE'?",
+      );
+    });
+
+    it("allows unqualified identifier that is not an enum member", () => {
+      const ctx = createMockReturnStatement(
+        createMockExpression({ identifier: "count" }),
+      );
+      const input = createMockInput({
+        enumMembers: new Map([["State", new Map([["IDLE", 0]])]]),
+      });
+      const state = createMockState();
+      const orchestrator = createMockOrchestrator({
+        returnType: "u32",
+        exprCode: "count",
+      });
+
+      const result = generateReturn(ctx, input, state, orchestrator);
+
+      expect(result.code).toBe("return count;");
+    });
+
+    it("does not throw for complex expressions containing enum-like identifiers", () => {
+      // Complex expression (a + b) should not be checked for enum membership
+      const ctx = createMockReturnStatement(
+        createMockExpression({ text: "a + IDLE", isSimple: false }),
+      );
+      const input = createMockInput({
+        enumMembers: new Map([["State", new Map([["IDLE", 0]])]]),
+      });
+      const state = createMockState();
+      const orchestrator = createMockOrchestrator({
+        returnType: "u32",
+        exprCode: "a + IDLE",
+      });
+
+      // Should not throw because expression is complex
+      const result = generateReturn(ctx, input, state, orchestrator);
+
+      expect(result.code).toBe("return a + IDLE;");
+    });
+  });
+
+  // ========================================================================
+  // Tests - generateIf
+  // ========================================================================
+
+  describe("generateIf", () => {
+    it("generates simple if statement", () => {
+      const ctx = createMockIfStatement();
+      const input = createMockInput();
+      const state = createMockState();
+      const orchestrator = createMockOrchestrator({
+        exprCode: "flag",
+        statementCode: "{ x = 1; }",
+      });
+
+      const result = generateIf(ctx, input, state, orchestrator);
+
+      expect(result.code).toBe("if (flag) { x = 1; }");
+    });
+
+    it("generates if-else statement", () => {
+      const ctx = createMockIfStatement({
+        thenStmt: createMockStatement(),
+        elseStmt: createMockStatement(),
+      });
+      const input = createMockInput();
+      const state = createMockState();
+      let stmtCount = 0;
+      const orchestrator = {
+        ...createMockOrchestrator({ exprCode: "x > 0" }),
+        generateStatement: vi.fn(() =>
+          stmtCount++ === 0 ? "{ a = 1; }" : "{ a = 2; }",
+        ),
+      } as unknown as IOrchestrator;
+
+      const result = generateIf(ctx, input, state, orchestrator);
+
+      expect(result.code).toBe("if (x > 0) { a = 1; } else { a = 2; }");
+    });
+
+    it("validates no function calls in condition (Issue #254)", () => {
+      const expr = createMockExpression();
+      const ctx = createMockIfStatement({ expr });
+      const input = createMockInput();
+      const state = createMockState();
+      const validateConditionNoFunctionCall = vi.fn();
+      const orchestrator = {
+        ...createMockOrchestrator(),
+        validateConditionNoFunctionCall,
+      } as unknown as IOrchestrator;
+
+      generateIf(ctx, input, state, orchestrator);
+
+      expect(validateConditionNoFunctionCall).toHaveBeenCalledWith(expr, "if");
+    });
+
+    it("throws when validation fails (function in condition)", () => {
+      const ctx = createMockIfStatement();
+      const input = createMockInput();
+      const state = createMockState();
+      const orchestrator = {
+        ...createMockOrchestrator(),
+        validateConditionNoFunctionCall: () => {
+          throw new Error("E0702: Function call not allowed in if condition");
+        },
+      } as unknown as IOrchestrator;
+
+      expect(() => generateIf(ctx, input, state, orchestrator)).toThrow(
+        "Function call not allowed in if condition",
+      );
+    });
+
+    it("flushes temp declarations before branches (Issue #250)", () => {
+      const ctx = createMockIfStatement();
+      const input = createMockInput();
+      const state = createMockState();
+      const orchestrator = createMockOrchestrator({
+        exprCode: "tmp_1",
+        tempDeclarations: "int tmp_1 = getValue();",
+        statementCode: "{ use(tmp_1); }",
+      });
+
+      const result = generateIf(ctx, input, state, orchestrator);
+
+      expect(result.code).toContain("int tmp_1 = getValue();");
+      expect(result.code).toContain("if (tmp_1)");
+    });
+
+    it("sets up strlen cache for length optimization", () => {
+      const ctx = createMockIfStatement();
+      const input = createMockInput();
+      const state = createMockState();
+      const setupLengthCache = vi.fn(() => "size_t __len_str = strlen(str);\n");
+      const orchestrator = {
+        ...createMockOrchestrator({ exprCode: "__len_str > 0" }),
+        setupLengthCache,
+        countStringLengthAccesses: vi.fn(() => new Map([["str", 2]])),
+      } as unknown as IOrchestrator;
+
+      const result = generateIf(ctx, input, state, orchestrator);
+
+      expect(setupLengthCache).toHaveBeenCalled();
+      expect(result.code).toContain("__len_str");
+    });
+
+    it("clears length cache after generating", () => {
+      const ctx = createMockIfStatement();
+      const input = createMockInput();
+      const state = createMockState();
+      const clearLengthCache = vi.fn();
+      const orchestrator = {
+        ...createMockOrchestrator(),
+        clearLengthCache,
+      } as unknown as IOrchestrator;
+
+      generateIf(ctx, input, state, orchestrator);
+
+      expect(clearLengthCache).toHaveBeenCalled();
+    });
+  });
+
+  // ========================================================================
+  // Tests - generateWhile
+  // ========================================================================
+
+  describe("generateWhile", () => {
+    it("generates simple while loop", () => {
+      const ctx = createMockWhileStatement();
+      const input = createMockInput();
+      const state = createMockState();
+      const orchestrator = createMockOrchestrator({
+        exprCode: "i < 10",
+        statementCode: "{ i++; }",
+      });
+
+      const result = generateWhile(ctx, input, state, orchestrator);
+
+      expect(result.code).toBe("while (i < 10) { i++; }");
+    });
+
+    it("validates no function calls in condition (Issue #254)", () => {
+      const expr = createMockExpression();
+      const ctx = createMockWhileStatement({ expr });
+      const input = createMockInput();
+      const state = createMockState();
+      const validateConditionNoFunctionCall = vi.fn();
+      const orchestrator = {
+        ...createMockOrchestrator(),
+        validateConditionNoFunctionCall,
+      } as unknown as IOrchestrator;
+
+      generateWhile(ctx, input, state, orchestrator);
+
+      expect(validateConditionNoFunctionCall).toHaveBeenCalledWith(
+        expr,
+        "while",
+      );
+    });
+
+    it("flushes temp declarations before body (Issue #250)", () => {
+      const ctx = createMockWhileStatement();
+      const input = createMockInput();
+      const state = createMockState();
+      const orchestrator = createMockOrchestrator({
+        exprCode: "tmp_1",
+        tempDeclarations: "bool tmp_1 = hasMore();",
+        statementCode: "{ process(); }",
+      });
+
+      const result = generateWhile(ctx, input, state, orchestrator);
+
+      expect(result.code).toContain("bool tmp_1 = hasMore();");
+      expect(result.code).toContain("while (tmp_1)");
+    });
+
+    it("returns empty effects", () => {
+      const ctx = createMockWhileStatement();
+      const input = createMockInput();
+      const state = createMockState();
+      const orchestrator = createMockOrchestrator();
+
+      const result = generateWhile(ctx, input, state, orchestrator);
+
+      expect(result.effects).toEqual([]);
+    });
+  });
+
+  // ========================================================================
+  // Tests - generateDoWhile
+  // ========================================================================
+
+  describe("generateDoWhile", () => {
+    it("generates simple do-while loop (ADR-027)", () => {
+      const ctx = createMockDoWhileStatement();
+      const input = createMockInput();
+      const state = createMockState();
+      const orchestrator = createMockOrchestrator({
+        exprCode: "count > 0",
+        blockCode: "{ count--; }",
+      });
+
+      const result = generateDoWhile(ctx, input, state, orchestrator);
+
+      expect(result.code).toBe("do { count--; } while (count > 0);");
+    });
+
+    it("validates do-while condition (E0701)", () => {
+      const expr = createMockExpression();
+      const ctx = createMockDoWhileStatement({ expr });
+      const input = createMockInput();
+      const state = createMockState();
+      const validateDoWhileCondition = vi.fn();
+      const orchestrator = {
+        ...createMockOrchestrator(),
+        validateDoWhileCondition,
+      } as unknown as IOrchestrator;
+
+      generateDoWhile(ctx, input, state, orchestrator);
+
+      expect(validateDoWhileCondition).toHaveBeenCalledWith(expr);
+    });
+
+    it("validates no function calls in condition (Issue #254)", () => {
+      const expr = createMockExpression();
+      const ctx = createMockDoWhileStatement({ expr });
+      const input = createMockInput();
+      const state = createMockState();
+      const validateConditionNoFunctionCall = vi.fn();
+      const orchestrator = {
+        ...createMockOrchestrator(),
+        validateConditionNoFunctionCall,
+      } as unknown as IOrchestrator;
+
+      generateDoWhile(ctx, input, state, orchestrator);
+
+      expect(validateConditionNoFunctionCall).toHaveBeenCalledWith(
+        expr,
+        "do-while",
+      );
+    });
+
+    it("flushes temp declarations before loop (Issue #250)", () => {
+      const ctx = createMockDoWhileStatement();
+      const input = createMockInput();
+      const state = createMockState();
+      const orchestrator = createMockOrchestrator({
+        exprCode: "tmp_1",
+        tempDeclarations: "int tmp_1 = check();",
+        blockCode: "{ work(); }",
+      });
+
+      const result = generateDoWhile(ctx, input, state, orchestrator);
+
+      expect(result.code).toContain("int tmp_1 = check();");
+      expect(result.code).toContain("while (tmp_1);");
+    });
+  });
+
+  // ========================================================================
+  // Tests - generateForVarDecl
+  // ========================================================================
+
+  describe("generateForVarDecl", () => {
+    it("generates simple variable declaration", () => {
+      const ctx = createMockForVarDecl({ identifier: "i" });
+      const input = createMockInput();
+      const state = createMockState();
+      const orchestrator = createMockOrchestrator({ typeCode: "int" });
+
+      const result = generateForVarDecl(ctx, input, state, orchestrator);
+
+      expect(result.code).toBe("int i");
+    });
+
+    it("generates declaration with initialization", () => {
+      const ctx = createMockForVarDecl({
+        identifier: "i",
+        expr: createMockExpression({ text: "0" }),
+      });
+      const input = createMockInput();
+      const state = createMockState();
+      const orchestrator = createMockOrchestrator({
+        typeCode: "int",
+        exprCode: "0",
+      });
+
+      const result = generateForVarDecl(ctx, input, state, orchestrator);
+
+      expect(result.code).toBe("int i = 0");
+    });
+
+    it("adds atomic modifier as volatile", () => {
+      const ctx = createMockForVarDecl({
+        identifier: "count",
+        atomicMod: true,
+      });
+      const input = createMockInput();
+      const state = createMockState();
+      const orchestrator = createMockOrchestrator({ typeCode: "int" });
+
+      const result = generateForVarDecl(ctx, input, state, orchestrator);
+
+      expect(result.code).toBe("volatile int count");
+    });
+
+    it("adds volatile modifier", () => {
+      const ctx = createMockForVarDecl({
+        identifier: "reg",
+        volatileMod: true,
+      });
+      const input = createMockInput();
+      const state = createMockState();
+      const orchestrator = createMockOrchestrator({ typeCode: "uint8_t" });
+
+      const result = generateForVarDecl(ctx, input, state, orchestrator);
+
+      expect(result.code).toBe("volatile uint8_t reg");
+    });
+
+    it("registers local variable (ADR-016)", () => {
+      const ctx = createMockForVarDecl({ identifier: "index" });
+      const input = createMockInput();
+      const state = createMockState();
+      const registerLocalVariable = vi.fn();
+      const orchestrator = {
+        ...createMockOrchestrator(),
+        registerLocalVariable,
+      } as unknown as IOrchestrator;
+
+      generateForVarDecl(ctx, input, state, orchestrator);
+
+      expect(registerLocalVariable).toHaveBeenCalledWith("index");
+    });
+
+    it("generates array dimensions (ADR-036)", () => {
+      const arrayDim = {} as Parser.ArrayDimensionContext;
+      const ctx = createMockForVarDecl({
+        identifier: "arr",
+        arrayDims: [arrayDim],
+      });
+      const input = createMockInput();
+      const state = createMockState();
+      const orchestrator = createMockOrchestrator({ typeCode: "int" });
+
+      const result = generateForVarDecl(ctx, input, state, orchestrator);
+
+      expect(result.code).toBe("int arr[10]");
+    });
+  });
+
+  // ========================================================================
+  // Tests - generateForAssignment
+  // ========================================================================
+
+  describe("generateForAssignment", () => {
+    it("generates simple assignment with <- operator", () => {
+      const ctx = createMockForAssignment({
+        target: createMockAssignmentTarget("i"),
+        operator: createMockAssignmentOperator("<-"),
+      });
+      const input = createMockInput();
+      const state = createMockState();
+      const orchestrator = createMockOrchestrator({ exprCode: "0" });
+
+      const result = generateForAssignment(ctx, input, state, orchestrator);
+
+      expect(result.code).toBe("i = 0");
+    });
+
+    it("generates compound assignment with +<- operator", () => {
+      const ctx = createMockForAssignment({
+        target: createMockAssignmentTarget("i"),
+        operator: createMockAssignmentOperator("+<-"),
+      });
+      const input = createMockInput();
+      const state = createMockState();
+      const orchestrator = createMockOrchestrator({ exprCode: "1" });
+
+      const result = generateForAssignment(ctx, input, state, orchestrator);
+
+      expect(result.code).toBe("i += 1");
+    });
+
+    it("maps all assignment operators correctly", () => {
+      const operators: [string, string][] = [
+        ["<-", "="],
+        ["+<-", "+="],
+        ["-<-", "-="],
+        ["*<-", "*="],
+        ["/<-", "/="],
+        ["%<-", "%="],
+        ["&<-", "&="],
+        ["|<-", "|="],
+        ["^<-", "^="],
+        ["<<<-", "<<="],
+        [">><-", ">>="],
+      ];
+
+      for (const [cnextOp, cOp] of operators) {
+        const ctx = createMockForAssignment({
+          target: createMockAssignmentTarget("x"),
+          operator: createMockAssignmentOperator(cnextOp),
+        });
+        const input = createMockInput();
+        const state = createMockState();
+        const orchestrator = createMockOrchestrator({ exprCode: "1" });
+
+        const result = generateForAssignment(ctx, input, state, orchestrator);
+
+        expect(result.code).toBe(`x ${cOp} 1`);
+      }
+    });
+  });
+
+  // ========================================================================
+  // Tests - generateFor
+  // ========================================================================
+
+  describe("generateFor", () => {
+    it("generates empty for loop (infinite loop)", () => {
+      const ctx = createMockForStatement();
+      const input = createMockInput();
+      const state = createMockState();
+      const orchestrator = createMockOrchestrator({ statementCode: "{ }" });
+
+      const result = generateFor(ctx, input, state, orchestrator);
+
+      expect(result.code).toBe("for (; ; ) { }");
+    });
+
+    it("generates for loop with all parts", () => {
+      const ctx = createMockForStatement({
+        init: createMockForInit({
+          varDecl: createMockForVarDecl({
+            identifier: "i",
+            expr: createMockExpression({ text: "0" }),
+          }),
+        }),
+        expr: createMockExpression({ text: "i < 10" }),
+        update: createMockForUpdate(),
+        stmt: createMockStatement(),
+      });
+      const input = createMockInput();
+      const state = createMockState();
+      let exprCount = 0;
+      const orchestrator = {
+        ...createMockOrchestrator({ typeCode: "int" }),
+        generateExpression: vi.fn(() => {
+          return ["0", "i < 10", "1"][exprCount++] ?? "x";
+        }),
+        generateStatement: vi.fn(() => "{ body(); }"),
+      } as unknown as IOrchestrator;
+
+      const result = generateFor(ctx, input, state, orchestrator);
+
+      expect(result.code).toContain(
+        "for (int i = 0; i < 10; i += 1) { body(); }",
+      );
+    });
+
+    it("generates for loop with assignment init", () => {
+      const ctx = createMockForStatement({
+        init: createMockForInit({
+          assignment: createMockForAssignment({
+            target: createMockAssignmentTarget("i"),
+            operator: createMockAssignmentOperator("<-"),
+          }),
+        }),
+      });
+      const input = createMockInput();
+      const state = createMockState();
+      const orchestrator = createMockOrchestrator({
+        exprCode: "0",
+        statementCode: "{ }",
+      });
+
+      const result = generateFor(ctx, input, state, orchestrator);
+
+      expect(result.code).toContain("for (i = 0;");
+    });
+
+    it("validates no function calls in condition (Issue #254)", () => {
+      const expr = createMockExpression();
+      const ctx = createMockForStatement({ expr });
+      const input = createMockInput();
+      const state = createMockState();
+      const validateConditionNoFunctionCall = vi.fn();
+      const orchestrator = {
+        ...createMockOrchestrator(),
+        validateConditionNoFunctionCall,
+      } as unknown as IOrchestrator;
+
+      generateFor(ctx, input, state, orchestrator);
+
+      expect(validateConditionNoFunctionCall).toHaveBeenCalledWith(expr, "for");
+    });
+
+    it("flushes temp declarations from all stages (Issue #250)", () => {
+      const ctx = createMockForStatement({
+        init: createMockForInit({
+          varDecl: createMockForVarDecl(),
+        }),
+        expr: createMockExpression(),
+        update: createMockForUpdate(),
+      });
+      const input = createMockInput();
+      const state = createMockState();
+      let flushCount = 0;
+      const temps = ["int tmp_init;", "int tmp_cond;", "int tmp_update;", ""];
+      const orchestrator = {
+        ...createMockOrchestrator(),
+        flushPendingTempDeclarations: vi.fn(() => temps[flushCount++] ?? ""),
+      } as unknown as IOrchestrator;
+
+      const result = generateFor(ctx, input, state, orchestrator);
+
+      // All temps should be prepended before the for loop
+      expect(result.code).toContain("int tmp_init;");
+      expect(result.code).toContain("int tmp_cond;");
+      expect(result.code).toContain("int tmp_update;");
+      expect(result.code).toContain("for (");
+    });
+
+    it("collects effects from init", () => {
+      const ctx = createMockForStatement({
+        init: createMockForInit({
+          varDecl: createMockForVarDecl(),
+        }),
+      });
+      const input = createMockInput();
+      const state = createMockState();
+      const orchestrator = createMockOrchestrator();
+
+      const result = generateFor(ctx, input, state, orchestrator);
+
+      // Effects come from generateForVarDecl which returns empty effects
+      expect(result.effects).toEqual([]);
+    });
+  });
+});

--- a/src/transpiler/output/codegen/generators/statements/__tests__/CriticalGenerator.test.ts
+++ b/src/transpiler/output/codegen/generators/statements/__tests__/CriticalGenerator.test.ts
@@ -1,0 +1,300 @@
+import { describe, it, expect, vi } from "vitest";
+import generateCriticalStatement from "../CriticalGenerator";
+import IGeneratorInput from "../../IGeneratorInput";
+import IGeneratorState from "../../IGeneratorState";
+import IOrchestrator from "../../IOrchestrator";
+import * as Parser from "../../../../../logic/parser/grammar/CNextParser";
+
+// ========================================================================
+// Test Helpers
+// ========================================================================
+
+/**
+ * Create a minimal mock block context.
+ */
+function createMockBlockContext(): Parser.BlockContext {
+  return {} as Parser.BlockContext;
+}
+
+/**
+ * Create a minimal mock critical statement context.
+ * CriticalGenerator only uses node.block()
+ */
+function createMockCriticalContext(
+  blockCtx?: Parser.BlockContext,
+): Parser.CriticalStatementContext {
+  const block = blockCtx ?? createMockBlockContext();
+  return {
+    block: () => block,
+  } as unknown as Parser.CriticalStatementContext;
+}
+
+/**
+ * Create minimal mock input.
+ * CriticalGenerator doesn't use input (_input parameter).
+ */
+function createMockInput(): IGeneratorInput {
+  return {
+    symbols: null,
+    symbolTable: null,
+    typeRegistry: new Map(),
+    functionSignatures: new Map(),
+    knownFunctions: new Set(),
+    knownStructs: new Set(),
+    constValues: new Map(),
+    callbackTypes: new Map(),
+    callbackFieldTypes: new Map(),
+    targetCapabilities: { hasAtomicSupport: false },
+    debugMode: false,
+  } as unknown as IGeneratorInput;
+}
+
+/**
+ * Create minimal mock state.
+ * CriticalGenerator doesn't use state (_state parameter).
+ */
+function createMockState(): IGeneratorState {
+  return {
+    currentScope: null,
+    indentLevel: 0,
+    inFunctionBody: true,
+    currentParameters: new Map(),
+    localVariables: new Set(),
+    localArrays: new Set(),
+    expectedType: null,
+    selfIncludeAdded: false,
+  };
+}
+
+/**
+ * Create mock orchestrator for CriticalGenerator.
+ * CriticalGenerator uses:
+ * - validateNoEarlyExits(block) - validation
+ * - generateBlock(block) - block generation
+ */
+function createMockOrchestrator(options?: {
+  blockCode?: string;
+  validateNoEarlyExits?: (ctx: Parser.BlockContext) => void;
+}): IOrchestrator {
+  const validateNoEarlyExits =
+    options?.validateNoEarlyExits ?? vi.fn(() => undefined);
+  const generateBlock = vi.fn(() => options?.blockCode ?? "{\n    x <- 1;\n}");
+
+  return {
+    validateNoEarlyExits,
+    generateBlock,
+  } as unknown as IOrchestrator;
+}
+
+// ========================================================================
+// Tests
+// ========================================================================
+
+describe("CriticalGenerator", () => {
+  describe("basic critical section generation", () => {
+    it("generates PRIMASK save/restore wrapper with block contents", () => {
+      const blockCtx = createMockBlockContext();
+      const ctx = createMockCriticalContext(blockCtx);
+      const input = createMockInput();
+      const state = createMockState();
+      const orchestrator = createMockOrchestrator({
+        blockCode: "{\n    counter <- counter + 1;\n}",
+      });
+
+      const result = generateCriticalStatement(ctx, input, state, orchestrator);
+
+      expect(result.code).toContain("uint32_t __primask = __cnx_get_PRIMASK()");
+      expect(result.code).toContain("__cnx_disable_irq()");
+      expect(result.code).toContain("counter <- counter + 1;");
+      expect(result.code).toContain("__cnx_set_PRIMASK(__primask)");
+    });
+
+    it("strips outer braces from block code", () => {
+      const ctx = createMockCriticalContext();
+      const input = createMockInput();
+      const state = createMockState();
+      const orchestrator = createMockOrchestrator({
+        blockCode: "{\n    x = 1;\n    y = 2;\n}",
+      });
+
+      const result = generateCriticalStatement(ctx, input, state, orchestrator);
+
+      // Should not have double braces
+      expect(result.code).not.toContain("{\n{");
+      expect(result.code).not.toContain("}\n}");
+      // Should have the inner content
+      expect(result.code).toContain("x = 1;");
+      expect(result.code).toContain("y = 2;");
+    });
+
+    it("generates correct wrapper structure", () => {
+      const ctx = createMockCriticalContext();
+      const input = createMockInput();
+      const state = createMockState();
+      const orchestrator = createMockOrchestrator({
+        blockCode: "{\n    operation();\n}",
+      });
+
+      const result = generateCriticalStatement(ctx, input, state, orchestrator);
+
+      // Check the exact structure: opening brace, PRIMASK save, disable, content, restore, closing brace
+      const lines = result.code.split("\n");
+      expect(lines[0]).toBe("{");
+      expect(lines[1]).toContain("__primask = __cnx_get_PRIMASK()");
+      expect(lines[2]).toContain("__cnx_disable_irq()");
+      expect(lines[3]).toContain("operation()");
+      expect(lines[4]).toContain("__cnx_set_PRIMASK(__primask)");
+      expect(lines[5]).toBe("}");
+    });
+  });
+
+  describe("validation", () => {
+    it("calls validateNoEarlyExits on the block", () => {
+      const blockCtx = createMockBlockContext();
+      const ctx = createMockCriticalContext(blockCtx);
+      const input = createMockInput();
+      const state = createMockState();
+      const validateNoEarlyExits = vi.fn();
+      const orchestrator = createMockOrchestrator({ validateNoEarlyExits });
+
+      generateCriticalStatement(ctx, input, state, orchestrator);
+
+      expect(validateNoEarlyExits).toHaveBeenCalledOnce();
+      expect(validateNoEarlyExits).toHaveBeenCalledWith(blockCtx);
+    });
+
+    it("throws when validation fails (early return in critical block)", () => {
+      const ctx = createMockCriticalContext();
+      const input = createMockInput();
+      const state = createMockState();
+      const orchestrator = createMockOrchestrator({
+        validateNoEarlyExits: () => {
+          throw new Error(
+            "Error: return statement not allowed inside critical block",
+          );
+        },
+      });
+
+      expect(() =>
+        generateCriticalStatement(ctx, input, state, orchestrator),
+      ).toThrow("return statement not allowed inside critical block");
+    });
+
+    it("throws when validation fails (break in critical block)", () => {
+      const ctx = createMockCriticalContext();
+      const input = createMockInput();
+      const state = createMockState();
+      const orchestrator = createMockOrchestrator({
+        validateNoEarlyExits: () => {
+          throw new Error(
+            "Error: break statement not allowed inside critical block",
+          );
+        },
+      });
+
+      expect(() =>
+        generateCriticalStatement(ctx, input, state, orchestrator),
+      ).toThrow("break statement not allowed inside critical block");
+    });
+  });
+
+  describe("effects", () => {
+    it("returns irq_wrappers include effect", () => {
+      const ctx = createMockCriticalContext();
+      const input = createMockInput();
+      const state = createMockState();
+      const orchestrator = createMockOrchestrator();
+
+      const result = generateCriticalStatement(ctx, input, state, orchestrator);
+
+      expect(result.effects).toHaveLength(1);
+      expect(result.effects[0]).toEqual({
+        type: "include",
+        header: "irq_wrappers",
+      });
+    });
+
+    it("uses __cnx_ prefixed functions (avoids macro collisions)", () => {
+      const ctx = createMockCriticalContext();
+      const input = createMockInput();
+      const state = createMockState();
+      const orchestrator = createMockOrchestrator();
+
+      const result = generateCriticalStatement(ctx, input, state, orchestrator);
+
+      // ADR-050: Use __cnx_ prefixed wrappers to avoid collision with platform headers
+      expect(result.code).toContain("__cnx_get_PRIMASK");
+      expect(result.code).toContain("__cnx_disable_irq");
+      expect(result.code).toContain("__cnx_set_PRIMASK");
+      // Should NOT use bare CMSIS names
+      expect(result.code).not.toMatch(/[^_]get_PRIMASK/);
+      expect(result.code).not.toMatch(/[^_]disable_irq/);
+      expect(result.code).not.toMatch(/[^_]set_PRIMASK/);
+    });
+  });
+
+  describe("block content handling", () => {
+    it("handles empty block", () => {
+      const ctx = createMockCriticalContext();
+      const input = createMockInput();
+      const state = createMockState();
+      const orchestrator = createMockOrchestrator({
+        blockCode: "{\n}",
+      });
+
+      const result = generateCriticalStatement(ctx, input, state, orchestrator);
+
+      expect(result.code).toContain("__cnx_get_PRIMASK");
+      expect(result.code).toContain("__cnx_set_PRIMASK");
+    });
+
+    it("handles block with multiple statements", () => {
+      const ctx = createMockCriticalContext();
+      const input = createMockInput();
+      const state = createMockState();
+      const orchestrator = createMockOrchestrator({
+        blockCode: "{\n    a = 1;\n    b = 2;\n    c = 3;\n}",
+      });
+
+      const result = generateCriticalStatement(ctx, input, state, orchestrator);
+
+      expect(result.code).toContain("a = 1;");
+      expect(result.code).toContain("b = 2;");
+      expect(result.code).toContain("c = 3;");
+    });
+
+    it("preserves indentation of inner block content", () => {
+      const ctx = createMockCriticalContext();
+      const input = createMockInput();
+      const state = createMockState();
+      const orchestrator = createMockOrchestrator({
+        blockCode: "{\n    if (x) {\n        y = 1;\n    }\n}",
+      });
+
+      const result = generateCriticalStatement(ctx, input, state, orchestrator);
+
+      // The inner content should be preserved with its structure
+      expect(result.code).toContain("if (x)");
+      expect(result.code).toContain("y = 1;");
+    });
+  });
+
+  describe("orchestrator delegation", () => {
+    it("calls generateBlock with the block context", () => {
+      const blockCtx = createMockBlockContext();
+      const ctx = createMockCriticalContext(blockCtx);
+      const input = createMockInput();
+      const state = createMockState();
+      const generateBlock = vi.fn(() => "{\n    code;\n}");
+      const orchestrator = {
+        validateNoEarlyExits: vi.fn(),
+        generateBlock,
+      } as unknown as IOrchestrator;
+
+      generateCriticalStatement(ctx, input, state, orchestrator);
+
+      expect(generateBlock).toHaveBeenCalledOnce();
+      expect(generateBlock).toHaveBeenCalledWith(blockCtx);
+    });
+  });
+});

--- a/src/transpiler/output/codegen/generators/statements/__tests__/SwitchGenerator.test.ts
+++ b/src/transpiler/output/codegen/generators/statements/__tests__/SwitchGenerator.test.ts
@@ -1,0 +1,828 @@
+import { describe, it, expect, vi } from "vitest";
+import switchGenerators from "../SwitchGenerator";
+import IGeneratorInput from "../../IGeneratorInput";
+import IGeneratorState from "../../IGeneratorState";
+import IOrchestrator from "../../IOrchestrator";
+import * as Parser from "../../../../../logic/parser/grammar/CNextParser";
+
+const {
+  generateSwitch,
+  generateSwitchCase,
+  generateCaseLabel,
+  generateDefaultCase,
+} = switchGenerators;
+
+// ========================================================================
+// Test Helpers - Mock Contexts
+// ========================================================================
+
+/**
+ * Create a mock case label context with a qualified type (e.g., State.IDLE)
+ */
+function createQualifiedTypeCaseLabel(
+  parts: string[],
+): Parser.CaseLabelContext {
+  return {
+    qualifiedType: () => ({
+      IDENTIFIER: () => parts.map((p) => ({ getText: () => p })),
+    }),
+    IDENTIFIER: () => null,
+    INTEGER_LITERAL: () => null,
+    HEX_LITERAL: () => null,
+    BINARY_LITERAL: () => null,
+    CHAR_LITERAL: () => null,
+    children: null,
+    start: { line: 1, column: 0 },
+  } as unknown as Parser.CaseLabelContext;
+}
+
+/**
+ * Create a mock case label context with an identifier
+ */
+function createIdentifierCaseLabel(
+  id: string,
+  line = 1,
+  col = 0,
+): Parser.CaseLabelContext {
+  return {
+    qualifiedType: () => null,
+    IDENTIFIER: () => ({ getText: () => id }),
+    INTEGER_LITERAL: () => null,
+    HEX_LITERAL: () => null,
+    BINARY_LITERAL: () => null,
+    CHAR_LITERAL: () => null,
+    children: null,
+    start: { line, column: col },
+  } as unknown as Parser.CaseLabelContext;
+}
+
+/**
+ * Create a mock case label context with an integer literal
+ */
+function createIntegerCaseLabel(
+  value: string,
+  hasNegative = false,
+): Parser.CaseLabelContext {
+  return {
+    qualifiedType: () => null,
+    IDENTIFIER: () => null,
+    INTEGER_LITERAL: () => ({ getText: () => value }),
+    HEX_LITERAL: () => null,
+    BINARY_LITERAL: () => null,
+    CHAR_LITERAL: () => null,
+    children: hasNegative ? [{ getText: () => "-" }] : null,
+    start: { line: 1, column: 0 },
+  } as unknown as Parser.CaseLabelContext;
+}
+
+/**
+ * Create a mock case label context with a hex literal
+ */
+function createHexCaseLabel(
+  value: string,
+  hasNegative = false,
+): Parser.CaseLabelContext {
+  return {
+    qualifiedType: () => null,
+    IDENTIFIER: () => null,
+    INTEGER_LITERAL: () => null,
+    HEX_LITERAL: () => ({ getText: () => value }),
+    BINARY_LITERAL: () => null,
+    CHAR_LITERAL: () => null,
+    children: hasNegative ? [{ getText: () => "-" }] : null,
+    start: { line: 1, column: 0 },
+  } as unknown as Parser.CaseLabelContext;
+}
+
+/**
+ * Create a mock case label context with a binary literal
+ */
+function createBinaryCaseLabel(
+  value: string,
+  hasNegative = false,
+): Parser.CaseLabelContext {
+  return {
+    qualifiedType: () => null,
+    IDENTIFIER: () => null,
+    INTEGER_LITERAL: () => null,
+    HEX_LITERAL: () => null,
+    BINARY_LITERAL: () => ({ getText: () => value }),
+    CHAR_LITERAL: () => null,
+    children: hasNegative ? [{ getText: () => "-" }] : null,
+    start: { line: 1, column: 0 },
+  } as unknown as Parser.CaseLabelContext;
+}
+
+/**
+ * Create a mock case label context with a character literal
+ */
+function createCharCaseLabel(value: string): Parser.CaseLabelContext {
+  return {
+    qualifiedType: () => null,
+    IDENTIFIER: () => null,
+    INTEGER_LITERAL: () => null,
+    HEX_LITERAL: () => null,
+    BINARY_LITERAL: () => null,
+    CHAR_LITERAL: () => ({ getText: () => value }),
+    children: null,
+    start: { line: 1, column: 0 },
+  } as unknown as Parser.CaseLabelContext;
+}
+
+/**
+ * Create a mock statement context
+ */
+function createMockStatement(): Parser.StatementContext {
+  return {} as Parser.StatementContext;
+}
+
+/**
+ * Create a mock block context with statements
+ */
+function createMockBlock(
+  statements: Parser.StatementContext[] = [],
+): Parser.BlockContext {
+  return {
+    statement: () => statements,
+  } as unknown as Parser.BlockContext;
+}
+
+/**
+ * Create a mock switch case context
+ */
+function createMockSwitchCase(
+  labels: Parser.CaseLabelContext[],
+  statements: Parser.StatementContext[] = [],
+): Parser.SwitchCaseContext {
+  return {
+    caseLabel: () => labels,
+    block: () => createMockBlock(statements),
+  } as unknown as Parser.SwitchCaseContext;
+}
+
+/**
+ * Create a mock default case context
+ */
+function createMockDefaultCase(
+  statements: Parser.StatementContext[] = [],
+): Parser.DefaultCaseContext {
+  return {
+    block: () => createMockBlock(statements),
+  } as unknown as Parser.DefaultCaseContext;
+}
+
+/**
+ * Create a mock expression context
+ */
+function createMockExpression(): Parser.ExpressionContext {
+  return {} as Parser.ExpressionContext;
+}
+
+/**
+ * Create a mock switch statement context
+ */
+function createMockSwitchStatement(options: {
+  cases?: Parser.SwitchCaseContext[];
+  defaultCase?: Parser.DefaultCaseContext | null;
+}): Parser.SwitchStatementContext {
+  return {
+    expression: createMockExpression,
+    switchCase: () => options.cases ?? [],
+    defaultCase: () => options.defaultCase ?? null,
+  } as unknown as Parser.SwitchStatementContext;
+}
+
+// ========================================================================
+// Test Helpers - Mock Input/State/Orchestrator
+// ========================================================================
+
+/**
+ * Create minimal mock input.
+ */
+function createMockInput(options?: {
+  enumMembers?: Map<string, Map<string, number>>;
+}): IGeneratorInput {
+  const enumMembers = options?.enumMembers ?? new Map();
+  return {
+    symbols: {
+      enumMembers,
+      knownScopes: new Set(),
+      knownStructs: new Set(),
+      knownRegisters: new Set(),
+      knownEnums: new Set(enumMembers.keys()),
+      knownBitmaps: new Set(),
+      scopeMembers: new Map(),
+      scopeMemberVisibility: new Map(),
+      structFields: new Map(),
+      structFieldArrays: new Map(),
+      structFieldDimensions: new Map(),
+      bitmapFields: new Map(),
+      bitmapBackingType: new Map(),
+      bitmapBitWidth: new Map(),
+      scopedRegisters: new Map(),
+      registerMemberAccess: new Map(),
+      registerMemberTypes: new Map(),
+      scopePrivateConstValues: new Map(),
+    },
+    symbolTable: null,
+    typeRegistry: new Map(),
+    functionSignatures: new Map(),
+    knownFunctions: new Set(),
+    knownStructs: new Set(),
+    constValues: new Map(),
+    callbackTypes: new Map(),
+    callbackFieldTypes: new Map(),
+    targetCapabilities: { hasAtomicSupport: false },
+    debugMode: false,
+  } as unknown as IGeneratorInput;
+}
+
+/**
+ * Create minimal mock state.
+ */
+function createMockState(): IGeneratorState {
+  return {
+    currentScope: null,
+    indentLevel: 0,
+    inFunctionBody: true,
+    currentParameters: new Map(),
+    localVariables: new Set(),
+    localArrays: new Set(),
+    expectedType: null,
+    selfIncludeAdded: false,
+  };
+}
+
+/**
+ * Create mock orchestrator for SwitchGenerator.
+ * Methods used:
+ * - generateExpression(expr) - for switch expression
+ * - validateSwitchStatement(node, expr) - validation
+ * - getExpressionEnumType(expr) - enum type resolution
+ * - indent(text) - indentation
+ * - generateStatement(stmt) - for statements in blocks
+ */
+function createMockOrchestrator(options?: {
+  exprCode?: string;
+  enumType?: string | null;
+  statementCode?: string;
+  validateSwitchStatement?: (
+    node: Parser.SwitchStatementContext,
+    expr: Parser.ExpressionContext,
+  ) => void;
+}): IOrchestrator {
+  const generateExpression = vi.fn(() => options?.exprCode ?? "state");
+  const validateSwitchStatement =
+    options?.validateSwitchStatement ?? vi.fn(() => undefined);
+  const getExpressionEnumType = vi.fn(() => options?.enumType ?? null);
+  const indent = vi.fn((text: string) => `    ${text}`);
+  const generateStatement = vi.fn(() => options?.statementCode ?? "x = 1;");
+
+  return {
+    generateExpression,
+    validateSwitchStatement,
+    getExpressionEnumType,
+    indent,
+    generateStatement,
+  } as unknown as IOrchestrator;
+}
+
+// ========================================================================
+// Tests - generateCaseLabel
+// ========================================================================
+
+describe("SwitchGenerator", () => {
+  describe("generateCaseLabel", () => {
+    describe("qualified type labels", () => {
+      it("converts qualified enum to C underscore format", () => {
+        const ctx = createQualifiedTypeCaseLabel(["State", "IDLE"]);
+        const input = createMockInput();
+        const state = createMockState();
+        const orchestrator = createMockOrchestrator();
+
+        const result = generateCaseLabel(ctx, input, state, orchestrator);
+
+        expect(result.code).toBe("State_IDLE");
+        expect(result.effects).toEqual([]);
+      });
+
+      it("handles multi-part qualified names", () => {
+        const ctx = createQualifiedTypeCaseLabel(["Motor", "State", "RUNNING"]);
+        const input = createMockInput();
+        const state = createMockState();
+        const orchestrator = createMockOrchestrator();
+
+        const result = generateCaseLabel(ctx, input, state, orchestrator);
+
+        expect(result.code).toBe("Motor_State_RUNNING");
+      });
+    });
+
+    describe("identifier labels", () => {
+      it("passes through plain identifiers (const variables)", () => {
+        const ctx = createIdentifierCaseLabel("MAX_VALUE");
+        const input = createMockInput();
+        const state = createMockState();
+        const orchestrator = createMockOrchestrator();
+
+        const result = generateCaseLabel(ctx, input, state, orchestrator);
+
+        expect(result.code).toBe("MAX_VALUE");
+      });
+
+      it("resolves unqualified enum member with type prefix (Issue #471)", () => {
+        const ctx = createIdentifierCaseLabel("IDLE");
+        const input = createMockInput({
+          enumMembers: new Map([
+            [
+              "State",
+              new Map([
+                ["IDLE", 0],
+                ["RUNNING", 1],
+              ]),
+            ],
+          ]),
+        });
+        const state = createMockState();
+        const orchestrator = createMockOrchestrator();
+
+        // Pass switchEnumType to enable resolution
+        const result = generateCaseLabel(
+          ctx,
+          input,
+          state,
+          orchestrator,
+          "State",
+        );
+
+        expect(result.code).toBe("State_IDLE");
+      });
+
+      it("throws for unqualified enum member when switch is not on enum (Issue #477)", () => {
+        const ctx = createIdentifierCaseLabel("IDLE", 5, 10);
+        const input = createMockInput({
+          enumMembers: new Map([["State", new Map([["IDLE", 0]])]]),
+        });
+        const state = createMockState();
+        const orchestrator = createMockOrchestrator();
+
+        // No switchEnumType - switching on non-enum
+        expect(() =>
+          generateCaseLabel(ctx, input, state, orchestrator),
+        ).toThrow(
+          "5:10 error[E0424]: 'IDLE' is not defined; did you mean 'State.IDLE'?",
+        );
+      });
+
+      it("suggests multiple enums when identifier exists in multiple", () => {
+        const ctx = createIdentifierCaseLabel("ACTIVE", 3, 5);
+        const input = createMockInput({
+          enumMembers: new Map([
+            ["Mode", new Map([["ACTIVE", 1]])],
+            ["Status", new Map([["ACTIVE", 2]])],
+          ]),
+        });
+        const state = createMockState();
+        const orchestrator = createMockOrchestrator();
+
+        expect(() =>
+          generateCaseLabel(ctx, input, state, orchestrator),
+        ).toThrow("exists in: Mode, Status. Use qualified access.");
+      });
+    });
+
+    describe("integer literals", () => {
+      it("handles positive integer literal", () => {
+        const ctx = createIntegerCaseLabel("42");
+        const input = createMockInput();
+        const state = createMockState();
+        const orchestrator = createMockOrchestrator();
+
+        const result = generateCaseLabel(ctx, input, state, orchestrator);
+
+        expect(result.code).toBe("42");
+      });
+
+      it("handles negative integer literal", () => {
+        const ctx = createIntegerCaseLabel("5", true);
+        const input = createMockInput();
+        const state = createMockState();
+        const orchestrator = createMockOrchestrator();
+
+        const result = generateCaseLabel(ctx, input, state, orchestrator);
+
+        expect(result.code).toBe("-5");
+      });
+
+      it("handles zero", () => {
+        const ctx = createIntegerCaseLabel("0");
+        const input = createMockInput();
+        const state = createMockState();
+        const orchestrator = createMockOrchestrator();
+
+        const result = generateCaseLabel(ctx, input, state, orchestrator);
+
+        expect(result.code).toBe("0");
+      });
+    });
+
+    describe("hex literals", () => {
+      it("handles hex literal", () => {
+        const ctx = createHexCaseLabel("0xFF");
+        const input = createMockInput();
+        const state = createMockState();
+        const orchestrator = createMockOrchestrator();
+
+        const result = generateCaseLabel(ctx, input, state, orchestrator);
+
+        expect(result.code).toBe("0xFF");
+      });
+
+      it("handles negative hex literal", () => {
+        const ctx = createHexCaseLabel("0x10", true);
+        const input = createMockInput();
+        const state = createMockState();
+        const orchestrator = createMockOrchestrator();
+
+        const result = generateCaseLabel(ctx, input, state, orchestrator);
+
+        expect(result.code).toBe("-0x10");
+      });
+    });
+
+    describe("binary literals", () => {
+      it("converts binary to hex", () => {
+        const ctx = createBinaryCaseLabel("0b1010");
+        const input = createMockInput();
+        const state = createMockState();
+        const orchestrator = createMockOrchestrator();
+
+        const result = generateCaseLabel(ctx, input, state, orchestrator);
+
+        expect(result.code).toBe("0xA");
+      });
+
+      it("converts negative binary to negative hex", () => {
+        const ctx = createBinaryCaseLabel("0b1111", true);
+        const input = createMockInput();
+        const state = createMockState();
+        const orchestrator = createMockOrchestrator();
+
+        const result = generateCaseLabel(ctx, input, state, orchestrator);
+
+        expect(result.code).toBe("-0xF");
+      });
+
+      it("adds ULL suffix for large binary values (Issue #114)", () => {
+        // Value > 0xFFFFFFFF requires ULL suffix
+        const ctx = createBinaryCaseLabel(
+          "0b100000000000000000000000000000000",
+        ); // 2^32
+        const input = createMockInput();
+        const state = createMockState();
+        const orchestrator = createMockOrchestrator();
+
+        const result = generateCaseLabel(ctx, input, state, orchestrator);
+
+        expect(result.code).toContain("ULL");
+        expect(result.code).toBe("0x100000000ULL");
+      });
+
+      it("does not add ULL for values within 32-bit range", () => {
+        const ctx = createBinaryCaseLabel("0b11111111111111111111111111111111"); // 0xFFFFFFFF
+        const input = createMockInput();
+        const state = createMockState();
+        const orchestrator = createMockOrchestrator();
+
+        const result = generateCaseLabel(ctx, input, state, orchestrator);
+
+        expect(result.code).not.toContain("ULL");
+        expect(result.code).toBe("0xFFFFFFFF");
+      });
+    });
+
+    describe("character literals", () => {
+      it("handles character literal", () => {
+        const ctx = createCharCaseLabel("'A'");
+        const input = createMockInput();
+        const state = createMockState();
+        const orchestrator = createMockOrchestrator();
+
+        const result = generateCaseLabel(ctx, input, state, orchestrator);
+
+        expect(result.code).toBe("'A'");
+      });
+
+      it("handles escape sequence character", () => {
+        const ctx = createCharCaseLabel("'\\n'");
+        const input = createMockInput();
+        const state = createMockState();
+        const orchestrator = createMockOrchestrator();
+
+        const result = generateCaseLabel(ctx, input, state, orchestrator);
+
+        expect(result.code).toBe("'\\n'");
+      });
+    });
+
+    describe("empty case", () => {
+      it("returns empty string for unknown label type", () => {
+        const ctx = {
+          qualifiedType: () => null,
+          IDENTIFIER: () => null,
+          INTEGER_LITERAL: () => null,
+          HEX_LITERAL: () => null,
+          BINARY_LITERAL: () => null,
+          CHAR_LITERAL: () => null,
+          children: null,
+          start: { line: 1, column: 0 },
+        } as unknown as Parser.CaseLabelContext;
+        const input = createMockInput();
+        const state = createMockState();
+        const orchestrator = createMockOrchestrator();
+
+        const result = generateCaseLabel(ctx, input, state, orchestrator);
+
+        expect(result.code).toBe("");
+      });
+    });
+  });
+
+  // ========================================================================
+  // Tests - generateSwitchCase
+  // ========================================================================
+
+  describe("generateSwitchCase", () => {
+    it("generates single case with block", () => {
+      const label = createIntegerCaseLabel("1");
+      const ctx = createMockSwitchCase([label], [createMockStatement()]);
+      const input = createMockInput();
+      const state = createMockState();
+      const orchestrator = createMockOrchestrator({ statementCode: "x = 1;" });
+
+      const result = generateSwitchCase(ctx, input, state, orchestrator);
+
+      expect(result.code).toContain("case 1: {");
+      expect(result.code).toContain("x = 1;");
+      expect(result.code).toContain("break;");
+      expect(result.code).toContain("}");
+    });
+
+    it("generates multiple labels for fall-through (|| expansion)", () => {
+      const label1 = createIntegerCaseLabel("1");
+      const label2 = createIntegerCaseLabel("2");
+      const label3 = createIntegerCaseLabel("3");
+      const ctx = createMockSwitchCase(
+        [label1, label2, label3],
+        [createMockStatement()],
+      );
+      const input = createMockInput();
+      const state = createMockState();
+      const orchestrator = createMockOrchestrator({
+        statementCode: "handle();",
+      });
+
+      const result = generateSwitchCase(ctx, input, state, orchestrator);
+
+      // First two are fall-through labels (no block)
+      expect(result.code).toContain("case 1:");
+      expect(result.code).toContain("case 2:");
+      // Last one has the block
+      expect(result.code).toContain("case 3: {");
+      expect(result.code).toContain("handle();");
+      expect(result.code).toContain("break;");
+    });
+
+    it("passes switchEnumType to case label generation", () => {
+      const label = createIdentifierCaseLabel("IDLE");
+      const ctx = createMockSwitchCase([label], []);
+      const input = createMockInput({
+        enumMembers: new Map([["State", new Map([["IDLE", 0]])]]),
+      });
+      const state = createMockState();
+      const orchestrator = createMockOrchestrator();
+
+      const result = generateSwitchCase(
+        ctx,
+        input,
+        state,
+        orchestrator,
+        "State",
+      );
+
+      expect(result.code).toContain("case State_IDLE: {");
+    });
+
+    it("handles empty block (no statements)", () => {
+      const label = createIntegerCaseLabel("0");
+      const ctx = createMockSwitchCase([label], []);
+      const input = createMockInput();
+      const state = createMockState();
+      const orchestrator = createMockOrchestrator();
+
+      const result = generateSwitchCase(ctx, input, state, orchestrator);
+
+      expect(result.code).toContain("case 0: {");
+      expect(result.code).toContain("break;");
+      expect(result.code).toContain("}");
+    });
+
+    it("generates multiple statements in block", () => {
+      const label = createIntegerCaseLabel("5");
+      const ctx = createMockSwitchCase(
+        [label],
+        [createMockStatement(), createMockStatement(), createMockStatement()],
+      );
+      const input = createMockInput();
+      const state = createMockState();
+      let callCount = 0;
+      const statementCodes = ["a = 1;", "b = 2;", "c = 3;"];
+      const orchestrator = {
+        indent: (text: string) => `    ${text}`,
+        generateStatement: vi.fn(() => statementCodes[callCount++]),
+      } as unknown as IOrchestrator;
+
+      const result = generateSwitchCase(ctx, input, state, orchestrator);
+
+      expect(result.code).toContain("a = 1;");
+      expect(result.code).toContain("b = 2;");
+      expect(result.code).toContain("c = 3;");
+    });
+  });
+
+  // ========================================================================
+  // Tests - generateDefaultCase
+  // ========================================================================
+
+  describe("generateDefaultCase", () => {
+    it("generates default case with block", () => {
+      const ctx = createMockDefaultCase([createMockStatement()]);
+      const input = createMockInput();
+      const state = createMockState();
+      const orchestrator = createMockOrchestrator({
+        statementCode: "error();",
+      });
+
+      const result = generateDefaultCase(ctx, input, state, orchestrator);
+
+      expect(result.code).toContain("default: {");
+      expect(result.code).toContain("error();");
+      expect(result.code).toContain("break;");
+      expect(result.code).toContain("}");
+    });
+
+    it("handles empty default block", () => {
+      const ctx = createMockDefaultCase([]);
+      const input = createMockInput();
+      const state = createMockState();
+      const orchestrator = createMockOrchestrator();
+
+      const result = generateDefaultCase(ctx, input, state, orchestrator);
+
+      expect(result.code).toContain("default: {");
+      expect(result.code).toContain("break;");
+      expect(result.code).toContain("}");
+    });
+
+    it("returns empty effects", () => {
+      const ctx = createMockDefaultCase([]);
+      const input = createMockInput();
+      const state = createMockState();
+      const orchestrator = createMockOrchestrator();
+
+      const result = generateDefaultCase(ctx, input, state, orchestrator);
+
+      expect(result.effects).toEqual([]);
+    });
+  });
+
+  // ========================================================================
+  // Tests - generateSwitch
+  // ========================================================================
+
+  describe("generateSwitch", () => {
+    it("generates basic switch statement", () => {
+      const caseCtx = createMockSwitchCase([createIntegerCaseLabel("1")], []);
+      const ctx = createMockSwitchStatement({ cases: [caseCtx] });
+      const input = createMockInput();
+      const state = createMockState();
+      const orchestrator = createMockOrchestrator({ exprCode: "value" });
+
+      const result = generateSwitch(ctx, input, state, orchestrator);
+
+      expect(result.code).toContain("switch (value) {");
+      expect(result.code).toContain("case 1: {");
+      expect(result.code).toContain("}");
+    });
+
+    it("generates switch with multiple cases", () => {
+      const case1 = createMockSwitchCase([createIntegerCaseLabel("0")], []);
+      const case2 = createMockSwitchCase([createIntegerCaseLabel("1")], []);
+      const ctx = createMockSwitchStatement({ cases: [case1, case2] });
+      const input = createMockInput();
+      const state = createMockState();
+      const orchestrator = createMockOrchestrator({ exprCode: "state" });
+
+      const result = generateSwitch(ctx, input, state, orchestrator);
+
+      expect(result.code).toContain("switch (state) {");
+      expect(result.code).toContain("case 0: {");
+      expect(result.code).toContain("case 1: {");
+    });
+
+    it("generates switch with default case", () => {
+      const caseCtx = createMockSwitchCase([createIntegerCaseLabel("1")], []);
+      const defaultCtx = createMockDefaultCase([]);
+      const ctx = createMockSwitchStatement({
+        cases: [caseCtx],
+        defaultCase: defaultCtx,
+      });
+      const input = createMockInput();
+      const state = createMockState();
+      const orchestrator = createMockOrchestrator({ exprCode: "x" });
+
+      const result = generateSwitch(ctx, input, state, orchestrator);
+
+      expect(result.code).toContain("switch (x) {");
+      expect(result.code).toContain("case 1: {");
+      expect(result.code).toContain("default: {");
+    });
+
+    it("calls validateSwitchStatement", () => {
+      const ctx = createMockSwitchStatement({ cases: [] });
+      const input = createMockInput();
+      const state = createMockState();
+      const validateSwitchStatement = vi.fn();
+      const orchestrator = createMockOrchestrator({ validateSwitchStatement });
+
+      generateSwitch(ctx, input, state, orchestrator);
+
+      expect(validateSwitchStatement).toHaveBeenCalledOnce();
+    });
+
+    it("throws when validation fails", () => {
+      const ctx = createMockSwitchStatement({ cases: [] });
+      const input = createMockInput();
+      const state = createMockState();
+      const orchestrator = createMockOrchestrator({
+        validateSwitchStatement: () => {
+          throw new Error("Error: switch requires at least one case");
+        },
+      });
+
+      expect(() => generateSwitch(ctx, input, state, orchestrator)).toThrow(
+        "switch requires at least one case",
+      );
+    });
+
+    it("uses enum type from expression for case resolution (Issue #471)", () => {
+      const caseCtx = createMockSwitchCase(
+        [createIdentifierCaseLabel("IDLE")],
+        [],
+      );
+      const ctx = createMockSwitchStatement({ cases: [caseCtx] });
+      const input = createMockInput({
+        enumMembers: new Map([["State", new Map([["IDLE", 0]])]]),
+      });
+      const state = createMockState();
+      const orchestrator = createMockOrchestrator({
+        exprCode: "currentState",
+        enumType: "State",
+      });
+
+      const result = generateSwitch(ctx, input, state, orchestrator);
+
+      expect(result.code).toContain("switch (currentState) {");
+      expect(result.code).toContain("case State_IDLE: {");
+    });
+
+    it("calls getExpressionEnumType to determine switch type", () => {
+      const ctx = createMockSwitchStatement({ cases: [] });
+      const input = createMockInput();
+      const state = createMockState();
+      const getExpressionEnumType = vi.fn(() => null);
+      const orchestrator = {
+        generateExpression: vi.fn(() => "x"),
+        validateSwitchStatement: vi.fn(),
+        getExpressionEnumType,
+        indent: (t: string) => `    ${t}`,
+      } as unknown as IOrchestrator;
+
+      generateSwitch(ctx, input, state, orchestrator);
+
+      expect(getExpressionEnumType).toHaveBeenCalledOnce();
+    });
+
+    it("returns empty effects when no effects from cases", () => {
+      const caseCtx = createMockSwitchCase([createIntegerCaseLabel("1")], []);
+      const ctx = createMockSwitchStatement({ cases: [caseCtx] });
+      const input = createMockInput();
+      const state = createMockState();
+      const orchestrator = createMockOrchestrator();
+
+      const result = generateSwitch(ctx, input, state, orchestrator);
+
+      expect(result.effects).toEqual([]);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Add 82 unit tests for statement generators in `src/transpiler/output/codegen/generators/statements/__tests__/`:
  - **CriticalGenerator** (12 tests): PRIMASK wrapper generation, validation, effects
  - **SwitchGenerator** (34 tests): case labels, enum resolution (Issue #471/#477), literal types
  - **ControlFlowGenerator** (36 tests): return, if/else, while, do-while, for, temp flushing (Issue #250), condition validation (Issue #254)

- Fix bug in SwitchGenerator: negative binary literals now correctly produce `-0xF` instead of `-0x-F`. The issue was that `BigInt.toString(16)` includes the minus sign for negative values, causing double negation when combined with the explicit sign prefix.

## Test plan

- [x] All 82 new unit tests pass
- [x] All 900 integration tests pass
- [x] All 2493 unit tests pass
- [x] All quality checks pass

🤖 Generated with [Claude Code](https://claude.ai/code)