### PR TITLE
Exclude scripts from coverage reporting

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -10,15 +10,13 @@ export default defineConfig({
     globals: true,
     coverage: {
       provider: "v8",
-      include: ["src/**/*.ts", "scripts/**/*.ts"],
+      include: ["src/**/*.ts"],
       exclude: [
         "**/*.test.ts",
         "src/antlr_parser/**", // Generated ANTLR code (legacy path)
         "src/transpiler/logic/parser/grammar/**", // Generated CNext parser
         "src/transpiler/logic/parser/c/grammar/**", // Generated C parser
         "src/transpiler/logic/parser/cpp/grammar/**", // Generated C++ parser
-        "scripts/test.ts", // Integration test runner
-        "scripts/test-worker.ts", // Test worker
       ],
       reporter: ["text", "html", "lcov"],
       reportsDirectory: "./coverage",


### PR DESCRIPTION
## Summary

Remove `scripts/**/*.ts` from coverage include in `vitest.config.ts`. Only `src/**/*.ts` is now tracked for coverage metrics.

- Script tests still run (included via test include pattern)
- Script source files no longer affect coverage percentages
- Removes now-unnecessary individual exclusions for `scripts/test.ts` and `scripts/test-worker.ts`

## Test plan

- [x] `npm run unit:coverage` runs successfully
- [x] Scripts directory not listed in coverage report
- [x] Script tests still execute

🤖 Generated with [Claude Code](https://claude.ai/code)