### PR TITLE
Document float bit indexing vs integer truncation

### DIFF
--- a/docs/decisions/adr-007-type-aware-bit-indexing.md
+++ b/docs/decisions/adr-007-type-aware-bit-indexing.md
@@ -281,6 +281,32 @@ uint8_t highByte = (memcpy(&__bits_value, &value, sizeof(value)), ((__bits_value
 - Network byte order conversion
 - Low-level IEEE-754 manipulation
 
+### Float Bit Access vs. Integer Truncation
+
+There are **two distinct ways** to extract bits from a float value:
+
+| Syntax           | Behavior                               | Result for `f32 a <- 1.5`       |
+| ---------------- | -------------------------------------- | ------------------------------- |
+| `a[0, 8]`        | Raw IEEE-754 bytes                     | `0x00` (low byte of 0x3FC00000) |
+| `((u32)a)[0, 8]` | Truncate to integer, then extract bits | `1` (integer part)              |
+
+**Example:**
+
+```cnx
+f32 temperature <- 25.7;
+
+// Raw IEEE-754 byte access (for binary protocols)
+u8 rawByte <- temperature[0, 8];  // Some byte from IEEE-754 representation
+
+// Integer truncation then bit extract (for numeric processing)
+u8 intValue <- ((u32)temperature)[0, 8];  // 25 (truncated integer value)
+```
+
+Choose the appropriate method based on your use case:
+
+- **Binary protocols/serialization**: Use `floatVar[offset, width]` for raw bytes
+- **Numeric value extraction**: Use `((u32)floatVar)[offset, width]` for truncated integer
+
 ---
 
 ## Compile-Time Validation (Future Work)

--- a/docs/learn-cnext-in-y-minutes.md
+++ b/docs/learn-cnext-in-y-minutes.md
@@ -803,6 +803,15 @@ value[16, 8] <- 0x80;  // Write byte 2
 value[24, 8] <- 0x3F;  // Write byte 3 (MSB) → value is now 1.0f
 
 u8 byte <- value[24, 8];  // Read high byte from float
+
+// Two ways to extract bits from floats:
+// 1. Raw IEEE-754 bytes (for binary protocols):
+f32 pi <- 3.14159;
+u8 rawByte <- pi[0, 8];           // Gets raw IEEE-754 byte 0
+
+// 2. Integer truncation then bit extract (for numeric values):
+f32 temp <- 25.7;
+u8 intBits <- ((u32)temp)[0, 8];  // Truncates to 25, then extracts bits → 25
 ```
 
 ## Bitmap Types


### PR DESCRIPTION
## Summary
- Clarify the two distinct ways to extract bits from float values
- Fix incorrect documentation that said `f32 → u32` cast was "not supported"

### The Two Approaches

| Syntax | Behavior | Use Case |
|--------|----------|----------|
| `floatVar[0, 8]` | Raw IEEE-754 byte access | Binary protocols, serialization |
| `((u32)floatVar)[0, 8]` | Truncate to integer, then extract bits | Numeric value processing |

### Files Updated
- `docs/learn-cnext-in-y-minutes.md` - Added examples showing both approaches
- `docs/decisions/adr-024-type-casting.md` - Fixed "not supported" to show truncation IS supported
- `docs/decisions/adr-007-type-aware-bit-indexing.md` - Added comparison section

## Test plan
- [x] All existing tests pass
- [x] Documentation reviewed for accuracy

🤖 Generated with [Claude Code](https://claude.com/claude-code)