### PR TITLE
Refactor generateMemberAccess to use buildMemberAccessChain (Issue #644)

### DIFF
--- a/src/transpiler/output/codegen/memberAccessChain.ts
+++ b/src/transpiler/output/codegen/memberAccessChain.ts
@@ -10,6 +10,7 @@
  */
 
 import { ParseTree } from "antlr4ng";
+import TypeCheckUtils from "../../../utils/TypeCheckUtils.js";
 
 /**
  * Options for struct parameter access helpers.
@@ -147,9 +148,11 @@ interface TypeTrackingState {
  */
 interface TypeTrackingCallbacks {
   /** Get the fields map for a struct type */
-  getStructFields: (structType: string) => Map<string, string> | undefined;
+  getStructFields: (
+    structType: string,
+  ) => ReadonlyMap<string, string> | undefined;
   /** Get the array fields set for a struct type */
-  getStructArrayFields: (structType: string) => Set<string> | undefined;
+  getStructArrayFields: (structType: string) => ReadonlySet<string> | undefined;
   /** Check if a type name is a known struct */
   isKnownStruct: StructChecker;
 }
@@ -273,9 +276,7 @@ function buildMemberAccessChain<TExpr>(
         const isPrimitiveInt =
           typeState.lastMemberType &&
           !typeState.lastMemberIsArray &&
-          ["u8", "u16", "u32", "u64", "i8", "i16", "i32", "i64"].includes(
-            typeState.lastMemberType,
-          );
+          TypeCheckUtils.isInteger(typeState.lastMemberType);
         const isLastExpr = exprIndex === expressions.length - 1;
 
         if (isPrimitiveInt && isLastExpr && exprIndex < expressions.length) {


### PR DESCRIPTION
## Summary

- Refactor `generateMemberAccess` to use the existing `buildMemberAccessChain` helper
- Update `memberAccessChain.ts` to use `TypeCheckUtils.isInteger` for consistency
- Update `TypeTrackingCallbacks` interface to use `ReadonlyMap`/`ReadonlySet`

## Results

- **Before**: 8559 lines
- **After**: 8479 lines
- **Reduction**: 80 lines

This completes Phase 5 of Issue #644. The `doGenerateAssignmentTarget` method uses different grammar rules (`postfixTargetOp`) and has more complex separator logic (C++ `::`, register chains, visibility validation), so it wasn't refactored to use `buildMemberAccessChain`.

## Total Issue #644 Progress

| Phase | Description | Lines Reduced |
|-------|-------------|---------------|
| 1-4 | Previous extractions | 412 |
| 5 | buildMemberAccessChain usage | 80 |
| **Total** | | **492** |

## Test plan

- [x] All 900 integration tests pass
- [x] All 2729 unit tests pass
- [x] TypeScript type check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)