### PR TITLE
Align SonarCloud coverage with vitest by excluding scripts/

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -6,8 +6,8 @@ sonar.projectKey=jlaustill_c-next
 sonar.organization=jlaustill
 
 # Source configuration
-sonar.sources=src,scripts
-sonar.tests=src,scripts
+sonar.sources=src
+sonar.tests=src
 sonar.test.inclusions=**/*.test.ts
 
 # Exclusions (generated code, dependencies, build artifacts)


### PR DESCRIPTION
## Summary
- Exclude `scripts/` from SonarCloud source analysis (`sonar.sources` and `sonar.tests`)
- Aligns coverage badge (~66.9%) with local vitest coverage (~74.73%)
- `scripts/` contains test infrastructure, not transpiler code

## Test plan
- [ ] Verify CI passes
- [ ] After merge, verify SonarCloud coverage badge updates to match vitest

🤖 Generated with [Claude Code](https://claude.ai/code)