### PR TITLE
Add unit tests for PostfixExpressionGenerator

### DIFF
--- a/src/transpiler/output/codegen/generators/expressions/__tests__/PostfixExpressionGenerator.test.ts
+++ b/src/transpiler/output/codegen/generators/expressions/__tests__/PostfixExpressionGenerator.test.ts
@@ -74,7 +74,11 @@ function createMockInput(overrides?: {
     constValues: new Map(),
     callbackTypes: new Map(),
     callbackFieldTypes: new Map(),
-    targetCapabilities: { hasAtomicSupport: false },
+    targetCapabilities: {
+      wordSize: 32,
+      hasLdrexStrex: false,
+      hasBasepri: false,
+    },
     debugMode: false,
   } as IGeneratorInput;
 }
@@ -116,6 +120,10 @@ function createMockState(overrides?: {
 function createMockOrchestrator(overrides?: {
   generatePrimaryExpr?: (ctx: Parser.PrimaryExpressionContext) => string;
   generateExpression?: (ctx: Parser.ExpressionContext) => string;
+  generateFunctionArg?: (
+    ctx: Parser.ExpressionContext,
+    targetParamBaseType?: string,
+  ) => string;
   isKnownStruct?: (name: string) => boolean;
   isKnownScope?: (name: string) => boolean;
   isCppScopeSymbol?: (name: string) => boolean;
@@ -171,7 +179,7 @@ function createMockOrchestrator(overrides?: {
     validateLiteralFitsType: vi.fn(),
     validateTypeConversion: vi.fn(),
     getSimpleIdentifier: vi.fn(),
-    generateFunctionArg: vi.fn(),
+    generateFunctionArg: overrides?.generateFunctionArg ?? vi.fn(),
     isConstValue: vi.fn(),
     getKnownEnums: vi.fn(() => new Set()),
     isCppMode: overrides?.isCppMode ?? vi.fn(() => false),


### PR DESCRIPTION
## Summary
- Adds 49 unit tests for `PostfixExpressionGenerator.ts`
- Tests cover: basic expression generation, global prefix handling (ADR-016), this.member handling, .length/.capacity/.size properties, bitmap field access, scope/enum/register member access, struct parameter access (C and C++ modes), array subscript and bit access, bit range access, float bit indexing, and function calls

## Test plan
- [x] All 49 tests pass
- [x] TypeScript type check passes
- [x] Linting passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)