### PR TITLE
Add unit tests for zero/low-coverage files

### DIFF
--- a/src/transpiler/data/__tests__/InputExpansion.test.ts
+++ b/src/transpiler/data/__tests__/InputExpansion.test.ts
@@ -1,0 +1,363 @@
+/**
+ * Unit tests for InputExpansion
+ *
+ * Tests CLI input expansion functionality - converting file paths and directories
+ * into lists of .cnx files.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { resolve } from "node:path";
+import InputExpansion from "../InputExpansion";
+
+// Mock node:fs module
+vi.mock("node:fs", () => ({
+  existsSync: vi.fn(),
+  statSync: vi.fn(),
+  readdirSync: vi.fn(),
+}));
+
+import { existsSync, statSync, readdirSync } from "node:fs";
+
+const mockExistsSync = vi.mocked(existsSync);
+const mockStatSync = vi.mocked(statSync);
+const mockReaddirSync = vi.mocked(readdirSync);
+
+// ============================================================================
+// Test Helpers
+// ============================================================================
+
+function mockFile(path: string): void {
+  mockExistsSync.mockImplementation((p) => p === path || p === resolve(path));
+  mockStatSync.mockReturnValue({
+    isFile: () => true,
+    isDirectory: () => false,
+  } as ReturnType<typeof statSync>);
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+describe("InputExpansion", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe("expandInputs", () => {
+    it("expands single .cnx file", () => {
+      const filePath = "/project/main.cnx";
+      mockFile(filePath);
+
+      const result = InputExpansion.expandInputs([filePath]);
+
+      expect(result).toHaveLength(1);
+      expect(result[0]).toBe(resolve(filePath));
+    });
+
+    it("expands single .cnext file", () => {
+      const filePath = "/project/main.cnext";
+      mockFile(filePath);
+
+      const result = InputExpansion.expandInputs([filePath]);
+
+      expect(result).toHaveLength(1);
+      expect(result[0]).toBe(resolve(filePath));
+    });
+
+    it("throws error for non-existent file", () => {
+      mockExistsSync.mockReturnValue(false);
+
+      expect(() => InputExpansion.expandInputs(["/nonexistent.cnx"])).toThrow(
+        "Input not found: /nonexistent.cnx",
+      );
+    });
+
+    it("removes duplicate files", () => {
+      const filePath = "/project/main.cnx";
+      mockFile(filePath);
+
+      const result = InputExpansion.expandInputs([filePath, filePath]);
+
+      expect(result).toHaveLength(1);
+    });
+
+    it("handles multiple input files", () => {
+      mockExistsSync.mockReturnValue(true);
+      mockStatSync.mockReturnValue({
+        isFile: () => true,
+        isDirectory: () => false,
+      } as ReturnType<typeof statSync>);
+
+      const result = InputExpansion.expandInputs([
+        "/project/a.cnx",
+        "/project/b.cnx",
+      ]);
+
+      expect(result).toHaveLength(2);
+    });
+  });
+
+  describe("validateFileExtension", () => {
+    it("accepts .cnx files", () => {
+      expect(() =>
+        InputExpansion.validateFileExtension("/path/to/file.cnx"),
+      ).not.toThrow();
+    });
+
+    it("accepts .cnext files", () => {
+      expect(() =>
+        InputExpansion.validateFileExtension("/path/to/file.cnext"),
+      ).not.toThrow();
+    });
+
+    it("rejects .c files", () => {
+      expect(() =>
+        InputExpansion.validateFileExtension("/path/to/file.c"),
+      ).toThrow("Cannot process implementation file 'file.c'");
+    });
+
+    it("rejects .cpp files", () => {
+      expect(() =>
+        InputExpansion.validateFileExtension("/path/to/file.cpp"),
+      ).toThrow("Cannot process implementation file 'file.cpp'");
+    });
+
+    it("rejects .cc files", () => {
+      expect(() =>
+        InputExpansion.validateFileExtension("/path/to/file.cc"),
+      ).toThrow("Cannot process implementation file 'file.cc'");
+    });
+
+    it("rejects .cxx files", () => {
+      expect(() =>
+        InputExpansion.validateFileExtension("/path/to/file.cxx"),
+      ).toThrow("Cannot process implementation file 'file.cxx'");
+    });
+
+    it("rejects .c++ files", () => {
+      expect(() =>
+        InputExpansion.validateFileExtension("/path/to/file.c++"),
+      ).toThrow("Cannot process implementation file 'file.c++'");
+    });
+
+    it("rejects unknown extensions", () => {
+      expect(() =>
+        InputExpansion.validateFileExtension("/path/to/file.txt"),
+      ).toThrow("Invalid file extension '.txt'");
+    });
+
+    it("rejects header files", () => {
+      expect(() =>
+        InputExpansion.validateFileExtension("/path/to/file.h"),
+      ).toThrow("Invalid file extension '.h'");
+    });
+
+    it("provides helpful message for implementation files", () => {
+      expect(() =>
+        InputExpansion.validateFileExtension("/path/to/impl.c"),
+      ).toThrow(
+        "If you need to include this file, create a header (.h) instead",
+      );
+    });
+
+    it("provides helpful message for unknown extensions", () => {
+      expect(() =>
+        InputExpansion.validateFileExtension("/path/to/file.js"),
+      ).toThrow("C-Next only accepts .cnx or .cnext files");
+    });
+  });
+
+  describe("findCNextFiles", () => {
+    it("finds .cnx files in directory", () => {
+      mockReaddirSync.mockReturnValue([
+        { name: "main.cnx", isFile: () => true, isDirectory: () => false },
+        { name: "util.cnx", isFile: () => true, isDirectory: () => false },
+      ] as unknown as ReturnType<typeof readdirSync>);
+
+      const result = InputExpansion.findCNextFiles("/project");
+
+      expect(result).toHaveLength(2);
+      expect(result).toContainEqual(resolve("/project", "main.cnx"));
+      expect(result).toContainEqual(resolve("/project", "util.cnx"));
+    });
+
+    it("finds .cnext files in directory", () => {
+      mockReaddirSync.mockReturnValue([
+        { name: "main.cnext", isFile: () => true, isDirectory: () => false },
+      ] as unknown as ReturnType<typeof readdirSync>);
+
+      const result = InputExpansion.findCNextFiles("/project");
+
+      expect(result).toHaveLength(1);
+      expect(result[0]).toContain("main.cnext");
+    });
+
+    it("ignores non-cnx files", () => {
+      mockReaddirSync.mockReturnValue([
+        { name: "main.cnx", isFile: () => true, isDirectory: () => false },
+        { name: "readme.md", isFile: () => true, isDirectory: () => false },
+        { name: "config.json", isFile: () => true, isDirectory: () => false },
+      ] as unknown as ReturnType<typeof readdirSync>);
+
+      const result = InputExpansion.findCNextFiles("/project");
+
+      expect(result).toHaveLength(1);
+      expect(result[0]).toContain("main.cnx");
+    });
+
+    it("skips hidden directories", () => {
+      mockReaddirSync.mockImplementation((dir) => {
+        if (String(dir).includes(".git")) {
+          return [
+            {
+              name: "hidden.cnx",
+              isFile: () => true,
+              isDirectory: () => false,
+            },
+          ] as unknown as ReturnType<typeof readdirSync>;
+        }
+        return [
+          { name: ".git", isFile: () => false, isDirectory: () => true },
+          { name: "main.cnx", isFile: () => true, isDirectory: () => false },
+        ] as unknown as ReturnType<typeof readdirSync>;
+      });
+
+      const result = InputExpansion.findCNextFiles("/project");
+
+      expect(result).toHaveLength(1);
+      expect(result[0]).toContain("main.cnx");
+    });
+
+    it("skips node_modules directory", () => {
+      mockReaddirSync.mockImplementation((dir) => {
+        if (String(dir).includes("node_modules")) {
+          return [
+            { name: "dep.cnx", isFile: () => true, isDirectory: () => false },
+          ] as unknown as ReturnType<typeof readdirSync>;
+        }
+        return [
+          {
+            name: "node_modules",
+            isFile: () => false,
+            isDirectory: () => true,
+          },
+          { name: "main.cnx", isFile: () => true, isDirectory: () => false },
+        ] as unknown as ReturnType<typeof readdirSync>;
+      });
+
+      const result = InputExpansion.findCNextFiles("/project");
+
+      expect(result).toHaveLength(1);
+      expect(result[0]).toContain("main.cnx");
+    });
+
+    it("skips build directory", () => {
+      mockReaddirSync.mockImplementation((dir) => {
+        if (String(dir).includes("build")) {
+          return [
+            {
+              name: "output.cnx",
+              isFile: () => true,
+              isDirectory: () => false,
+            },
+          ] as unknown as ReturnType<typeof readdirSync>;
+        }
+        return [
+          { name: "build", isFile: () => false, isDirectory: () => true },
+          { name: "main.cnx", isFile: () => true, isDirectory: () => false },
+        ] as unknown as ReturnType<typeof readdirSync>;
+      });
+
+      const result = InputExpansion.findCNextFiles("/project");
+
+      expect(result).toHaveLength(1);
+    });
+
+    it("skips .pio directory (PlatformIO)", () => {
+      mockReaddirSync.mockImplementation((dir) => {
+        if (String(dir).includes(".pio")) {
+          return [
+            {
+              name: "cached.cnx",
+              isFile: () => true,
+              isDirectory: () => false,
+            },
+          ] as unknown as ReturnType<typeof readdirSync>;
+        }
+        return [
+          { name: ".pio", isFile: () => false, isDirectory: () => true },
+          { name: "main.cnx", isFile: () => true, isDirectory: () => false },
+        ] as unknown as ReturnType<typeof readdirSync>;
+      });
+
+      const result = InputExpansion.findCNextFiles("/project");
+
+      expect(result).toHaveLength(1);
+    });
+
+    it("skips dist directory", () => {
+      mockReaddirSync.mockImplementation((dir) => {
+        if (String(dir).includes("dist")) {
+          return [
+            {
+              name: "bundled.cnx",
+              isFile: () => true,
+              isDirectory: () => false,
+            },
+          ] as unknown as ReturnType<typeof readdirSync>;
+        }
+        return [
+          { name: "dist", isFile: () => false, isDirectory: () => true },
+          { name: "main.cnx", isFile: () => true, isDirectory: () => false },
+        ] as unknown as ReturnType<typeof readdirSync>;
+      });
+
+      const result = InputExpansion.findCNextFiles("/project");
+
+      expect(result).toHaveLength(1);
+    });
+
+    it("recursively scans subdirectories", () => {
+      mockReaddirSync.mockImplementation((dir) => {
+        const dirStr = String(dir);
+        if (dirStr.endsWith("src")) {
+          return [
+            { name: "util.cnx", isFile: () => true, isDirectory: () => false },
+          ] as unknown as ReturnType<typeof readdirSync>;
+        }
+        return [
+          { name: "src", isFile: () => false, isDirectory: () => true },
+          { name: "main.cnx", isFile: () => true, isDirectory: () => false },
+        ] as unknown as ReturnType<typeof readdirSync>;
+      });
+
+      const result = InputExpansion.findCNextFiles("/project");
+
+      expect(result).toHaveLength(2);
+    });
+
+    it("throws error when directory scan fails", () => {
+      mockReaddirSync.mockImplementation(() => {
+        throw new Error("Permission denied");
+      });
+
+      expect(() => InputExpansion.findCNextFiles("/protected")).toThrow(
+        "Failed to scan directory /protected",
+      );
+    });
+
+    it("returns empty array for empty directory", () => {
+      mockReaddirSync.mockReturnValue(
+        [] as unknown as ReturnType<typeof readdirSync>,
+      );
+
+      const result = InputExpansion.findCNextFiles("/empty");
+
+      expect(result).toHaveLength(0);
+    });
+  });
+});

--- a/src/transpiler/output/codegen/generators/statements/__tests__/AtomicGenerator.test.ts
+++ b/src/transpiler/output/codegen/generators/statements/__tests__/AtomicGenerator.test.ts
@@ -1,0 +1,348 @@
+/**
+ * Unit tests for AtomicGenerator
+ *
+ * Tests atomic Read-Modify-Write operation generation for embedded platforms.
+ */
+
+import { describe, it, expect } from "vitest";
+import atomicGenerators from "../AtomicGenerator";
+import TTypeInfo from "../../../types/TTypeInfo";
+import ITargetCapabilities from "../../../types/ITargetCapabilities";
+
+const {
+  generateAtomicRMW,
+  generateInnerAtomicOp,
+  generateLdrexStrexLoop,
+  generatePrimaskWrapper,
+} = atomicGenerators;
+
+// ============================================================================
+// Test Helpers
+// ============================================================================
+
+function createTypeInfo(
+  baseType: string,
+  overflowBehavior: "clamp" | "wrap" = "clamp",
+): TTypeInfo {
+  return {
+    baseType,
+    bitWidth: 32,
+    isArray: false,
+    isConst: false,
+    overflowBehavior,
+  };
+}
+
+function createCapabilities(hasLdrexStrex: boolean): ITargetCapabilities {
+  return {
+    wordSize: 32,
+    hasLdrexStrex,
+    hasBasepri: true,
+  };
+}
+
+// ============================================================================
+// Tests - generateInnerAtomicOp
+// ============================================================================
+
+describe("AtomicGenerator", () => {
+  describe("generateInnerAtomicOp", () => {
+    it("generates clamp helper for += with clamp behavior", () => {
+      const typeInfo = createTypeInfo("u32", "clamp");
+      const result = generateInnerAtomicOp("+=", "5", typeInfo);
+
+      expect(result.code).toBe("cnx_clamp_add_u32(__old, 5)");
+      expect(result.effects).toHaveLength(1);
+      expect(result.effects[0]).toEqual({
+        type: "helper",
+        operation: "add",
+        cnxType: "u32",
+      });
+    });
+
+    it("generates clamp helper for -= with clamp behavior", () => {
+      const typeInfo = createTypeInfo("u16", "clamp");
+      const result = generateInnerAtomicOp("-=", "value", typeInfo);
+
+      expect(result.code).toBe("cnx_clamp_sub_u16(__old, value)");
+      expect(result.effects[0]).toEqual({
+        type: "helper",
+        operation: "sub",
+        cnxType: "u16",
+      });
+    });
+
+    it("generates clamp helper for *= with clamp behavior", () => {
+      const typeInfo = createTypeInfo("i8", "clamp");
+      const result = generateInnerAtomicOp("*=", "2", typeInfo);
+
+      expect(result.code).toBe("cnx_clamp_mul_i8(__old, 2)");
+      expect(result.effects[0]).toEqual({
+        type: "helper",
+        operation: "mul",
+        cnxType: "i8",
+      });
+    });
+
+    it("generates natural arithmetic for wrap behavior", () => {
+      const typeInfo = createTypeInfo("u32", "wrap");
+      const result = generateInnerAtomicOp("+=", "5", typeInfo);
+
+      expect(result.code).toBe("__old + 5");
+      expect(result.effects).toHaveLength(0);
+    });
+
+    it("generates natural arithmetic for non-clamp ops", () => {
+      const typeInfo = createTypeInfo("u32", "clamp");
+      const result = generateInnerAtomicOp("/=", "2", typeInfo);
+
+      expect(result.code).toBe("__old / 2");
+      expect(result.effects).toHaveLength(0);
+    });
+
+    it("generates natural arithmetic for bitwise ops", () => {
+      const typeInfo = createTypeInfo("u32", "clamp");
+
+      expect(generateInnerAtomicOp("&=", "0xFF", typeInfo).code).toBe(
+        "__old & 0xFF",
+      );
+      expect(generateInnerAtomicOp("|=", "0x01", typeInfo).code).toBe(
+        "__old | 0x01",
+      );
+      expect(generateInnerAtomicOp("^=", "mask", typeInfo).code).toBe(
+        "__old ^ mask",
+      );
+    });
+
+    it("generates natural arithmetic for shift ops", () => {
+      const typeInfo = createTypeInfo("u32", "clamp");
+
+      expect(generateInnerAtomicOp("<<=", "2", typeInfo).code).toBe(
+        "__old << 2",
+      );
+      expect(generateInnerAtomicOp(">>=", "4", typeInfo).code).toBe(
+        "__old >> 4",
+      );
+    });
+
+    it("generates natural arithmetic for floats even with clamp", () => {
+      const typeInfo = createTypeInfo("f32", "clamp");
+      const result = generateInnerAtomicOp("+=", "1.0f", typeInfo);
+
+      expect(result.code).toBe("__old + 1.0f");
+      expect(result.effects).toHaveLength(0);
+    });
+
+    it("handles unknown operator with default +", () => {
+      const typeInfo = createTypeInfo("u32", "wrap");
+      const result = generateInnerAtomicOp("??=", "5", typeInfo);
+
+      expect(result.code).toBe("__old + 5");
+    });
+  });
+
+  // ============================================================================
+  // Tests - generateLdrexStrexLoop
+  // ============================================================================
+
+  describe("generateLdrexStrexLoop", () => {
+    it("generates LDREX/STREX loop for u32", () => {
+      const typeInfo = createTypeInfo("u32");
+      const result = generateLdrexStrexLoop(
+        "counter",
+        "__old + 1",
+        typeInfo,
+        [],
+      );
+
+      expect(result.code).toContain("do {");
+      expect(result.code).toContain("uint32_t __old = __LDREXW(&counter)");
+      expect(result.code).toContain("uint32_t __new = __old + 1");
+      expect(result.code).toContain(
+        "if (__STREXW(__new, &counter) == 0) break;",
+      );
+      expect(result.code).toContain("} while (1);");
+      expect(result.effects).toContainEqual({
+        type: "include",
+        header: "cmsis",
+      });
+    });
+
+    it("generates LDREX/STREX loop for u16", () => {
+      const typeInfo = createTypeInfo("u16");
+      const result = generateLdrexStrexLoop("value", "__old - 1", typeInfo, []);
+
+      expect(result.code).toContain("uint16_t __old = __LDREXH(&value)");
+      expect(result.code).toContain("__STREXH(__new, &value)");
+    });
+
+    it("generates LDREX/STREX loop for u8", () => {
+      const typeInfo = createTypeInfo("u8");
+      const result = generateLdrexStrexLoop(
+        "byte",
+        "__old | 0x80",
+        typeInfo,
+        [],
+      );
+
+      expect(result.code).toContain("uint8_t __old = __LDREXB(&byte)");
+      expect(result.code).toContain("__STREXB(__new, &byte)");
+    });
+
+    it("generates LDREX/STREX loop for signed types", () => {
+      const typeInfo = createTypeInfo("i32");
+      const result = generateLdrexStrexLoop(
+        "signed_val",
+        "__old + 5",
+        typeInfo,
+        [],
+      );
+
+      expect(result.code).toContain("int32_t __old = __LDREXW(&signed_val)");
+      expect(result.code).toContain("int32_t __new");
+    });
+
+    it("preserves inner effects", () => {
+      const typeInfo = createTypeInfo("u32");
+      const innerEffects = [
+        { type: "helper" as const, operation: "add", cnxType: "u32" },
+      ];
+      const result = generateLdrexStrexLoop(
+        "counter",
+        "helper()",
+        typeInfo,
+        innerEffects,
+      );
+
+      expect(result.effects).toContainEqual({
+        type: "helper",
+        operation: "add",
+        cnxType: "u32",
+      });
+      expect(result.effects).toContainEqual({
+        type: "include",
+        header: "cmsis",
+      });
+    });
+  });
+
+  // ============================================================================
+  // Tests - generatePrimaskWrapper
+  // ============================================================================
+
+  describe("generatePrimaskWrapper", () => {
+    it("generates PRIMASK wrapper for simple op", () => {
+      const typeInfo = createTypeInfo("u32", "wrap");
+      const result = generatePrimaskWrapper("counter", "+=", "1", typeInfo);
+
+      expect(result.code).toContain("uint32_t __primask = __get_PRIMASK();");
+      expect(result.code).toContain("__disable_irq();");
+      expect(result.code).toContain("counter += 1;");
+      expect(result.code).toContain("__set_PRIMASK(__primask);");
+      expect(result.effects).toContainEqual({
+        type: "include",
+        header: "cmsis",
+      });
+    });
+
+    it("generates PRIMASK wrapper with clamp helper for +=", () => {
+      const typeInfo = createTypeInfo("u32", "clamp");
+      const result = generatePrimaskWrapper("counter", "+=", "5", typeInfo);
+
+      expect(result.code).toContain("counter = cnx_clamp_add_u32(counter, 5);");
+      expect(result.effects).toContainEqual({
+        type: "helper",
+        operation: "add",
+        cnxType: "u32",
+      });
+    });
+
+    it("generates PRIMASK wrapper with clamp helper for -=", () => {
+      const typeInfo = createTypeInfo("u16", "clamp");
+      const result = generatePrimaskWrapper("value", "-=", "10", typeInfo);
+
+      expect(result.code).toContain("value = cnx_clamp_sub_u16(value, 10);");
+    });
+
+    it("generates PRIMASK wrapper with clamp helper for *=", () => {
+      const typeInfo = createTypeInfo("i8", "clamp");
+      const result = generatePrimaskWrapper("factor", "*=", "2", typeInfo);
+
+      expect(result.code).toContain("factor = cnx_clamp_mul_i8(factor, 2);");
+    });
+
+    it("generates PRIMASK wrapper without clamp for /=", () => {
+      const typeInfo = createTypeInfo("u32", "clamp");
+      const result = generatePrimaskWrapper("value", "/=", "2", typeInfo);
+
+      expect(result.code).toContain("value /= 2;");
+      // Should not have helper effect for division
+      expect(result.effects.filter((e) => e.type === "helper")).toHaveLength(0);
+    });
+
+    it("generates PRIMASK wrapper without clamp for floats", () => {
+      const typeInfo = createTypeInfo("f32", "clamp");
+      const result = generatePrimaskWrapper("value", "+=", "1.0f", typeInfo);
+
+      expect(result.code).toContain("value += 1.0f;");
+      // Floats don't use clamp helpers
+      expect(result.effects.filter((e) => e.type === "helper")).toHaveLength(0);
+    });
+  });
+
+  // ============================================================================
+  // Tests - generateAtomicRMW (integration)
+  // ============================================================================
+
+  describe("generateAtomicRMW", () => {
+    it("uses LDREX/STREX when available for supported type", () => {
+      const typeInfo = createTypeInfo("u32");
+      const caps = createCapabilities(true);
+      const result = generateAtomicRMW("counter", "+=", "1", typeInfo, caps);
+
+      expect(result.code).toContain("__LDREXW");
+      expect(result.code).toContain("__STREXW");
+    });
+
+    it("falls back to PRIMASK when LDREX/STREX not available", () => {
+      const typeInfo = createTypeInfo("u32");
+      const caps = createCapabilities(false);
+      const result = generateAtomicRMW("counter", "+=", "1", typeInfo, caps);
+
+      expect(result.code).toContain("__get_PRIMASK()");
+      expect(result.code).toContain("__disable_irq()");
+    });
+
+    it("falls back to PRIMASK for u64 (no LDREX support)", () => {
+      const typeInfo = createTypeInfo("u64");
+      const caps = createCapabilities(true);
+      const result = generateAtomicRMW("counter", "+=", "1", typeInfo, caps);
+
+      // u64 doesn't have LDREX support, should use PRIMASK
+      expect(result.code).toContain("__get_PRIMASK()");
+    });
+
+    it("includes clamp helper effect when using clamp behavior", () => {
+      const typeInfo = createTypeInfo("u32", "clamp");
+      const caps = createCapabilities(true);
+      const result = generateAtomicRMW("counter", "+=", "5", typeInfo, caps);
+
+      expect(result.effects).toContainEqual({
+        type: "helper",
+        operation: "add",
+        cnxType: "u32",
+      });
+    });
+
+    it("includes cmsis header effect", () => {
+      const typeInfo = createTypeInfo("u32");
+      const caps = createCapabilities(true);
+      const result = generateAtomicRMW("counter", "+=", "1", typeInfo, caps);
+
+      expect(result.effects).toContainEqual({
+        type: "include",
+        header: "cmsis",
+      });
+    });
+  });
+});

--- a/src/transpiler/output/headers/__tests__/CppHeaderGenerator.test.ts
+++ b/src/transpiler/output/headers/__tests__/CppHeaderGenerator.test.ts
@@ -1,0 +1,406 @@
+/**
+ * Unit tests for CppHeaderGenerator
+ *
+ * Tests C++ header generation with reference-based pass-by-reference semantics.
+ */
+
+import { describe, it, expect } from "vitest";
+import CppHeaderGenerator from "../CppHeaderGenerator";
+import ISymbol from "../../../../utils/types/ISymbol";
+import ESymbolKind from "../../../../utils/types/ESymbolKind";
+import ESourceLanguage from "../../../../utils/types/ESourceLanguage";
+import IParameterSymbol from "../../../../utils/types/IParameterSymbol";
+
+// ============================================================================
+// Test Helpers
+// ============================================================================
+
+function createFunctionSymbol(
+  name: string,
+  returnType: string,
+  parameters: IParameterSymbol[] = [],
+  isExported = true,
+): ISymbol {
+  return {
+    name,
+    kind: ESymbolKind.Function,
+    type: returnType,
+    parameters,
+    isExported,
+    sourceFile: "test.cnx",
+    sourceLine: 1,
+    sourceLanguage: ESourceLanguage.CNext,
+  };
+}
+
+function createParam(
+  name: string,
+  type: string,
+  options: Partial<IParameterSymbol> = {},
+): IParameterSymbol {
+  return {
+    name,
+    type,
+    isConst: false,
+    isAutoConst: false,
+    isArray: false,
+    ...options,
+  };
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+describe("CppHeaderGenerator", () => {
+  describe("generate", () => {
+    it("generates header with include guard", () => {
+      const generator = new CppHeaderGenerator();
+      const symbols: ISymbol[] = [];
+
+      const result = generator.generate(symbols, "test.h");
+
+      expect(result).toContain("#ifndef TEST_H");
+      expect(result).toContain("#define TEST_H");
+      expect(result).toContain("#endif /* TEST_H */");
+    });
+
+    it("generates header with custom guard prefix", () => {
+      const generator = new CppHeaderGenerator();
+      const symbols: ISymbol[] = [];
+
+      const result = generator.generate(symbols, "module.h", {
+        guardPrefix: "MY_PROJECT",
+      });
+
+      expect(result).toContain("#ifndef MY_PROJECT_MODULE_H");
+      expect(result).toContain("#define MY_PROJECT_MODULE_H");
+    });
+
+    it("generates extern C wrapper for C++ compatibility", () => {
+      const generator = new CppHeaderGenerator();
+      const symbols: ISymbol[] = [];
+
+      const result = generator.generate(symbols, "test.h");
+
+      expect(result).toContain("#ifdef __cplusplus");
+      expect(result).toContain('extern "C" {');
+      expect(result).toContain("#endif");
+    });
+
+    it("generates function prototypes", () => {
+      const generator = new CppHeaderGenerator();
+      const symbols: ISymbol[] = [createFunctionSymbol("doSomething", "void")];
+
+      const result = generator.generate(symbols, "test.h");
+
+      expect(result).toContain("void doSomething(void);");
+    });
+
+    it("filters to exported symbols when exportedOnly is true", () => {
+      const generator = new CppHeaderGenerator();
+      const symbols: ISymbol[] = [
+        createFunctionSymbol("publicFunc", "void", [], true),
+        createFunctionSymbol("privateFunc", "void", [], false),
+      ];
+
+      const result = generator.generate(symbols, "test.h", {
+        exportedOnly: true,
+      });
+
+      expect(result).toContain("publicFunc");
+      expect(result).not.toContain("privateFunc");
+    });
+
+    it("includes all symbols when exportedOnly is false", () => {
+      const generator = new CppHeaderGenerator();
+      const symbols: ISymbol[] = [
+        createFunctionSymbol("publicFunc", "void", [], true),
+        createFunctionSymbol("privateFunc", "void", [], false),
+      ];
+
+      const result = generator.generate(symbols, "test.h", {
+        exportedOnly: false,
+      });
+
+      expect(result).toContain("publicFunc");
+      expect(result).toContain("privateFunc");
+    });
+  });
+
+  describe("function prototype generation", () => {
+    it("generates void function with no parameters", () => {
+      const generator = new CppHeaderGenerator();
+      const symbols: ISymbol[] = [createFunctionSymbol("init", "void")];
+
+      const result = generator.generate(symbols, "test.h");
+
+      expect(result).toContain("void init(void);");
+    });
+
+    it("generates function with return type", () => {
+      const generator = new CppHeaderGenerator();
+      const symbols: ISymbol[] = [createFunctionSymbol("getValue", "u32")];
+
+      const result = generator.generate(symbols, "test.h");
+
+      expect(result).toContain("uint32_t getValue(void);");
+    });
+
+    it("forces main to return int", () => {
+      const generator = new CppHeaderGenerator();
+      const symbols: ISymbol[] = [createFunctionSymbol("main", "u32")];
+
+      const result = generator.generate(symbols, "test.h");
+
+      expect(result).toContain("int main(void);");
+    });
+
+    it("generates function with single parameter using reference", () => {
+      const generator = new CppHeaderGenerator();
+      const symbols: ISymbol[] = [
+        createFunctionSymbol("process", "void", [createParam("value", "u32")]),
+      ];
+
+      const result = generator.generate(symbols, "test.h");
+
+      expect(result).toContain("void process(uint32_t& value);");
+    });
+
+    it("generates function with const parameter", () => {
+      const generator = new CppHeaderGenerator();
+      const symbols: ISymbol[] = [
+        createFunctionSymbol("process", "void", [
+          createParam("value", "u32", { isConst: true }),
+        ]),
+      ];
+
+      const result = generator.generate(symbols, "test.h");
+
+      expect(result).toContain("void process(const uint32_t& value);");
+    });
+
+    it("generates function with auto-const parameter", () => {
+      const generator = new CppHeaderGenerator();
+      const symbols: ISymbol[] = [
+        createFunctionSymbol("process", "void", [
+          createParam("value", "u32", { isAutoConst: true }),
+        ]),
+      ];
+
+      const result = generator.generate(symbols, "test.h");
+
+      expect(result).toContain("void process(const uint32_t& value);");
+    });
+
+    it("generates function with multiple parameters", () => {
+      const generator = new CppHeaderGenerator();
+      const symbols: ISymbol[] = [
+        createFunctionSymbol("add", "u32", [
+          createParam("a", "u32"),
+          createParam("b", "u32"),
+        ]),
+      ];
+
+      const result = generator.generate(symbols, "test.h");
+
+      expect(result).toContain("uint32_t add(uint32_t& a, uint32_t& b);");
+    });
+
+    it("uses pass-by-value for parameters in passByValueParams", () => {
+      const generator = new CppHeaderGenerator();
+      const symbols: ISymbol[] = [
+        createFunctionSymbol("process", "void", [createParam("value", "u32")]),
+      ];
+      const passByValueParams = new Map([["process", new Set(["value"])]]);
+
+      const result = generator.generate(
+        symbols,
+        "test.h",
+        {},
+        undefined,
+        passByValueParams,
+      );
+
+      expect(result).toContain("void process(uint32_t value);");
+    });
+
+    it("uses pass-by-value for float types (f32)", () => {
+      const generator = new CppHeaderGenerator();
+      const symbols: ISymbol[] = [
+        createFunctionSymbol("setFloat", "void", [createParam("value", "f32")]),
+      ];
+
+      const result = generator.generate(symbols, "test.h");
+
+      expect(result).toContain("void setFloat(float value);");
+    });
+
+    it("uses pass-by-value for float types (f64)", () => {
+      const generator = new CppHeaderGenerator();
+      const symbols: ISymbol[] = [
+        createFunctionSymbol("setDouble", "void", [
+          createParam("value", "f64"),
+        ]),
+      ];
+
+      const result = generator.generate(symbols, "test.h");
+
+      expect(result).toContain("void setDouble(double value);");
+    });
+
+    it("uses pass-by-value for enum types", () => {
+      const generator = new CppHeaderGenerator();
+      const symbols: ISymbol[] = [
+        createFunctionSymbol("setState", "void", [
+          createParam("state", "State"),
+        ]),
+      ];
+      const allKnownEnums = new Set(["State"]);
+
+      const result = generator.generate(
+        symbols,
+        "test.h",
+        {},
+        undefined,
+        undefined,
+        allKnownEnums,
+      );
+
+      expect(result).toContain("void setState(State state);");
+    });
+
+    it("uses pass-by-value for ISR type (function pointer)", () => {
+      const generator = new CppHeaderGenerator();
+      const symbols: ISymbol[] = [
+        createFunctionSymbol("setHandler", "void", [
+          createParam("handler", "ISR"),
+        ]),
+      ];
+
+      const result = generator.generate(symbols, "test.h");
+
+      expect(result).toContain("void setHandler(ISR handler);");
+    });
+
+    it("generates array parameter with pointer syntax", () => {
+      const generator = new CppHeaderGenerator();
+      const symbols: ISymbol[] = [
+        createFunctionSymbol("processArray", "void", [
+          createParam("data", "u8", { isArray: true, arrayDimensions: ["10"] }),
+        ]),
+      ];
+
+      const result = generator.generate(symbols, "test.h");
+
+      expect(result).toContain("void processArray(uint8_t data[10]);");
+    });
+
+    it("generates const array parameter", () => {
+      const generator = new CppHeaderGenerator();
+      const symbols: ISymbol[] = [
+        createFunctionSymbol("readArray", "void", [
+          createParam("data", "u8", {
+            isConst: true,
+            isArray: true,
+            arrayDimensions: ["10"],
+          }),
+        ]),
+      ];
+
+      const result = generator.generate(symbols, "test.h");
+
+      expect(result).toContain("void readArray(const uint8_t data[10]);");
+    });
+
+    it("generates string array parameter as char*", () => {
+      const generator = new CppHeaderGenerator();
+      const symbols: ISymbol[] = [
+        createFunctionSymbol("processStrings", "void", [
+          createParam("strings", "string", {
+            isArray: true,
+            arrayDimensions: ["5"],
+          }),
+        ]),
+      ];
+
+      const result = generator.generate(symbols, "test.h");
+
+      expect(result).toContain("void processStrings(char* strings[5]);");
+    });
+
+    it("generates multi-dimensional array parameter", () => {
+      const generator = new CppHeaderGenerator();
+      const symbols: ISymbol[] = [
+        createFunctionSymbol("processMatrix", "void", [
+          createParam("matrix", "u32", {
+            isArray: true,
+            arrayDimensions: ["3", "4"],
+          }),
+        ]),
+      ];
+
+      const result = generator.generate(symbols, "test.h");
+
+      expect(result).toContain("void processMatrix(uint32_t matrix[3][4]);");
+    });
+  });
+
+  describe("type mapping", () => {
+    it("maps C-Next integer types to C types", () => {
+      const generator = new CppHeaderGenerator();
+      const types = [
+        { cnx: "u8", c: "uint8_t" },
+        { cnx: "u16", c: "uint16_t" },
+        { cnx: "u32", c: "uint32_t" },
+        { cnx: "u64", c: "uint64_t" },
+        { cnx: "i8", c: "int8_t" },
+        { cnx: "i16", c: "int16_t" },
+        { cnx: "i32", c: "int32_t" },
+        { cnx: "i64", c: "int64_t" },
+      ];
+
+      for (const { cnx, c } of types) {
+        const symbols: ISymbol[] = [createFunctionSymbol("get", cnx)];
+        const result = generator.generate(symbols, "test.h");
+        expect(result).toContain(`${c} get(void);`);
+      }
+    });
+
+    it("maps bool type", () => {
+      const generator = new CppHeaderGenerator();
+      const symbols: ISymbol[] = [createFunctionSymbol("isReady", "bool")];
+
+      const result = generator.generate(symbols, "test.h");
+
+      expect(result).toContain("bool isReady(void);");
+    });
+
+    it("maps float types", () => {
+      const generator = new CppHeaderGenerator();
+      const symbols: ISymbol[] = [
+        createFunctionSymbol("getF32", "f32"),
+        createFunctionSymbol("getF64", "f64"),
+      ];
+
+      const result = generator.generate(symbols, "test.h");
+
+      expect(result).toContain("float getF32(void);");
+      expect(result).toContain("double getF64(void);");
+    });
+  });
+
+  describe("empty inputs", () => {
+    it("generates valid header with no functions", () => {
+      const generator = new CppHeaderGenerator();
+      const symbols: ISymbol[] = [];
+
+      const result = generator.generate(symbols, "empty.h");
+
+      expect(result).toContain("#ifndef EMPTY_H");
+      expect(result).toContain("#define EMPTY_H");
+      expect(result).toContain("#endif /* EMPTY_H */");
+      expect(result).not.toContain("Function prototypes");
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Add 78 new unit tests targeting files with very low or zero coverage - the "quick wins" for improving overall coverage metrics.

| File | Before | Tests Added |
|------|--------|-------------|
| InputExpansion.ts | 0% | 27 tests |
| CppHeaderGenerator.ts | 1.2% | 26 tests |
| AtomicGenerator.ts | 10.2% | 25 tests |

### Tests Added

**InputExpansion.ts** - CLI file/directory expansion:
- File and directory expansion
- Extension validation (.cnx, .cnext accepted; .c, .cpp rejected)
- Recursive directory scanning
- Skipping hidden/build directories (node_modules, .git, .pio, etc.)

**CppHeaderGenerator.ts** - C++ header generation:
- Header guard generation
- C++ extern "C" wrapper
- Function prototype generation
- Pass-by-value vs pass-by-reference semantics
- Type mapping (C-Next to C types)

**AtomicGenerator.ts** - Atomic RMW operations:
- LDREX/STREX loop generation for ARM
- PRIMASK wrapper generation (interrupt disable)
- Clamp/wrap overflow behavior
- Platform capability handling

## Impact

These ~120 lines of previously uncovered code represent ~1.1% of total coverage. Combined with the SonarCloud config fix (#656) and code quality fixes (#658), this should bring coverage closer to the 80% target.

## Test plan

- [x] All 78 new tests pass
- [x] All 2807 unit tests pass
- [x] All 900 integration tests pass
- [x] TypeScript type check passes

🤖 Generated with [Claude Code](https://claude.ai/code)