### PR TITLE
Release v0.1.58

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.58] - 2026-02-04
+
+### Changed
+
+- Switch to ES modules for top-level await support (PR #669)
+- Move all test files to `__tests__` directories (PR #668)
+- Upgrade GitHub Actions and publish workflow to Node.js 24 (PR #672)
+- Extract separator and dereference resolution utilities for improved testability (PR #681)
+- Reduce cognitive complexity across multiple functions to meet SonarCloud thresholds:
+  - `generate()`, `analyzeModificationsOnly`, `walkPostfixExpressionForCalls`
+  - `trackVariableType`, `hasPostfixFunctionCall`, `_getZeroInitializer`
+  - `generateAssignment()` (PRs #670, #671, #673, #675, #676, #678, #680, #682)
+
+### Fixed
+
+- Exclude test files from SonarCloud coverage requirements (PR #674)
+- Resolve tsx/vitest ESM interop issue with @n1ru4l/toposort (PR #672)
+- Remove unnecessary non-null assertions (PR #671)
+- Use direct tsx path instead of npx for faster CLI startup (PR #670)
+- Update bin script and CLI tests for ESM compatibility (PR #669)
+
+### Added
+
+- Improve unit test coverage for CHeaderGenerator and StringDeclHelper (PR #679)
+- Bring lib and Transpiler to near-100% unit test coverage (PR #674)
+- Add comprehensive unit tests for transpiler components (PR #668)
+- 42 new unit tests for MemberSeparatorResolver and ParameterDereferenceResolver (PR #681)
+
 ## [0.1.57] - 2026-02-04
 
 ### Fixed
@@ -709,6 +737,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - 38 legacy ESLint errors (non-blocking, tracked for future cleanup)
 
 [Unreleased]: https://github.com/jlaustill/c-next/compare/v0.1.57...HEAD
+[0.1.58]: https://github.com/jlaustill/c-next/compare/v0.1.57...v0.1.58
 [0.1.57]: https://github.com/jlaustill/c-next/compare/v0.1.56...v0.1.57
 [0.1.56]: https://github.com/jlaustill/c-next/compare/v0.1.55...v0.1.56
 [0.1.55]: https://github.com/jlaustill/c-next/compare/v0.1.54...v0.1.55

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "c-next",
-  "version": "0.1.57",
+  "version": "0.1.58",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "c-next",
-      "version": "0.1.57",
+      "version": "0.1.58",
       "license": "MIT",
       "dependencies": {
         "@n1ru4l/toposort": "^0.0.1",
@@ -274,7 +274,6 @@
       "integrity": "sha512-lf6d+BdMkJIFCxx2FpajLpqVGGyaGUNFU6jhEM6QUPeGuoA5et2kJXrL0NSY2uWLOVyYYc/FPjzlbe8trA9tBQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20"
       }
@@ -356,8 +355,7 @@
       "resolved": "https://registry.npmjs.org/@cspell/dict-css/-/dict-css-4.0.19.tgz",
       "integrity": "sha512-VYHtPnZt/Zd/ATbW3rtexWpBnHUohUrQOHff/2JBhsVgxOrksAxJnLAO43Q1ayLJBJUUwNVo+RU0sx0aaysZfg==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@cspell/dict-dart": {
       "version": "2.3.2",
@@ -497,16 +495,14 @@
       "resolved": "https://registry.npmjs.org/@cspell/dict-html/-/dict-html-4.0.14.tgz",
       "integrity": "sha512-2bf7n+kS92g+cMKV0wr9o/Oq9n8JzU7CcrB96gIh2GHgnF+0xDOqO2W/1KeFAqOfqosoOVE48t+4dnEMkkoJ2Q==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@cspell/dict-html-symbol-entities": {
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/@cspell/dict-html-symbol-entities/-/dict-html-symbol-entities-4.0.5.tgz",
       "integrity": "sha512-429alTD4cE0FIwpMucvSN35Ld87HCyuM8mF731KU5Rm4Je2SG6hmVx7nkBsLyrmH3sQukTcr1GaiZsiEg8svPA==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@cspell/dict-java": {
       "version": "5.0.12",
@@ -704,8 +700,7 @@
       "resolved": "https://registry.npmjs.org/@cspell/dict-typescript/-/dict-typescript-3.2.3.tgz",
       "integrity": "sha512-zXh1wYsNljQZfWWdSPYwQhpwiuW0KPW1dSd8idjMRvSD0aSvWWHoWlrMsmZeRl4qM4QCEAjua8+cjflm41cQBg==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@cspell/dict-vue": {
       "version": "3.0.5",
@@ -2127,7 +2122,6 @@
       "integrity": "sha512-DZ8VwRFUNzuqJ5khrvwMXHmvPe+zGayJhr2CDNiKB1WBE1ST8Djl00D0IC4vvNmHMdj6DlbYRIaFE7WHjlDl5w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -2297,7 +2291,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3639,7 +3632,6 @@
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-5.6.0.tgz",
       "integrity": "sha512-CYDD3SOtsHtyXeEORYRx2qBtpDJFjRTGXUtmNEMGyzYOKj1TE3tycdlho7kA1Ufx9OYWZzg52QFBGALTirzDSw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@keyv/serialize": "^1.1.1"
       }
@@ -4660,7 +4652,6 @@
       "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
       "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "~0.27.0",
         "get-tsconfig": "^4.7.5"
@@ -4680,7 +4671,6 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -4702,7 +4692,6 @@
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -4778,7 +4767,6 @@
       "integrity": "sha512-hOQuK7h0FGKgBAas7v0mSAsnvrIgAvWmRFjmzpJ7SwFHH3g1k2u37JtYwOwmEKhK6ZO3v9ggDBBm0La1LCK4uQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.0.18",
         "@vitest/mocker": "4.0.18",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "c-next",
-  "version": "0.1.57",
+  "version": "0.1.58",
   "description": "A safer C for embedded systems development. Transpiles to clean, readable C.",
   "type": "module",
   "main": "src/index.ts",

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "c-next",
   "displayName": "C-Next",
   "description": "Syntax highlighting and live C preview for C-Next, a safer C for embedded systems",
-  "version": "0.1.55",
+  "version": "0.1.58",
   "publisher": "jlaustill",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
## Release v0.1.58

### Changed

- Switch to ES modules for top-level await support (PR #669)
- Move all test files to `__tests__` directories (PR #668)
- Upgrade GitHub Actions and publish workflow to Node.js 24 (PR #672)
- Extract separator and dereference resolution utilities for improved testability (PR #681)
- Reduce cognitive complexity across multiple functions to meet SonarCloud thresholds

### Fixed

- Exclude test files from SonarCloud coverage requirements (PR #674)
- Resolve tsx/vitest ESM interop issue with @n1ru4l/toposort (PR #672)
- Remove unnecessary non-null assertions (PR #671)
- Use direct tsx path instead of npx for faster CLI startup (PR #670)
- Update bin script and CLI tests for ESM compatibility (PR #669)

### Added

- Improve unit test coverage for CHeaderGenerator and StringDeclHelper (PR #679)
- Bring lib and Transpiler to near-100% unit test coverage (PR #674)
- Add comprehensive unit tests for transpiler components (PR #668)
- 42 new unit tests for MemberSeparatorResolver and ParameterDereferenceResolver (PR #681)

---

**Checklist:**
- [x] Version bumped in package.json (0.1.57 → 0.1.58)
- [x] Version bumped in vscode-extension/package.json
- [x] CHANGELOG.md updated
- [x] All tests pass (904 integration + 3617 unit)
- [x] TypeScript compiles without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)