### PR TITLE
test: 100% branch coverage for analysis module

### DIFF
--- a/src/transpiler/logic/analysis/__tests__/GrammarCoverageListener.test.ts
+++ b/src/transpiler/logic/analysis/__tests__/GrammarCoverageListener.test.ts
@@ -1,0 +1,281 @@
+/**
+ * Unit tests for GrammarCoverageListener
+ * Tests grammar rule coverage tracking (pure unit tests, no parsing needed)
+ */
+import { describe, it, expect } from "vitest";
+import { ParserRuleContext, TerminalNode, Token } from "antlr4ng";
+import GrammarCoverageListener from "../GrammarCoverageListener";
+
+/**
+ * Create a mock ParserRuleContext with a given ruleIndex
+ */
+function mockRuleContext(ruleIndex: number): ParserRuleContext {
+  const ctx = new ParserRuleContext(null);
+  Object.defineProperty(ctx, "ruleIndex", { value: ruleIndex });
+  return ctx;
+}
+
+/**
+ * Create a mock TerminalNode with a given token type
+ */
+function mockTerminalNode(tokenType: number): TerminalNode {
+  const token = { type: tokenType } as Token;
+  return { symbol: token } as TerminalNode;
+}
+
+describe("GrammarCoverageListener", () => {
+  const parserRuleNames = ["program", "statement", "expression"];
+  const lexerRuleNames = ["IDENTIFIER", "INTEGER_LITERAL", "PLUS"];
+
+  describe("enterEveryRule", () => {
+    it("should increment count for valid rule index", () => {
+      const listener = new GrammarCoverageListener(
+        parserRuleNames,
+        lexerRuleNames,
+      );
+      listener.enterEveryRule(mockRuleContext(0));
+
+      const visits = listener.getParserRuleVisits();
+      expect(visits.get("program")).toBe(1);
+    });
+
+    it("should increment count on repeated visits", () => {
+      const listener = new GrammarCoverageListener(
+        parserRuleNames,
+        lexerRuleNames,
+      );
+      listener.enterEveryRule(mockRuleContext(1));
+      listener.enterEveryRule(mockRuleContext(1));
+      listener.enterEveryRule(mockRuleContext(1));
+
+      const visits = listener.getParserRuleVisits();
+      expect(visits.get("statement")).toBe(3);
+    });
+
+    it("should not crash with out-of-range rule index", () => {
+      const listener = new GrammarCoverageListener(
+        parserRuleNames,
+        lexerRuleNames,
+      );
+      listener.enterEveryRule(mockRuleContext(999));
+
+      const visits = listener.getParserRuleVisits();
+      expect(visits.size).toBe(0);
+    });
+  });
+
+  describe("visitTerminal", () => {
+    it("should increment count for valid token type", () => {
+      const listener = new GrammarCoverageListener(
+        parserRuleNames,
+        lexerRuleNames,
+      );
+      // Token type 1 maps to lexerRuleNames[0] = "IDENTIFIER"
+      listener.visitTerminal(mockTerminalNode(1));
+
+      const visits = listener.getLexerRuleVisits();
+      expect(visits.get("IDENTIFIER")).toBe(1);
+    });
+
+    it("should skip EOF token (type -1)", () => {
+      const listener = new GrammarCoverageListener(
+        parserRuleNames,
+        lexerRuleNames,
+      );
+      listener.visitTerminal(mockTerminalNode(-1));
+
+      const visits = listener.getLexerRuleVisits();
+      expect(visits.size).toBe(0);
+    });
+
+    it("should not crash with out-of-range token type", () => {
+      const listener = new GrammarCoverageListener(
+        parserRuleNames,
+        lexerRuleNames,
+      );
+      listener.visitTerminal(mockTerminalNode(999));
+
+      const visits = listener.getLexerRuleVisits();
+      expect(visits.size).toBe(0);
+    });
+
+    it("should handle multiple different tokens", () => {
+      const listener = new GrammarCoverageListener(
+        parserRuleNames,
+        lexerRuleNames,
+      );
+      listener.visitTerminal(mockTerminalNode(1)); // IDENTIFIER
+      listener.visitTerminal(mockTerminalNode(2)); // INTEGER_LITERAL
+      listener.visitTerminal(mockTerminalNode(3)); // PLUS
+
+      const visits = listener.getLexerRuleVisits();
+      expect(visits.size).toBe(3);
+      expect(visits.get("IDENTIFIER")).toBe(1);
+      expect(visits.get("INTEGER_LITERAL")).toBe(1);
+      expect(visits.get("PLUS")).toBe(1);
+    });
+  });
+
+  describe("merge", () => {
+    it("should combine counts from two listeners", () => {
+      const listener1 = new GrammarCoverageListener(
+        parserRuleNames,
+        lexerRuleNames,
+      );
+      const listener2 = new GrammarCoverageListener(
+        parserRuleNames,
+        lexerRuleNames,
+      );
+
+      listener1.enterEveryRule(mockRuleContext(0)); // program: 1
+      listener1.visitTerminal(mockTerminalNode(1)); // IDENTIFIER: 1
+
+      listener2.enterEveryRule(mockRuleContext(0)); // program: 1
+      listener2.enterEveryRule(mockRuleContext(1)); // statement: 1
+      listener2.visitTerminal(mockTerminalNode(1)); // IDENTIFIER: 1
+      listener2.visitTerminal(mockTerminalNode(2)); // INTEGER_LITERAL: 1
+
+      listener1.merge(listener2);
+
+      const parserVisits = listener1.getParserRuleVisits();
+      expect(parserVisits.get("program")).toBe(2);
+      expect(parserVisits.get("statement")).toBe(1);
+
+      const lexerVisits = listener1.getLexerRuleVisits();
+      expect(lexerVisits.get("IDENTIFIER")).toBe(2);
+      expect(lexerVisits.get("INTEGER_LITERAL")).toBe(1);
+    });
+  });
+
+  describe("reset", () => {
+    it("should clear all counts", () => {
+      const listener = new GrammarCoverageListener(
+        parserRuleNames,
+        lexerRuleNames,
+      );
+      listener.enterEveryRule(mockRuleContext(0));
+      listener.visitTerminal(mockTerminalNode(1));
+
+      listener.reset();
+
+      expect(listener.getParserRuleVisits().size).toBe(0);
+      expect(listener.getLexerRuleVisits().size).toBe(0);
+    });
+  });
+
+  describe("getParserRuleVisits / getLexerRuleVisits", () => {
+    it("should return copies that don't affect internal state", () => {
+      const listener = new GrammarCoverageListener(
+        parserRuleNames,
+        lexerRuleNames,
+      );
+      listener.enterEveryRule(mockRuleContext(0));
+
+      const visits = listener.getParserRuleVisits();
+      visits.set("program", 999);
+
+      const freshVisits = listener.getParserRuleVisits();
+      expect(freshVisits.get("program")).toBe(1);
+    });
+  });
+
+  describe("getReport", () => {
+    it("should return correct totals and percentages", () => {
+      const listener = new GrammarCoverageListener(
+        parserRuleNames,
+        lexerRuleNames,
+      );
+      listener.enterEveryRule(mockRuleContext(0)); // visit "program"
+      listener.visitTerminal(mockTerminalNode(1)); // visit "IDENTIFIER"
+
+      const report = listener.getReport();
+
+      expect(report.totalParserRules).toBe(3);
+      expect(report.totalLexerRules).toBe(3);
+      expect(report.visitedParserRules).toBe(1);
+      expect(report.visitedLexerRules).toBe(1);
+      expect(report.parserCoveragePercentage).toBeCloseTo(33.33, 1);
+      expect(report.lexerCoveragePercentage).toBeCloseTo(33.33, 1);
+      expect(report.combinedCoveragePercentage).toBeCloseTo(33.33, 1);
+    });
+
+    it("should list never-visited rules", () => {
+      const listener = new GrammarCoverageListener(
+        parserRuleNames,
+        lexerRuleNames,
+      );
+      listener.enterEveryRule(mockRuleContext(0)); // only visit "program"
+
+      const report = listener.getReport();
+
+      expect(report.neverVisitedParserRules).toEqual([
+        "statement",
+        "expression",
+      ]);
+      expect(report.neverVisitedLexerRules).toEqual([
+        "IDENTIFIER",
+        "INTEGER_LITERAL",
+        "PLUS",
+      ]);
+    });
+
+    it("should handle zero rules without division error", () => {
+      const listener = new GrammarCoverageListener([], []);
+      const report = listener.getReport();
+
+      expect(report.totalParserRules).toBe(0);
+      expect(report.totalLexerRules).toBe(0);
+      expect(report.parserCoveragePercentage).toBe(0);
+      expect(report.lexerCoveragePercentage).toBe(0);
+      expect(report.combinedCoveragePercentage).toBe(0);
+    });
+
+    it("should return map copies in report", () => {
+      const listener = new GrammarCoverageListener(
+        parserRuleNames,
+        lexerRuleNames,
+      );
+      listener.enterEveryRule(mockRuleContext(0));
+
+      const report = listener.getReport();
+      report.parserRuleVisits.set("program", 999);
+
+      const freshReport = listener.getReport();
+      expect(freshReport.parserRuleVisits.get("program")).toBe(1);
+    });
+
+    it("should report 100% when all rules visited", () => {
+      const listener = new GrammarCoverageListener(
+        parserRuleNames,
+        lexerRuleNames,
+      );
+      listener.enterEveryRule(mockRuleContext(0));
+      listener.enterEveryRule(mockRuleContext(1));
+      listener.enterEveryRule(mockRuleContext(2));
+      listener.visitTerminal(mockTerminalNode(1));
+      listener.visitTerminal(mockTerminalNode(2));
+      listener.visitTerminal(mockTerminalNode(3));
+
+      const report = listener.getReport();
+
+      expect(report.parserCoveragePercentage).toBe(100);
+      expect(report.lexerCoveragePercentage).toBe(100);
+      expect(report.combinedCoveragePercentage).toBe(100);
+      expect(report.neverVisitedParserRules).toHaveLength(0);
+      expect(report.neverVisitedLexerRules).toHaveLength(0);
+    });
+  });
+
+  describe("exitEveryRule / visitErrorNode", () => {
+    it("should not crash when called", () => {
+      const listener = new GrammarCoverageListener(
+        parserRuleNames,
+        lexerRuleNames,
+      );
+      const ctx = mockRuleContext(0);
+
+      expect(() => listener.exitEveryRule(ctx)).not.toThrow();
+      expect(() => listener.visitErrorNode(undefined as never)).not.toThrow();
+    });
+  });
+});

--- a/src/transpiler/logic/analysis/__tests__/StructFieldAnalyzer.test.ts
+++ b/src/transpiler/logic/analysis/__tests__/StructFieldAnalyzer.test.ts
@@ -1,0 +1,159 @@
+/**
+ * Unit tests for StructFieldAnalyzer
+ * Validates struct field names don't conflict with C-Next reserved property names
+ */
+import { describe, it, expect } from "vitest";
+import { CharStream, CommonTokenStream } from "antlr4ng";
+import { CNextLexer } from "../../parser/grammar/CNextLexer";
+import { CNextParser } from "../../parser/grammar/CNextParser";
+import StructFieldAnalyzer from "../StructFieldAnalyzer";
+
+/**
+ * Helper to parse C-Next code and return the AST
+ */
+function parse(source: string) {
+  const charStream = CharStream.fromString(source);
+  const lexer = new CNextLexer(charStream);
+  const tokenStream = new CommonTokenStream(lexer);
+  const parser = new CNextParser(tokenStream);
+  return parser.program();
+}
+
+describe("StructFieldAnalyzer", () => {
+  describe("reserved field name detection", () => {
+    it("should detect reserved field name 'length'", () => {
+      const code = `
+        struct MyStruct {
+          u32 length;
+        }
+      `;
+      const tree = parse(code);
+      const analyzer = new StructFieldAnalyzer();
+      const errors = analyzer.analyze(tree);
+
+      expect(errors).toHaveLength(1);
+      expect(errors[0].code).toBe("E0355");
+      expect(errors[0].fieldName).toBe("length");
+      expect(errors[0].structName).toBe("MyStruct");
+    });
+
+    it("should not flag non-reserved field names", () => {
+      const code = `
+        struct Point {
+          u32 x;
+          u32 y;
+          u32 count;
+        }
+      `;
+      const tree = parse(code);
+      const analyzer = new StructFieldAnalyzer();
+      const errors = analyzer.analyze(tree);
+
+      expect(errors).toHaveLength(0);
+    });
+
+    it("should detect reserved field among multiple fields", () => {
+      const code = `
+        struct Data {
+          u32 count;
+          u32 length;
+          u32 size;
+        }
+      `;
+      const tree = parse(code);
+      const analyzer = new StructFieldAnalyzer();
+      const errors = analyzer.analyze(tree);
+
+      expect(errors).toHaveLength(1);
+      expect(errors[0].fieldName).toBe("length");
+      expect(errors[0].structName).toBe("Data");
+    });
+  });
+
+  describe("error details", () => {
+    it("should report correct error code and message format", () => {
+      const code = `
+        struct Buffer {
+          u32 length;
+        }
+      `;
+      const tree = parse(code);
+      const analyzer = new StructFieldAnalyzer();
+      const errors = analyzer.analyze(tree);
+
+      expect(errors[0].code).toBe("E0355");
+      expect(errors[0].message).toContain("reserved C-Next property name");
+      expect(errors[0].message).toContain("'length'");
+      expect(errors[0].message).toContain("'Buffer'");
+    });
+
+    it("should provide help text with alternatives", () => {
+      const code = `
+        struct Buffer {
+          u32 length;
+        }
+      `;
+      const tree = parse(code);
+      const analyzer = new StructFieldAnalyzer();
+      const errors = analyzer.analyze(tree);
+
+      expect(errors[0].helpText).toContain("Reserved field names:");
+      expect(errors[0].helpText).toContain("length");
+      expect(errors[0].helpText).toContain("len");
+      expect(errors[0].helpText).toContain("size");
+      expect(errors[0].helpText).toContain("count");
+    });
+
+    it("should report correct line and column", () => {
+      const code = `struct S {
+  u32 length;
+}`;
+      const tree = parse(code);
+      const analyzer = new StructFieldAnalyzer();
+      const errors = analyzer.analyze(tree);
+
+      expect(errors[0].line).toBe(2);
+      expect(errors[0].column).toBeGreaterThan(0);
+    });
+  });
+
+  describe("edge cases", () => {
+    it("should handle empty program", () => {
+      const code = ``;
+      const tree = parse(code);
+      const analyzer = new StructFieldAnalyzer();
+      const errors = analyzer.analyze(tree);
+
+      expect(errors).toHaveLength(0);
+    });
+
+    it("should handle multiple structs with mixed fields", () => {
+      const code = `
+        struct Good {
+          u32 x;
+        }
+        struct Bad {
+          u32 length;
+        }
+      `;
+      const tree = parse(code);
+      const analyzer = new StructFieldAnalyzer();
+      const errors = analyzer.analyze(tree);
+
+      expect(errors).toHaveLength(1);
+      expect(errors[0].structName).toBe("Bad");
+    });
+
+    it("should be reusable across multiple analyze calls", () => {
+      const analyzer = new StructFieldAnalyzer();
+
+      const code1 = `struct A { u32 length; }`;
+      const errors1 = analyzer.analyze(parse(code1));
+      expect(errors1).toHaveLength(1);
+
+      const code2 = `struct B { u32 count; }`;
+      const errors2 = analyzer.analyze(parse(code2));
+      expect(errors2).toHaveLength(0);
+    });
+  });
+});

--- a/src/transpiler/logic/analysis/__tests__/runAnalyzers.test.ts
+++ b/src/transpiler/logic/analysis/__tests__/runAnalyzers.test.ts
@@ -1,0 +1,304 @@
+/**
+ * Unit tests for runAnalyzers
+ * Tests that all 8 analyzers run in sequence with early returns on errors
+ */
+import { describe, it, expect } from "vitest";
+import { CharStream, CommonTokenStream } from "antlr4ng";
+import { CNextLexer } from "../../parser/grammar/CNextLexer";
+import { CNextParser } from "../../parser/grammar/CNextParser";
+import runAnalyzers from "../runAnalyzers";
+import SymbolTable from "../../symbols/SymbolTable";
+import ESymbolKind from "../../../../utils/types/ESymbolKind";
+import ESourceLanguage from "../../../../utils/types/ESourceLanguage";
+
+/**
+ * Helper to parse C-Next code and return AST + token stream
+ */
+function parseWithStream(source: string) {
+  const charStream = CharStream.fromString(source);
+  const lexer = new CNextLexer(charStream);
+  const tokenStream = new CommonTokenStream(lexer);
+  const parser = new CNextParser(tokenStream);
+  const tree = parser.program();
+  return { tree, tokenStream };
+}
+
+describe("runAnalyzers", () => {
+  // ========================================================================
+  // Happy Path
+  // ========================================================================
+
+  describe("valid code", () => {
+    it("should return no errors for valid code", () => {
+      const { tree, tokenStream } = parseWithStream(`
+        void main() {
+          u32 x <- 5;
+          u32 y <- x + 3;
+        }
+      `);
+      const errors = runAnalyzers(tree, tokenStream);
+      expect(errors).toHaveLength(0);
+    });
+
+    it("should return no errors for empty program", () => {
+      const { tree, tokenStream } = parseWithStream(``);
+      const errors = runAnalyzers(tree, tokenStream);
+      expect(errors).toHaveLength(0);
+    });
+  });
+
+  // ========================================================================
+  // Phase 1: Parameter Naming Errors (early return)
+  // ========================================================================
+
+  describe("phase 1 - parameter naming", () => {
+    it("should return early on parameter naming error", () => {
+      const { tree, tokenStream } = parseWithStream(`
+        void process(u32 process_data) {
+          u32 x <- process_data;
+        }
+      `);
+      const errors = runAnalyzers(tree, tokenStream);
+
+      expect(errors.length).toBeGreaterThan(0);
+      expect(errors[0].severity).toBe("error");
+      expect(errors[0].message).toContain("process_data");
+    });
+  });
+
+  // ========================================================================
+  // Phase 2: Struct Field Errors (early return)
+  // ========================================================================
+
+  describe("phase 2 - struct field naming", () => {
+    it("should return early on struct field reserved name", () => {
+      const { tree, tokenStream } = parseWithStream(`
+        struct MyStruct {
+          u32 length;
+        }
+      `);
+      const errors = runAnalyzers(tree, tokenStream);
+
+      expect(errors.length).toBeGreaterThan(0);
+      expect(errors[0].severity).toBe("error");
+      expect(errors[0].message).toContain("E0355");
+    });
+  });
+
+  // ========================================================================
+  // Phase 3: Initialization Errors (early return)
+  // ========================================================================
+
+  describe("phase 3 - initialization", () => {
+    it("should return early on use-before-init error", () => {
+      const { tree, tokenStream } = parseWithStream(`
+        void main() {
+          u32 x;
+          u32 y <- x;
+        }
+      `);
+      const errors = runAnalyzers(tree, tokenStream);
+
+      expect(errors.length).toBeGreaterThan(0);
+      expect(errors[0].severity).toBe("error");
+      // InitializationAnalyzer uses E0381 for use-before-init
+      expect(errors[0].message).toContain("E0381");
+    });
+  });
+
+  // ========================================================================
+  // Phase 4: Function Call Errors (early return)
+  // ========================================================================
+
+  describe("phase 4 - function call", () => {
+    it("should return early on call-before-define error", () => {
+      const { tree, tokenStream } = parseWithStream(`
+        void main() {
+          helper();
+        }
+        void helper() {
+          u32 x <- 5;
+        }
+      `);
+      const errors = runAnalyzers(tree, tokenStream);
+
+      expect(errors.length).toBeGreaterThan(0);
+      expect(errors[0].severity).toBe("error");
+      expect(errors[0].message).toContain("E0422");
+    });
+  });
+
+  // ========================================================================
+  // Phase 5: Null Check Errors (early return)
+  // ========================================================================
+
+  describe("phase 5 - null check", () => {
+    it("should return early on missing null check", () => {
+      const { tree, tokenStream } = parseWithStream(`
+        #include <string.h>
+        void main() {
+          cstring str <- "hello";
+          strchr(str, 'x');
+        }
+      `);
+      const errors = runAnalyzers(tree, tokenStream);
+
+      expect(errors.length).toBeGreaterThan(0);
+      expect(errors[0].severity).toBe("error");
+      expect(errors[0].message).toContain("E0901");
+    });
+  });
+
+  // ========================================================================
+  // Phase 6: Division by Zero Errors (early return)
+  // ========================================================================
+
+  describe("phase 6 - division by zero", () => {
+    it("should return early on division by zero", () => {
+      const { tree, tokenStream } = parseWithStream(`
+        void main() {
+          u32 x <- 10 / 0;
+        }
+      `);
+      const errors = runAnalyzers(tree, tokenStream);
+
+      expect(errors.length).toBeGreaterThan(0);
+      expect(errors[0].severity).toBe("error");
+      expect(errors[0].message).toContain("E0800");
+    });
+  });
+
+  // ========================================================================
+  // Phase 7: Float Modulo Errors (early return)
+  // ========================================================================
+
+  describe("phase 7 - float modulo", () => {
+    it("should return early on float modulo", () => {
+      const { tree, tokenStream } = parseWithStream(`
+        void main() {
+          f32 x <- 10.5;
+          f32 result <- x % 3;
+        }
+      `);
+      const errors = runAnalyzers(tree, tokenStream);
+
+      expect(errors.length).toBeGreaterThan(0);
+      expect(errors[0].severity).toBe("error");
+      expect(errors[0].message).toContain("E0804");
+    });
+  });
+
+  // ========================================================================
+  // Phase 8: Comment Validation
+  // ========================================================================
+
+  describe("phase 8 - comment validation", () => {
+    it("should return comment errors for nested comment markers", () => {
+      // MISRA 3.1: no nested comment start markers inside comments
+      const code = "/* outer /* nested */ \nvoid main() { u32 x <- 1; }";
+      const { tree, tokenStream } = parseWithStream(code);
+      const errors = runAnalyzers(tree, tokenStream);
+
+      expect(errors.length).toBeGreaterThan(0);
+      expect(errors[0].severity).toBe("error");
+      expect(errors[0].message).toContain("MISRA");
+    });
+  });
+
+  // ========================================================================
+  // Options: externalStructFields and symbolTable
+  // ========================================================================
+
+  describe("options", () => {
+    it("should pass externalStructFields to InitializationAnalyzer", () => {
+      // Code that uses a field from an external struct - the externalStructFields
+      // option tells the analyzer about external struct types
+      const { tree, tokenStream } = parseWithStream(`
+        void main() {
+          u32 x <- 5;
+        }
+      `);
+
+      const externalStructFields = new Map<string, Set<string>>([
+        ["ExternalStruct", new Set(["field1", "field2"])],
+      ]);
+
+      const errors = runAnalyzers(tree, tokenStream, { externalStructFields });
+      expect(errors).toHaveLength(0);
+    });
+
+    it("should pass symbolTable to analyzers", () => {
+      const { tree, tokenStream } = parseWithStream(`
+        void main() {
+          u32 x <- 5;
+        }
+      `);
+
+      const symbolTable = new SymbolTable();
+      symbolTable.addSymbol({
+        name: "ExternalFunc",
+        kind: ESymbolKind.Function,
+        sourceLanguage: ESourceLanguage.C,
+        sourceFile: "external.h",
+        sourceLine: 1,
+        isExported: true,
+      });
+
+      const errors = runAnalyzers(tree, tokenStream, { symbolTable });
+      expect(errors).toHaveLength(0);
+    });
+
+    it("should pass both options together", () => {
+      const { tree, tokenStream } = parseWithStream(`
+        void main() {
+          u32 x <- 5;
+        }
+      `);
+
+      const externalStructFields = new Map<string, Set<string>>([
+        ["CppMessage", new Set(["pgn"])],
+      ]);
+      const symbolTable = new SymbolTable();
+      symbolTable.addSymbol({
+        name: "CppMessage",
+        kind: ESymbolKind.Class,
+        sourceLanguage: ESourceLanguage.Cpp,
+        sourceFile: "CppMessage.hpp",
+        sourceLine: 1,
+        isExported: true,
+      });
+
+      const errors = runAnalyzers(tree, tokenStream, {
+        externalStructFields,
+        symbolTable,
+      });
+      expect(errors).toHaveLength(0);
+    });
+  });
+
+  // ========================================================================
+  // Error format validation
+  // ========================================================================
+
+  describe("error format", () => {
+    it("should include line, column, message, and severity on all errors", () => {
+      const { tree, tokenStream } = parseWithStream(`
+        void main() {
+          u32 x <- 10 / 0;
+        }
+      `);
+      const errors = runAnalyzers(tree, tokenStream);
+
+      for (const error of errors) {
+        expect(error).toHaveProperty("line");
+        expect(error).toHaveProperty("column");
+        expect(error).toHaveProperty("message");
+        expect(error).toHaveProperty("severity");
+        expect(typeof error.line).toBe("number");
+        expect(typeof error.column).toBe("number");
+        expect(typeof error.message).toBe("string");
+        expect(error.severity).toBe("error");
+      }
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add unit tests for `StructFieldAnalyzer` (9 tests) — branch coverage 50% → 100%
- Add unit tests for `GrammarCoverageListener` (16 tests) — branch coverage 55% → 100%
- Add unit tests for `runAnalyzers` (14 tests) — branch coverage 56.25% → 100%

## Test plan
- [x] All 39 new tests pass (`npm run unit`)
- [x] Full unit suite passes (3709 tests)
- [x] Integration tests pass (904 tests)
- [x] TypeScript type check passes
- [x] Pre-push quality gates all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)