### PR TITLE
refactor: reduce walkOrExpression cognitive complexity from 55 to 1

### DIFF
--- a/src/transpiler/output/codegen/CodeGenerator.ts
+++ b/src/transpiler/output/codegen/CodeGenerator.ts
@@ -3105,27 +3105,18 @@ export default class CodeGenerator implements IOrchestrator {
     orExpr: Parser.OrExpressionContext,
     handler: (unaryExpr: Parser.UnaryExpressionContext) => void,
   ): void {
-    for (const andExpr of orExpr.andExpression()) {
-      for (const eqExpr of andExpr.equalityExpression()) {
-        for (const relExpr of eqExpr.relationalExpression()) {
-          for (const bitOrExpr of relExpr.bitwiseOrExpression()) {
-            for (const bitXorExpr of bitOrExpr.bitwiseXorExpression()) {
-              for (const bitAndExpr of bitXorExpr.bitwiseAndExpression()) {
-                for (const shiftExpr of bitAndExpr.shiftExpression()) {
-                  for (const addExpr of shiftExpr.additiveExpression()) {
-                    for (const mulExpr of addExpr.multiplicativeExpression()) {
-                      for (const unaryExpr of mulExpr.unaryExpression()) {
-                        handler(unaryExpr);
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-    }
+    orExpr
+      .andExpression()
+      .flatMap((and) => and.equalityExpression())
+      .flatMap((eq) => eq.relationalExpression())
+      .flatMap((rel) => rel.bitwiseOrExpression())
+      .flatMap((bor) => bor.bitwiseXorExpression())
+      .flatMap((bxor) => bxor.bitwiseAndExpression())
+      .flatMap((band) => band.shiftExpression())
+      .flatMap((shift) => shift.additiveExpression())
+      .flatMap((add) => add.multiplicativeExpression())
+      .flatMap((mul) => mul.unaryExpression())
+      .forEach(handler);
   }
 
   /**


### PR DESCRIPTION
## Summary
- Refactored `walkOrExpression` in CodeGenerator to reduce cognitive complexity from 55 to ~1
- Replaced 10 levels of nested for-loops with a `flatMap` chain
- Functionally equivalent traversal of the expression grammar hierarchy

## Changes
The deeply nested loops:
```typescript
for (const andExpr of orExpr.andExpression()) {
  for (const eqExpr of andExpr.equalityExpression()) {
    // ... 8 more levels of nesting
  }
}
```

Become a linear chain:
```typescript
orExpr
  .andExpression()
  .flatMap((and) => and.equalityExpression())
  // ... continues linearly
  .forEach(handler);
```

## Test plan
- [x] All 905 integration tests pass
- [x] All 3832 unit tests pass
- [x] Linting passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)