### PR TITLE
Release v0.1.59

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.59] - 2026-02-05
+
+### Fixed
+
+- Unify getMemberTypeInfo across expression and assignment paths, fixing assignment path's inability to resolve C header struct fields (PR #701)
+- Show dot notation in hover signature for scope functions (PR #695)
+- Prevent doubled string capacity dimension in struct header fields (PR #695)
+- Resolve .capacity/.size against struct field type, not primary variable (PR #695)
+
+### Added
+
+- Enable strict CLI options mode for better error messages on unknown flags (PR #697)
+- Improve hover provider symbol resolution with proper scope hierarchy (PR #695)
+- Cross-file scope tests in DualCodePaths.test.ts for both function calls and variable assignments (PR #701)
+- Comprehensive unit tests for TransitiveEnumCollector, CallExprGenerator, analysis module branch coverage (PRs #685, #687, #688, #691, #693, #699)
+
+### Changed
+
+- Reduce cognitive complexity across multiple functions to meet SonarCloud thresholds:
+  - `AssignmentClassifier`, `ScopeGenerator`, `generateMemberAccess`, `PostfixExpressionGenerator`
+  - `walkOrExpression` (55→1), `generateVariableDecl` (52→~10), `_generatePrimaryExpr` (38→~8)
+  - (PRs #684, #686, #690, #694, #696, #698, #700)
+- VS Code extension architecture cleanup: injectable context, CSP nonce policy, debounced handlers, workspace boundary validation (PR #689)
+- Clean up README badges (PR #692)
+
 ## [0.1.58] - 2026-02-04
 
 ### Changed
@@ -737,6 +762,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - 38 legacy ESLint errors (non-blocking, tracked for future cleanup)
 
 [Unreleased]: https://github.com/jlaustill/c-next/compare/v0.1.57...HEAD
+[0.1.59]: https://github.com/jlaustill/c-next/compare/v0.1.58...v0.1.59
 [0.1.58]: https://github.com/jlaustill/c-next/compare/v0.1.57...v0.1.58
 [0.1.57]: https://github.com/jlaustill/c-next/compare/v0.1.56...v0.1.57
 [0.1.56]: https://github.com/jlaustill/c-next/compare/v0.1.55...v0.1.56

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "c-next",
-  "version": "0.1.58",
+  "version": "0.1.59",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "c-next",
-      "version": "0.1.58",
+      "version": "0.1.59",
       "license": "MIT",
       "dependencies": {
         "@n1ru4l/toposort": "^0.0.1",
@@ -274,6 +274,7 @@
       "integrity": "sha512-lf6d+BdMkJIFCxx2FpajLpqVGGyaGUNFU6jhEM6QUPeGuoA5et2kJXrL0NSY2uWLOVyYYc/FPjzlbe8trA9tBQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20"
       }
@@ -355,7 +356,8 @@
       "resolved": "https://registry.npmjs.org/@cspell/dict-css/-/dict-css-4.0.19.tgz",
       "integrity": "sha512-VYHtPnZt/Zd/ATbW3rtexWpBnHUohUrQOHff/2JBhsVgxOrksAxJnLAO43Q1ayLJBJUUwNVo+RU0sx0aaysZfg==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@cspell/dict-dart": {
       "version": "2.3.2",
@@ -495,14 +497,16 @@
       "resolved": "https://registry.npmjs.org/@cspell/dict-html/-/dict-html-4.0.14.tgz",
       "integrity": "sha512-2bf7n+kS92g+cMKV0wr9o/Oq9n8JzU7CcrB96gIh2GHgnF+0xDOqO2W/1KeFAqOfqosoOVE48t+4dnEMkkoJ2Q==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@cspell/dict-html-symbol-entities": {
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/@cspell/dict-html-symbol-entities/-/dict-html-symbol-entities-4.0.5.tgz",
       "integrity": "sha512-429alTD4cE0FIwpMucvSN35Ld87HCyuM8mF731KU5Rm4Je2SG6hmVx7nkBsLyrmH3sQukTcr1GaiZsiEg8svPA==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@cspell/dict-java": {
       "version": "5.0.12",
@@ -700,7 +704,8 @@
       "resolved": "https://registry.npmjs.org/@cspell/dict-typescript/-/dict-typescript-3.2.3.tgz",
       "integrity": "sha512-zXh1wYsNljQZfWWdSPYwQhpwiuW0KPW1dSd8idjMRvSD0aSvWWHoWlrMsmZeRl4qM4QCEAjua8+cjflm41cQBg==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@cspell/dict-vue": {
       "version": "3.0.5",
@@ -2122,6 +2127,7 @@
       "integrity": "sha512-DZ8VwRFUNzuqJ5khrvwMXHmvPe+zGayJhr2CDNiKB1WBE1ST8Djl00D0IC4vvNmHMdj6DlbYRIaFE7WHjlDl5w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -2291,6 +2297,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3632,6 +3639,7 @@
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-5.6.0.tgz",
       "integrity": "sha512-CYDD3SOtsHtyXeEORYRx2qBtpDJFjRTGXUtmNEMGyzYOKj1TE3tycdlho7kA1Ufx9OYWZzg52QFBGALTirzDSw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@keyv/serialize": "^1.1.1"
       }
@@ -4652,6 +4660,7 @@
       "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
       "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "~0.27.0",
         "get-tsconfig": "^4.7.5"
@@ -4671,6 +4680,7 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -4692,6 +4702,7 @@
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -4767,6 +4778,7 @@
       "integrity": "sha512-hOQuK7h0FGKgBAas7v0mSAsnvrIgAvWmRFjmzpJ7SwFHH3g1k2u37JtYwOwmEKhK6ZO3v9ggDBBm0La1LCK4uQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.0.18",
         "@vitest/mocker": "4.0.18",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "c-next",
-  "version": "0.1.58",
+  "version": "0.1.59",
   "description": "A safer C for embedded systems development. Transpiles to clean, readable C.",
   "type": "module",
   "main": "src/index.ts",

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "c-next",
   "displayName": "C-Next",
   "description": "Syntax highlighting and live C preview for C-Next, a safer C for embedded systems",
-  "version": "0.1.58",
+  "version": "0.1.59",
   "publisher": "jlaustill",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
## Summary

Patch release v0.1.59 with bug fixes, refactoring, and test coverage improvements.

### Fixed
- Unify getMemberTypeInfo across expression and assignment paths (PR #701)
- Show dot notation in hover signature for scope functions (PR #695)
- Prevent doubled string capacity dimension in struct header fields (PR #695)

### Added
- Strict CLI options mode for better error messages (PR #697)
- Improved hover provider symbol resolution with scope hierarchy (PR #695)
- Cross-file scope tests in DualCodePaths.test.ts (PR #701)

### Changed
- Reduce cognitive complexity across 7+ functions (PRs #684, #686, #690, #694, #696, #698, #700)
- VS Code extension architecture cleanup (PR #689)

🤖 Generated with [Claude Code](https://claude.com/claude-code)