### PR TITLE
refactor: convert AssignmentHandlerRegistry from singleton to static class

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -98,6 +98,18 @@ class TestUtils {
 export default TestUtils;
 ```
 
+**No singleton instance exports** - Don't instantiate and export class instances:
+
+```typescript
+// ❌ Wrong - singleton (knip can't detect unused methods)
+class Registry { private map = new Map(); register() { ... } }
+export default new Registry();
+
+// ✅ Correct - static class
+class Registry { private static map = new Map(); static register() { ... } }
+export default Registry;
+```
+
 **Readonly Map restoration** - Can't reassign `readonly` Map properties. Use `map.clear()` then `for (const [k, v] of saved) map.set(k, v)` to restore state.
 
 **No destructuring** - Always use the class name prefix for self-documenting code:
@@ -347,6 +359,8 @@ u32 main() {
 - **Prevent helper cleanup**: Create `.expected.h` for helper `.cnx` files to prevent test framework from deleting generated `.h` files needed by other tests
 - **Auto-generating helper snapshots**: `npm test -- <path> --update` creates `.expected.h` for helper `.cnx` files; helper `.h` files must also be committed for CI
 - **Worker debug output**: `console.log` in `test-worker.ts` doesn't appear (forked process). Use `--jobs 1` for sequential mode, but note `test.ts` has duplicated logic
+- **Assignment handler imports**: Import `AssignmentHandlerRegistry` from `assignment/index` (not `handlers/index`) to ensure handlers are registered
+- **Testing error paths with enums**: Use fake values (e.g., `9999 as AssignmentKind`) to test unregistered handler errors
 
 ### Error Validation Tests (test-error pattern)
 
@@ -445,8 +459,10 @@ If implementing a feature, all documents must be current and memory must be upda
 **Dead code and unused exports:**
 
 - `npx knip` — Find unused files, exports, and dependencies (config: `knip.json`)
+- `npx knip --include classMembers` — Find unused class methods (many false positives from generated parser files)
 - `npm run analyze:prune` — Find exported functions/classes not imported anywhere (ts-prune)
 - `parseWithSymbols.ts` is a public API entry point (used by vscode-extension)
+- **Singleton limitation**: knip can't detect unused methods on exported class instances — use static classes instead
 
 **Code duplication:**
 

--- a/knip.json
+++ b/knip.json
@@ -12,5 +12,6 @@
     "src/transpiler/output/codegen/helpers/CppModeHelper.ts",
     "src/transpiler/output/codegen/analysis/StringLengthCounter.ts"
   ],
-  "ignoreBinaries": ["jscpd", "jq", "dot"]
+  "ignoreBinaries": ["jscpd", "jq", "dot", "madge", "ts-prune"],
+  "ignoreDependencies": ["madge", "ts-prune"]
 }

--- a/src/transpiler/output/codegen/CodeGenerator.ts
+++ b/src/transpiler/output/codegen/CodeGenerator.ts
@@ -67,7 +67,7 @@ import memberAccessChain from "./memberAccessChain";
 // Shared member access validation (ADR-013/016/057)
 import MemberAccessValidator from "./helpers/MemberAccessValidator";
 // ADR-109: Assignment decomposition (Phase 2)
-import assignmentHandlers from "./assignment/index";
+import AssignmentHandlerRegistry from "./assignment/index";
 import AssignmentClassifier from "./assignment/AssignmentClassifier";
 import buildAssignmentContext from "./assignment/AssignmentContextBuilder";
 import IHandlerDeps from "./assignment/handlers/IHandlerDeps";
@@ -6647,7 +6647,7 @@ export default class CodeGenerator implements IOrchestrator {
       getMemberTypeInfo: handlerDeps.getMemberTypeInfo,
     });
     const assignmentKind = classifier.classify(assignCtx);
-    const handler = assignmentHandlers.getHandler(assignmentKind);
+    const handler = AssignmentHandlerRegistry.getHandler(assignmentKind);
     return handler(assignCtx, handlerDeps);
   }
 

--- a/src/transpiler/output/codegen/assignment/handlers/__tests__/AssignmentHandlerRegistry.test.ts
+++ b/src/transpiler/output/codegen/assignment/handlers/__tests__/AssignmentHandlerRegistry.test.ts
@@ -1,0 +1,81 @@
+/**
+ * Unit tests for AssignmentHandlerRegistry.
+ * Tests the static registry for assignment handlers.
+ */
+
+import { describe, expect, it } from "vitest";
+// Import from parent module to ensure handlers are registered
+import AssignmentHandlerRegistry from "../../index";
+import AssignmentKind from "../../AssignmentKind";
+
+describe("AssignmentHandlerRegistry", () => {
+  describe("getHandler", () => {
+    it("returns handler for registered assignment kind", () => {
+      const handler = AssignmentHandlerRegistry.getHandler(
+        AssignmentKind.SIMPLE,
+      );
+
+      expect(handler).toBeDefined();
+      expect(typeof handler).toBe("function");
+    });
+
+    it("throws error for unregistered assignment kind", () => {
+      // Use an invalid enum value to test the error path
+      const invalidKind = 9999 as AssignmentKind;
+
+      expect(() => AssignmentHandlerRegistry.getHandler(invalidKind)).toThrow(
+        "No handler registered for assignment kind:",
+      );
+    });
+
+    it("returns correct handler for each registered kind", () => {
+      // Verify all registered kinds return handlers
+      const registeredKinds = [
+        AssignmentKind.SIMPLE,
+        AssignmentKind.BITMAP_FIELD_SINGLE_BIT,
+        AssignmentKind.ARRAY_ELEMENT,
+        AssignmentKind.STRING_SIMPLE,
+        AssignmentKind.REGISTER_BIT,
+        AssignmentKind.INTEGER_BIT,
+        AssignmentKind.GLOBAL_MEMBER,
+        AssignmentKind.THIS_MEMBER,
+      ];
+
+      for (const kind of registeredKinds) {
+        const handler = AssignmentHandlerRegistry.getHandler(kind);
+        expect(handler).toBeDefined();
+        expect(typeof handler).toBe("function");
+      }
+    });
+  });
+
+  describe("register", () => {
+    it("registers a new handler", () => {
+      // Use a very high number that won't conflict with real enum values
+      const testKind = 99999 as AssignmentKind;
+      const testHandler = () => "test result";
+
+      AssignmentHandlerRegistry.register(testKind, testHandler);
+
+      const handler = AssignmentHandlerRegistry.getHandler(testKind);
+      expect(handler).toBe(testHandler);
+    });
+  });
+
+  describe("registerAll", () => {
+    it("registers multiple handlers at once", () => {
+      const testKind1 = 88881 as AssignmentKind;
+      const testKind2 = 88882 as AssignmentKind;
+      const handler1 = () => "result 1";
+      const handler2 = () => "result 2";
+
+      AssignmentHandlerRegistry.registerAll([
+        [testKind1, handler1],
+        [testKind2, handler2],
+      ]);
+
+      expect(AssignmentHandlerRegistry.getHandler(testKind1)).toBe(handler1);
+      expect(AssignmentHandlerRegistry.getHandler(testKind2)).toBe(handler2);
+    });
+  });
+});

--- a/src/transpiler/output/codegen/assignment/handlers/index.ts
+++ b/src/transpiler/output/codegen/assignment/handlers/index.ts
@@ -9,29 +9,32 @@ import AssignmentKind from "../AssignmentKind";
 import TAssignmentHandler from "./TAssignmentHandler";
 
 /**
- * Registry mapping AssignmentKind to handler functions.
+ * Static registry mapping AssignmentKind to handler functions.
  *
  * Handlers are registered lazily to avoid circular dependencies.
  * Use getHandler() to retrieve the handler for a given kind.
  */
 class AssignmentHandlerRegistry {
-  private readonly handlers = new Map<AssignmentKind, TAssignmentHandler>();
+  private static readonly handlers = new Map<
+    AssignmentKind,
+    TAssignmentHandler
+  >();
 
   /**
    * Register a handler for an assignment kind.
    */
-  register(kind: AssignmentKind, handler: TAssignmentHandler): void {
-    this.handlers.set(kind, handler);
+  static register(kind: AssignmentKind, handler: TAssignmentHandler): void {
+    AssignmentHandlerRegistry.handlers.set(kind, handler);
   }
 
   /**
    * Register multiple handlers at once.
    */
-  registerAll(
+  static registerAll(
     entries: ReadonlyArray<[AssignmentKind, TAssignmentHandler]>,
   ): void {
     for (const [kind, handler] of entries) {
-      this.handlers.set(kind, handler);
+      AssignmentHandlerRegistry.handlers.set(kind, handler);
     }
   }
 
@@ -39,8 +42,8 @@ class AssignmentHandlerRegistry {
    * Get the handler for an assignment kind.
    * Throws if no handler is registered.
    */
-  getHandler(kind: AssignmentKind): TAssignmentHandler {
-    const handler = this.handlers.get(kind);
+  static getHandler(kind: AssignmentKind): TAssignmentHandler {
+    const handler = AssignmentHandlerRegistry.handlers.get(kind);
     if (!handler) {
       throw new Error(
         `No handler registered for assignment kind: ${AssignmentKind[kind]}`,
@@ -48,23 +51,6 @@ class AssignmentHandlerRegistry {
     }
     return handler;
   }
-
-  /**
-   * Check if a handler is registered for an assignment kind.
-   */
-  hasHandler(kind: AssignmentKind): boolean {
-    return this.handlers.has(kind);
-  }
-
-  /**
-   * Get all registered kinds (for debugging/testing).
-   */
-  getRegisteredKinds(): AssignmentKind[] {
-    return Array.from(this.handlers.keys());
-  }
 }
 
-/** Singleton registry instance */
-const assignmentHandlers = new AssignmentHandlerRegistry();
-
-export default assignmentHandlers;
+export default AssignmentHandlerRegistry;

--- a/src/transpiler/output/codegen/assignment/index.ts
+++ b/src/transpiler/output/codegen/assignment/index.ts
@@ -9,7 +9,7 @@
  * - handlers/index (registry)
  */
 import AssignmentKind from "./AssignmentKind";
-import assignmentHandlers from "./handlers/index";
+import AssignmentHandlerRegistry from "./handlers/index";
 
 // Import all handler modules
 import handleSimple from "./handlers/SimpleHandler";
@@ -26,17 +26,17 @@ import accessPatternHandlers from "./handlers/AccessPatternHandlers";
  * Called once during module load.
  */
 function initializeHandlers(): void {
-  assignmentHandlers.register(AssignmentKind.SIMPLE, handleSimple);
-  assignmentHandlers.registerAll(bitmapHandlers);
-  assignmentHandlers.registerAll(registerHandlers);
-  assignmentHandlers.registerAll(stringHandlers);
-  assignmentHandlers.registerAll(bitAccessHandlers);
-  assignmentHandlers.registerAll(arrayHandlers);
-  assignmentHandlers.registerAll(specialHandlers);
-  assignmentHandlers.registerAll(accessPatternHandlers);
+  AssignmentHandlerRegistry.register(AssignmentKind.SIMPLE, handleSimple);
+  AssignmentHandlerRegistry.registerAll(bitmapHandlers);
+  AssignmentHandlerRegistry.registerAll(registerHandlers);
+  AssignmentHandlerRegistry.registerAll(stringHandlers);
+  AssignmentHandlerRegistry.registerAll(bitAccessHandlers);
+  AssignmentHandlerRegistry.registerAll(arrayHandlers);
+  AssignmentHandlerRegistry.registerAll(specialHandlers);
+  AssignmentHandlerRegistry.registerAll(accessPatternHandlers);
 }
 
 // Initialize handlers on module load
 initializeHandlers();
 
-export default assignmentHandlers;
+export default AssignmentHandlerRegistry;


### PR DESCRIPTION
## Summary

- Refactor `AssignmentHandlerRegistry` to use static methods instead of exporting a singleton instance
- Remove dead code: `hasHandler()` and `getRegisteredKinds()` methods that were never called
- Add unit tests achieving 100% coverage for `handlers/index.ts`
- Update CLAUDE.md with learnings about singleton anti-pattern

## Why

The singleton pattern (instantiating a class and exporting the instance) is an anti-pattern because:
1. **knip can't detect unused methods** on exported class instances
2. Static classes are more explicit and easier to analyze

## Changes

| File | Change |
|------|--------|
| `handlers/index.ts` | Converted to static class, removed 2 unused methods |
| `assignment/index.ts` | Updated to use static method calls |
| `CodeGenerator.ts` | Updated import and usage |
| `AssignmentHandlerRegistry.test.ts` | New unit tests (5 tests) |
| `CLAUDE.md` | Added learnings about static class preference |

## Coverage Improvement

| Metric | Before | After |
|--------|--------|-------|
| Statements | 72.72% | 100% |
| Branches | 50% | 100% |
| Lines | 72.72% | 100% |

## Test plan

- [x] All 905 integration tests pass
- [x] All 3871 unit tests pass
- [x] Linting passes (oxlint)
- [x] All pre-push quality checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)