### PR TITLE
fix: increase timeout for flaky Transpiler.coverage.test.ts in CI

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -91,10 +91,6 @@ Check the terminal report for files you changed — any new code below 80% cover
 - **Get cognitive complexity issues**: `curl -s "https://sonarcloud.io/api/issues/search?componentKeys=jlaustill_c-next&statuses=OPEN,CONFIRMED&rules=typescript:S3776&ps=100" | jq '.issues[] | {message, component, line}'`
 - **Get complexity sorted by severity**: `curl -s "https://sonarcloud.io/api/issues/search?componentKeys=jlaustill_c-next&statuses=OPEN,CONFIRMED&rules=typescript:S3776&ps=100" | jq '[.issues[] | {file: (.component | split(":")[1]), line, complexity: (.message | capture("from (?<from>[0-9]+)") | .from | tonumber)}] | sort_by(.complexity) | reverse'`
 
-### Flaky CI Tests
-
-- **Transpiler.coverage.test.ts** can timeout in CI (5s limit). Re-run with `gh run rerun <run-id> --failed`
-
 ### CSpell (Spelling Check)
 
 - **Run manually**: `npm run cspell:check` (runs automatically on push)

--- a/src/transpiler/__tests__/Transpiler.coverage.test.ts
+++ b/src/transpiler/__tests__/Transpiler.coverage.test.ts
@@ -55,7 +55,7 @@ describe("Transpiler coverage tests", () => {
       // Check output file has .cpp extension
       const writeCalls = mockFs.getWriteLog();
       expect(writeCalls.some((w) => w.path.endsWith(".cpp"))).toBe(true);
-    });
+    }, 10000); // Extended timeout for ANTLR parser initialization in CI
 
     it("transpileSource respects cppRequired config", async () => {
       const transpiler = new Transpiler(


### PR DESCRIPTION
## Summary

- Extended timeout for the flaky test from 5s to 10s to handle ANTLR parser initialization overhead in CI
- Removed the workaround note from CLAUDE.md since manual reruns are no longer needed

Fixes #716

## Test plan

- [x] Verified test passes locally with `npm run unit -- src/transpiler/__tests__/Transpiler.coverage.test.ts`
- [ ] CI should pass without flaky timeouts

🤖 Generated with [Claude Code](https://claude.com/claude-code)