### PR TITLE
test: add unit tests for GeneratorRegistry has* methods

### DIFF
--- a/src/transpiler/output/codegen/generators/__tests__/GeneratorRegistry.test.ts
+++ b/src/transpiler/output/codegen/generators/__tests__/GeneratorRegistry.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { ParserRuleContext } from "antlr4ng";
+import GeneratorRegistry from "../GeneratorRegistry";
+import TGeneratorFn from "../TGeneratorFn";
+
+// Mock generator function for testing
+const mockGenerator: TGeneratorFn<ParserRuleContext> = () => ({
+  code: "mock",
+  effects: [],
+});
+
+export default describe("GeneratorRegistry", () => {
+  let registry: GeneratorRegistry;
+
+  beforeEach(() => {
+    registry = new GeneratorRegistry();
+  });
+
+  describe("hasDeclaration", () => {
+    it("returns false for unregistered kind", () => {
+      expect(registry.hasDeclaration("struct")).toBe(false);
+    });
+
+    it("returns true for registered kind", () => {
+      registry.registerDeclaration("struct", mockGenerator);
+      expect(registry.hasDeclaration("struct")).toBe(true);
+    });
+  });
+
+  describe("hasStatement", () => {
+    it("returns false for unregistered kind", () => {
+      expect(registry.hasStatement("if")).toBe(false);
+    });
+
+    it("returns true for registered kind", () => {
+      registry.registerStatement("if", mockGenerator);
+      expect(registry.hasStatement("if")).toBe(true);
+    });
+  });
+
+  describe("hasExpression", () => {
+    it("returns false for unregistered kind", () => {
+      expect(registry.hasExpression("ternary")).toBe(false);
+    });
+
+    it("returns true for registered kind", () => {
+      registry.registerExpression("ternary", mockGenerator);
+      expect(registry.hasExpression("ternary")).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add unit tests for `hasDeclaration`, `hasStatement`, and `hasExpression` methods
- Achieves 100% test coverage on `GeneratorRegistry.ts`

## Test plan
- [x] `npm run unit` passes
- [x] `npm run unit:coverage` shows 100% coverage for GeneratorRegistry.ts

🤖 Generated with [Claude Code](https://claude.com/claude-code)