### PR TITLE
fix(sonarcloud): reduce cognitive complexity in transpileSource

### DIFF
--- a/src/transpiler/Transpiler.ts
+++ b/src/transpiler/Transpiler.ts
@@ -48,6 +48,7 @@ import runAnalyzers from "./logic/analysis/runAnalyzers";
 import ModificationAnalyzer from "./logic/analysis/ModificationAnalyzer";
 import AnalyzerContextBuilder from "./logic/analysis/AnalyzerContextBuilder";
 import CacheManager from "../utils/cache/CacheManager";
+import MapUtils from "../utils/MapUtils";
 import detectCppSyntax from "./logic/detectCppSyntax";
 import AutoConstUpdater from "./logic/symbols/AutoConstUpdater";
 import TransitiveEnumCollector from "./logic/symbols/TransitiveEnumCollector";
@@ -1098,10 +1099,7 @@ class Transpiler {
 
       // Get pass-by-value params (snapshot before next file clears it)
       const passByValue = this.codeGenerator.getPassByValueParams();
-      const passByValueCopy = new Map<string, Set<string>>();
-      for (const [funcName, params] of passByValue) {
-        passByValueCopy.set(funcName, new Set(params));
-      }
+      const passByValueCopy = MapUtils.deepCopyStringSetMap(passByValue);
 
       // Issue #634: Symbol collection moved to before code generation (line ~905)
       // This consolidates the timing with run() path - both now collect symbols before generate()

--- a/src/utils/MapUtils.ts
+++ b/src/utils/MapUtils.ts
@@ -1,0 +1,25 @@
+/**
+ * Map utilities for deep copying and manipulation.
+ * Pure functions for working with Map collections.
+ */
+class MapUtils {
+  /**
+   * Deep copy a Map<string, Set<string>>.
+   * Creates new Map and new Set instances to ensure complete isolation.
+   * Accepts ReadonlyMap/ReadonlySet for flexibility with immutable sources.
+   *
+   * @param source - The source Map to copy (can be readonly)
+   * @returns A new mutable Map with cloned Set values
+   */
+  static deepCopyStringSetMap(
+    source: ReadonlyMap<string, ReadonlySet<string>>,
+  ): Map<string, Set<string>> {
+    const copy = new Map<string, Set<string>>();
+    for (const [key, value] of source) {
+      copy.set(key, new Set(value));
+    }
+    return copy;
+  }
+}
+
+export default MapUtils;

--- a/src/utils/__tests__/MapUtils.test.ts
+++ b/src/utils/__tests__/MapUtils.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from "vitest";
+import MapUtils from "../MapUtils.js";
+
+describe("MapUtils", () => {
+  describe("deepCopyStringSetMap", () => {
+    it("should return empty map for empty input", () => {
+      const source = new Map<string, Set<string>>();
+      const result = MapUtils.deepCopyStringSetMap(source);
+
+      expect(result.size).toBe(0);
+      expect(result).not.toBe(source);
+    });
+
+    it("should deep copy map with single entry", () => {
+      const source = new Map<string, Set<string>>([
+        ["func1", new Set(["param1", "param2"])],
+      ]);
+
+      const result = MapUtils.deepCopyStringSetMap(source);
+
+      expect(result.size).toBe(1);
+      expect(result.get("func1")).toEqual(new Set(["param1", "param2"]));
+    });
+
+    it("should deep copy map with multiple entries", () => {
+      const source = new Map<string, Set<string>>([
+        ["func1", new Set(["a", "b"])],
+        ["func2", new Set(["c"])],
+        ["func3", new Set(["d", "e", "f"])],
+      ]);
+
+      const result = MapUtils.deepCopyStringSetMap(source);
+
+      expect(result.size).toBe(3);
+      expect(result.get("func1")).toEqual(new Set(["a", "b"]));
+      expect(result.get("func2")).toEqual(new Set(["c"]));
+      expect(result.get("func3")).toEqual(new Set(["d", "e", "f"]));
+    });
+
+    it("should create independent Map instance", () => {
+      const source = new Map<string, Set<string>>([
+        ["func1", new Set(["param1"])],
+      ]);
+
+      const result = MapUtils.deepCopyStringSetMap(source);
+
+      // Modify source - should not affect result
+      source.set("func2", new Set(["new"]));
+      source.delete("func1");
+
+      expect(result.size).toBe(1);
+      expect(result.has("func1")).toBe(true);
+      expect(result.has("func2")).toBe(false);
+    });
+
+    it("should create independent Set instances", () => {
+      const originalSet = new Set(["param1", "param2"]);
+      const source = new Map<string, Set<string>>([["func1", originalSet]]);
+
+      const result = MapUtils.deepCopyStringSetMap(source);
+
+      // Modify original Set - should not affect result
+      originalSet.add("param3");
+      originalSet.delete("param1");
+
+      const resultSet = result.get("func1");
+      expect(resultSet).toBeDefined();
+      expect(resultSet!.has("param1")).toBe(true);
+      expect(resultSet!.has("param2")).toBe(true);
+      expect(resultSet!.has("param3")).toBe(false);
+    });
+
+    it("should handle empty Sets in map", () => {
+      const source = new Map<string, Set<string>>([
+        ["func1", new Set()],
+        ["func2", new Set(["a"])],
+      ]);
+
+      const result = MapUtils.deepCopyStringSetMap(source);
+
+      expect(result.get("func1")?.size).toBe(0);
+      expect(result.get("func2")?.size).toBe(1);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Extract inline for-loop to `MapUtils.deepCopyStringSetMap` utility
- Reduces cognitive complexity in `Transpiler.transpileSource()` from 16 to 15 (threshold is 15)
- New utility has 100% test coverage

## Test plan
- [x] Unit tests for MapUtils (6 tests)
- [x] Transpiler tests pass (27 tests)
- [x] All 905 integration tests pass
- [x] Linting passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)