### PR TITLE
docs(claude-md): add guidance on extracting loops for complexity

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,6 +54,8 @@ SonarCloud runs as a required PR check. **PRs cannot merge until the SonarCloud 
 
 **Reducing cognitive complexity:** Extract nested logic into private helper methods with early returns. Keep helpers in the same class when they need many instance dependencies. Name helpers descriptively (e.g., `_resolveIdentifierExpression`, `_resolveUnqualifiedEnumMember`).
 
+**Loops add +1 complexity:** Extract `for`/`while` loops to static utility methods in `src/utils/` when the loop is self-contained (e.g., `MapUtils.deepCopyStringSetMap()`). Use `ReadonlyMap`/`ReadonlySet` in utility signatures for flexibility with immutable sources.
+
 **Before refactoring complexity issues:**
 
 1. **Check ExpressionUtils first** - `src/utils/ExpressionUtils.ts` has expression tree traversal helpers (`extractIdentifier`, `hasFunctionCall`, `extractUnaryExpression`) - don't duplicate this logic


### PR DESCRIPTION
## Summary
- Add guidance that `for`/`while` loops add +1 to cognitive complexity
- Document pattern of extracting to static utility methods in `src/utils/`
- Reference `MapUtils.deepCopyStringSetMap()` as example
- Note about using `ReadonlyMap`/`ReadonlySet` in utility signatures

## Context
Learning from PR #732 where extracting a loop to a utility reduced complexity from 16 → 15.

🤖 Generated with [Claude Code](https://claude.com/claude-code)