### PR TITLE
chore: remove stale antlr_parser gitignore entry

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,9 +15,6 @@ coverage/
 # Test builds
 test-teensy/
 
-# Generated parser files (regenerated from grammar)
-src/antlr_parser/
-
 # Generated C files (transpiler output) - tracked for test snapshots
 # *.c
 

--- a/.jscpd.json
+++ b/.jscpd.json
@@ -3,6 +3,7 @@
   "reporters": ["console"],
   "ignore": [
     "**/node_modules/**",
+    "**/antlr_parser/**",
     "**/parser/grammar/**",
     "**/parser/c/grammar/**",
     "**/parser/cpp/grammar/**",


### PR DESCRIPTION
## Summary
- Remove `src/antlr_parser/` from `.gitignore` (stale entry from old build config)
- Add `**/antlr_parser/**` to `.jscpd.json` as safety net for local directories
- ANTLR output now goes to `src/transpiler/logic/parser/*/grammar/`

## Test plan
- [ ] Run `npm run analyze:duplication` locally (should not report antlr_parser clones)
- [ ] Delete local `src/antlr_parser/` directory if present

🤖 Generated with [Claude Code](https://claude.com/claude-code)