### PR TITLE
Release v0.1.63

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,51 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.63] - 2026-02-10
+
+### Added
+
+- Enforce C-Next array syntax (`u8[10] arr`) and reject C-style declarations (`u8 arr[10]`) for user types including structs, bitmaps, and enums (ADR-058, PR #749)
+- ADR-058 documentation for C-Next array syntax enforcement
+- Unit tests for array syntax validation, CodeGenState, resolvers, and generator registration error paths
+
+### Changed
+
+- Migrate 9 helpers from DI to static CodeGenState pattern: CppModeHelper, StringLengthCounter, MemberChainAnalyzer, FloatBitHelper, AssignmentExpectedTypeResolver, AssignmentClassifier, AssignmentValidator, ArrayInitHelper, StringDeclHelper (PRs #750, #753)
+- Extract CodeGenState for centralized code generation state management
+- Extract ScopeResolver, EnumTypeResolver, SizeofResolver from CodeGenerator
+- Convert TypeResolver to static class (PR #749)
+- Extract shared ArrayDimensionUtils to eliminate duplication
+
+### Fixed
+
+- Resolve struct enum field assignment via global prefix (PR #751)
+- Fix global arrays passed to functions incorrectly using address-of operator (PR #747)
+- Fix array subscript bug in TypeResolver refactoring (PR #749)
+- Resolve 12 SonarCloud issues: complexity, redundant code, negated conditions (PRs #750, #752)
+- Remove duplicate statements and dead code from CodeGenerator
+
+## [0.1.62] - 2026-02-08
+
+### Changed
+
+- Unify transpiler pipeline and eliminate dual code paths (PR #747)
+- Inline CodeGenerator delegator methods for simplified architecture (PRs #744-#747)
+- Consolidate array/member access grammar paths
+- Extract ArrayAccessHelper and CodegenParserUtils utilities
+
+### Fixed
+
+- Inline private const scope members referenced without `this.` prefix
+- Reduce cognitive complexity in `transpileSource` for SonarCloud compliance
+- Remove orphaned JSDoc and unused methods
+
+### Added
+
+- 35+ CodeGenerator unit tests for improved coverage
+- Tests for TypeGenerationHelper array and template types
+- Mocked tests for parseCHeader edge cases
+
 ## [0.1.61] - 2026-02-07
 
 ### Changed
@@ -868,6 +913,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [0.1.35]: https://github.com/jlaustill/c-next/compare/v0.1.34...v0.1.35
 [0.1.34]: https://github.com/jlaustill/c-next/compare/v0.1.33...v0.1.34
 [0.1.33]: https://github.com/jlaustill/c-next/compare/v0.1.32...v0.1.33
+[0.1.63]: https://github.com/jlaustill/c-next/compare/v0.1.62...v0.1.63
+[0.1.62]: https://github.com/jlaustill/c-next/compare/v0.1.61...v0.1.62
 [0.1.32]: https://github.com/jlaustill/c-next/compare/v0.1.31...v0.1.32
 [0.1.31]: https://github.com/jlaustill/c-next/compare/v0.1.30...v0.1.31
 [0.1.30]: https://github.com/jlaustill/c-next/compare/v0.1.29...v0.1.30

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "c-next",
-  "version": "0.1.62",
+  "version": "0.1.63",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "c-next",
-      "version": "0.1.62",
+      "version": "0.1.63",
       "license": "MIT",
       "dependencies": {
         "@n1ru4l/toposort": "^0.0.1",
@@ -276,6 +276,7 @@
       "integrity": "sha512-lf6d+BdMkJIFCxx2FpajLpqVGGyaGUNFU6jhEM6QUPeGuoA5et2kJXrL0NSY2uWLOVyYYc/FPjzlbe8trA9tBQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20"
       }
@@ -357,7 +358,8 @@
       "resolved": "https://registry.npmjs.org/@cspell/dict-css/-/dict-css-4.0.19.tgz",
       "integrity": "sha512-VYHtPnZt/Zd/ATbW3rtexWpBnHUohUrQOHff/2JBhsVgxOrksAxJnLAO43Q1ayLJBJUUwNVo+RU0sx0aaysZfg==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@cspell/dict-dart": {
       "version": "2.3.2",
@@ -497,14 +499,16 @@
       "resolved": "https://registry.npmjs.org/@cspell/dict-html/-/dict-html-4.0.14.tgz",
       "integrity": "sha512-2bf7n+kS92g+cMKV0wr9o/Oq9n8JzU7CcrB96gIh2GHgnF+0xDOqO2W/1KeFAqOfqosoOVE48t+4dnEMkkoJ2Q==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@cspell/dict-html-symbol-entities": {
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/@cspell/dict-html-symbol-entities/-/dict-html-symbol-entities-4.0.5.tgz",
       "integrity": "sha512-429alTD4cE0FIwpMucvSN35Ld87HCyuM8mF731KU5Rm4Je2SG6hmVx7nkBsLyrmH3sQukTcr1GaiZsiEg8svPA==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@cspell/dict-java": {
       "version": "5.0.12",
@@ -702,7 +706,8 @@
       "resolved": "https://registry.npmjs.org/@cspell/dict-typescript/-/dict-typescript-3.2.3.tgz",
       "integrity": "sha512-zXh1wYsNljQZfWWdSPYwQhpwiuW0KPW1dSd8idjMRvSD0aSvWWHoWlrMsmZeRl4qM4QCEAjua8+cjflm41cQBg==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@cspell/dict-vue": {
       "version": "3.0.5",
@@ -2241,6 +2246,7 @@
       "integrity": "sha512-CPrnr8voK8vC6eEtyRzvMpgp3VyVRhgclonE7qYi6P9sXwYb59ucfrnmFBTaP0yUi8Gk4yZg/LlTJULGxvTNsg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -2617,6 +2623,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4599,6 +4606,7 @@
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-5.6.0.tgz",
       "integrity": "sha512-CYDD3SOtsHtyXeEORYRx2qBtpDJFjRTGXUtmNEMGyzYOKj1TE3tycdlho7kA1Ufx9OYWZzg52QFBGALTirzDSw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@keyv/serialize": "^1.1.1"
       }
@@ -5469,6 +5477,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -6449,6 +6458,7 @@
       "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
       "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "~0.27.0",
         "get-tsconfig": "^4.7.5"
@@ -6468,6 +6478,7 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -6496,6 +6507,7 @@
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -6571,6 +6583,7 @@
       "integrity": "sha512-hOQuK7h0FGKgBAas7v0mSAsnvrIgAvWmRFjmzpJ7SwFHH3g1k2u37JtYwOwmEKhK6ZO3v9ggDBBm0La1LCK4uQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.0.18",
         "@vitest/mocker": "4.0.18",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "c-next",
-  "version": "0.1.62",
+  "version": "0.1.63",
   "description": "A safer C for embedded systems development. Transpiles to clean, readable C.",
   "packageManager": "npm@11.9.0",
   "type": "module",


### PR DESCRIPTION
## Summary

- Bump version to 0.1.63
- Add CHANGELOG entries for v0.1.62 (retroactive) and v0.1.63
- Add comparison links for both versions

### v0.1.63 highlights

- **C-Next array syntax enforcement**: `u8[10] arr` required, C-style `u8 arr[10]` rejected for user types (ADR-058)
- **CodeGenState migration**: 9 helpers migrated from DI to static CodeGenState pattern
- **Extracted resolvers**: ScopeResolver, EnumTypeResolver, SizeofResolver, TypeResolver (now static)
- **Bug fixes**: struct enum field assignment via global prefix, global array address-of operator, array subscript bug
- **12 SonarCloud issues resolved**

## Test plan

- [x] `npm test` — 910/910 integration tests pass
- [x] `npm run unit` — 4826/4826 unit tests pass
- [x] `npm run typecheck` — clean
- [x] Pre-push quality checks all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)