### PR TITLE
Release v0.1.64

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.64] - 2026-02-10
+
+### Fixed
+
+- Fix C-Next style array types (`CppClass[4] items`) not detected as arrays in C++ mode codegen, causing incorrect scalar reference generation (PR #755)
+- Fix constructor detection false-positives on C function prototypes in test framework — `hasCppFeatures()` now excludes C return types and typed arguments (PR #755)
+- Unify `_getArrayZeroInitializer` detection logic for C-style and C-Next style arrays (PR #755)
+
+### Changed
+
+- Reuse transpiler's `detectCppSyntax()` in test framework for robust C++ header detection (class, namespace, template, access specifiers) instead of narrow typed-enum regex (PR #755)
+- Extract shared `C_KEYWORDS` and `C_TYPES` constants for constructor detection regex patterns (PR #755)
+
 ## [0.1.63] - 2026-02-10
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "c-next",
-  "version": "0.1.63",
+  "version": "0.1.64",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "c-next",
-      "version": "0.1.63",
+      "version": "0.1.64",
       "license": "MIT",
       "dependencies": {
         "@n1ru4l/toposort": "^0.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "c-next",
-  "version": "0.1.63",
+  "version": "0.1.64",
   "description": "A safer C for embedded systems development. Transpiles to clean, readable C.",
   "packageManager": "npm@11.9.0",
   "type": "module",


### PR DESCRIPTION
## Summary

- Patch release with C++ mode codegen fixes and test framework improvements from PR #755

### Fixed
- C-Next style array types (`CppClass[4] items`) not detected as arrays in C++ mode
- Constructor detection false-positives on C function prototypes in test framework
- Asymmetric `_getArrayZeroInitializer` detection logic unified

### Changed
- Reuse transpiler's `detectCppSyntax()` in test framework for robust C++ header detection
- Extract shared regex constants for constructor detection patterns

## Test plan
- [x] 912/912 integration tests pass
- [x] 4,849/4,849 unit tests pass
- [x] All pre-push quality checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)