### PR TITLE
chore: release v0.1.65

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "c-next",
-  "version": "0.1.64",
+  "version": "0.1.65",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "c-next",
-      "version": "0.1.64",
+      "version": "0.1.65",
       "license": "MIT",
       "dependencies": {
         "@n1ru4l/toposort": "^0.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "c-next",
-  "version": "0.1.64",
+  "version": "0.1.65",
   "description": "A safer C for embedded systems development. Transpiles to clean, readable C.",
   "packageManager": "npm@11.9.0",
   "type": "module",


### PR DESCRIPTION
## Summary
Release v0.1.65

## Changes since v0.1.64
- **Memory safety**: Reject unbounded array parameters - all dimensions must have explicit sizes
- Extended grammar to support multi-dimensional array types in type position (u8[4][4], string<32>[5])
- Reject C-style array parameters with helpful error suggesting C-Next style syntax
- Fixed string array parameter `.length` to correctly generate `strlen(arr[index])`

🤖 Generated with [Claude Code](https://claude.com/claude-code)