### PR TITLE
Release v0.1.66

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,44 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.66] - 2026-02-11
+
+### Added
+
+- Dual-mode test infrastructure: tests now run in both C and C++ modes by default (PR #765)
+- Test mode markers: `// test-c-only`, `// test-cpp-only`, `// test-no-exec`, `// test-transpile-only`
+- C++ snapshot generation for helper `.cnx` files via `#include` directive traversal (PR #766)
+- ADR-058 explicit `.length` properties for arrays on structs (PR #761)
+- Unified variable declaration formatting for consistent output (PR #763)
+- Volta pinning for Node 24.13.1 and npm 11.8.0 in CI (PR #759)
+- 74+ new unit tests for CodeGenerator, ParameterInputAdapter, and ADR-058 edge cases
+
+### Changed
+
+- Test framework auto-detects C++ requirements from headers (class, namespace, template)
+- `generate-cpp-snapshots.ts` script now processes helper files recursively
+- Unified parameter generation pipeline with ParameterInputAdapter
+
+### Fixed
+
+- Fix enum array dimensions in generated headers (PR #761)
+- Address ADR-058 review feedback for property handlers (PR #764)
+- Reduce cognitive complexity in `_isArrayAccessStringExpression` (PR #765)
+- Remove stale `.expected.c` files from cpp-only tests
+
+## [0.1.65] - 2026-02-10
+
+### Added
+
+- Reject unbounded array parameters (`u8[] arr`) for memory safety (PR #757)
+- Require C-Next style array parameters (`u8[10] arr` not `u8 arr[10]`)
+
+### Fixed
+
+- Fix string array `.length` property returning wrong value
+- Reduce cognitive complexity for SonarCloud compliance (S3776)
+- Use nullish coalescing for simpler code (S6606)
+
 ## [0.1.64] - 2026-02-10
 
 ### Fixed
@@ -874,7 +912,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - 38 legacy ESLint errors (non-blocking, tracked for future cleanup)
 
-[Unreleased]: https://github.com/jlaustill/c-next/compare/v0.1.61...HEAD
+[Unreleased]: https://github.com/jlaustill/c-next/compare/v0.1.66...HEAD
+[0.1.66]: https://github.com/jlaustill/c-next/compare/v0.1.65...v0.1.66
+[0.1.65]: https://github.com/jlaustill/c-next/compare/v0.1.64...v0.1.65
+[0.1.64]: https://github.com/jlaustill/c-next/compare/v0.1.63...v0.1.64
+[0.1.63]: https://github.com/jlaustill/c-next/compare/v0.1.62...v0.1.63
+[0.1.62]: https://github.com/jlaustill/c-next/compare/v0.1.61...v0.1.62
 [0.1.61]: https://github.com/jlaustill/c-next/compare/v0.1.60...v0.1.61
 [0.1.60]: https://github.com/jlaustill/c-next/compare/v0.1.59...v0.1.60
 [0.1.59]: https://github.com/jlaustill/c-next/compare/v0.1.58...v0.1.59

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "c-next",
-  "version": "0.1.65",
+  "version": "0.1.66",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "c-next",
-      "version": "0.1.65",
+      "version": "0.1.66",
       "license": "MIT",
       "dependencies": {
         "@n1ru4l/toposort": "^0.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "c-next",
-  "version": "0.1.65",
+  "version": "0.1.66",
   "description": "A safer C for embedded systems development. Transpiles to clean, readable C.",
   "packageManager": "npm@11.9.0",
   "type": "module",


### PR DESCRIPTION
## Release v0.1.66

### Highlights

- **Dual-mode test infrastructure**: Tests now run in both C and C++ modes by default (PR #765)
- **C++ snapshot generation for helper files**: `generate-cpp-snapshots.ts` now recursively processes helper `.cnx` files via `#include` traversal (PR #766)
- **ADR-058 explicit length properties**: Arrays on structs now have `.length` properties (PR #761)
- **Unified variable declaration formatting**: Consistent output generation (PR #763)

### Changes

#### Added
- Test mode markers: `// test-c-only`, `// test-cpp-only`, `// test-no-exec`, `// test-transpile-only`
- Volta pinning for Node 24.13.1 and npm 11.8.0 in CI (PR #759)
- 74+ new unit tests for CodeGenerator, ParameterInputAdapter, and ADR-058 edge cases

#### Changed
- Test framework auto-detects C++ requirements from headers
- Unified parameter generation pipeline with ParameterInputAdapter

#### Fixed
- Fix enum array dimensions in generated headers
- Address ADR-058 review feedback for property handlers
- Reduce cognitive complexity in `_isArrayAccessStringExpression`
- Remove stale `.expected.c` files from cpp-only tests

### Checklist

- [x] CHANGELOG.md updated with v0.1.65 and v0.1.66 entries
- [x] Version bumped in package.json (0.1.65 → 0.1.66)
- [x] All tests pass (`npm run test:all`)
- [x] TypeScript type check passes (`npm run typecheck`)

---

After merging, tag and push:
```bash
git checkout main && git pull
git tag v0.1.66
git push origin v0.1.66
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)