### PR TITLE
Release v0.1.67

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.67] - 2026-02-11
+
+### Added
+
+- Qualified enum access in array dimensions: `u8[EColor.COUNT]` generates `u8[EColor_COUNT]` (PR #772)
+- Compile error `error[E0424]` for bare enum members in non-enum contexts with helpful suggestion (Issue #770, PR #772)
+- 3 new error tests for bare enum members in comparisons, function args, and array dimensions
+
+### Changed
+
+- Bare enum members now only resolve where `expectedType` is set (assignments, returns, struct inits, switch cases)
+- Updated existing tests to use qualified enum access in comparisons and function arguments
+
+### Removed
+
+- `SymbolTable.resolveExternalEnumArrayDimensions()` and Stage 3c pipeline — replaced by qualified access
+- `TSymbolAdapter.buildEnumMemberLookup()` — auto-resolution no longer needed
+
+### Fixed
+
+- `CodeGenState` import path after architecture refactoring (PR #768)
+- Cross-file enum array dimensions in generated headers (PR #769)
+
 ## [0.1.66] - 2026-02-11
 
 ### Added
@@ -981,6 +1004,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [0.1.25]: https://github.com/jlaustill/c-next/compare/v0.1.24...v0.1.25
 [0.1.24]: https://github.com/jlaustill/c-next/compare/v0.1.23...v0.1.24
 [0.1.23]: https://github.com/jlaustill/c-next/compare/v0.1.22...v0.1.23
+[0.1.67]: https://github.com/jlaustill/c-next/compare/v0.1.66...v0.1.67
 [0.1.22]: https://github.com/jlaustill/c-next/compare/v0.1.21...v0.1.22
 [0.1.21]: https://github.com/jlaustill/c-next/compare/v0.1.20...v0.1.21
 [0.1.20]: https://github.com/jlaustill/c-next/compare/v0.1.19...v0.1.20

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "c-next",
-  "version": "0.1.66",
+  "version": "0.1.67",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "c-next",
-      "version": "0.1.66",
+      "version": "0.1.67",
       "license": "MIT",
       "dependencies": {
         "@n1ru4l/toposort": "^0.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "c-next",
-  "version": "0.1.66",
+  "version": "0.1.67",
   "description": "A safer C for embedded systems development. Transpiles to clean, readable C.",
   "packageManager": "npm@11.9.0",
   "type": "module",


### PR DESCRIPTION
## Summary
Release preparation for v0.1.67.

### Highlights
- **Bare enum members in non-enum contexts now produce a compile error** with a helpful suggestion to use qualified access (e.g., `EColor.COUNT` instead of `COUNT`)
- **Qualified enum access in array dimensions**: `u8[EColor.COUNT]` correctly generates `u8[EColor_COUNT]` in both code and headers
- Removed auto-resolution infrastructure (Stage 3c) that silently resolved bare enum members

### Changes since v0.1.66
- PR #768: Fix CodeGenState import path after architecture refactoring
- PR #769: Fix cross-file enum array dimensions in generated headers
- PR #772: Bare enum members in non-enum contexts produce compile error (Issue #770)

🤖 Generated with [Claude Code](https://claude.com/claude-code)