### PR TITLE
Release v0.1.68

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.68] - 2026-02-12
+
+### Fixed
+
+- Allow enum access inside scopes without `global.` prefix when unambiguous (Issue #774, PR #775)
+- Improved error message for enum shadowing conflicts suggests using `global.EnumName.Member`
+
+### Changed
+
+- Consolidate logic layer state into `CodeGenState` — external struct fields now built once per run (PR #776)
+- Remove `AnalyzerContextBuilder` class — logic moved to `CodeGenState.buildExternalStructFields()`
+- Simplify `runAnalyzers()` API — reads state from `CodeGenState` by default
+
 ## [0.1.67] - 2026-02-11
 
 ### Added
@@ -1004,6 +1017,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [0.1.25]: https://github.com/jlaustill/c-next/compare/v0.1.24...v0.1.25
 [0.1.24]: https://github.com/jlaustill/c-next/compare/v0.1.23...v0.1.24
 [0.1.23]: https://github.com/jlaustill/c-next/compare/v0.1.22...v0.1.23
+[0.1.68]: https://github.com/jlaustill/c-next/compare/v0.1.67...v0.1.68
 [0.1.67]: https://github.com/jlaustill/c-next/compare/v0.1.66...v0.1.67
 [0.1.22]: https://github.com/jlaustill/c-next/compare/v0.1.21...v0.1.22
 [0.1.21]: https://github.com/jlaustill/c-next/compare/v0.1.20...v0.1.21

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "c-next",
-  "version": "0.1.67",
+  "version": "0.1.68",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "c-next",
-      "version": "0.1.67",
+      "version": "0.1.68",
       "license": "MIT",
       "dependencies": {
         "@n1ru4l/toposort": "^0.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "c-next",
-  "version": "0.1.67",
+  "version": "0.1.68",
   "description": "A safer C for embedded systems development. Transpiles to clean, readable C.",
   "packageManager": "npm@11.9.0",
   "type": "module",


### PR DESCRIPTION
## Summary

Release preparation for v0.1.68.

## Changes Since v0.1.67

### Fixed

- Allow enum access inside scopes without `global.` prefix when unambiguous (Issue #774, PR #775)
- Improved error message for enum shadowing conflicts suggests using `global.EnumName.Member`

### Changed

- Consolidate logic layer state into `CodeGenState` — external struct fields now built once per run (PR #776)
- Remove `AnalyzerContextBuilder` class — logic moved to `CodeGenState.buildExternalStructFields()`
- Simplify `runAnalyzers()` API — reads state from `CodeGenState` by default

## Test plan

- [x] All 940 integration tests pass
- [x] All 5055 unit tests pass
- [x] TypeScript compilation passes
- [x] All quality checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)