### PR TITLE
Release v0.1.69

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.69] - 2026-02-12
+
+### Fixed
+
+- Platform-portable IRQ wrappers for critical sections - fixes Teensy 4.0 compilation (Issue #778, PR #782)
+- Array member access without `this.` now resolves to scope prefix (Issue #779, PR #780)
+
+### Changed
+
+- Remove dead `GeneratorContext` class and compute unmodified params on-demand (PR #781)
+- Make `CodeGenState.scopeMembers` private with accessor methods for encapsulation
+
 ## [0.1.68] - 2026-02-12
 
 ### Fixed
@@ -1017,6 +1029,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [0.1.25]: https://github.com/jlaustill/c-next/compare/v0.1.24...v0.1.25
 [0.1.24]: https://github.com/jlaustill/c-next/compare/v0.1.23...v0.1.24
 [0.1.23]: https://github.com/jlaustill/c-next/compare/v0.1.22...v0.1.23
+[0.1.69]: https://github.com/jlaustill/c-next/compare/v0.1.68...v0.1.69
 [0.1.68]: https://github.com/jlaustill/c-next/compare/v0.1.67...v0.1.68
 [0.1.67]: https://github.com/jlaustill/c-next/compare/v0.1.66...v0.1.67
 [0.1.22]: https://github.com/jlaustill/c-next/compare/v0.1.21...v0.1.22

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "c-next",
-  "version": "0.1.68",
+  "version": "0.1.69",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "c-next",
-      "version": "0.1.68",
+      "version": "0.1.69",
       "license": "MIT",
       "dependencies": {
         "@n1ru4l/toposort": "^0.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "c-next",
-  "version": "0.1.68",
+  "version": "0.1.69",
   "description": "A safer C for embedded systems development. Transpiles to clean, readable C.",
   "packageManager": "npm@11.9.0",
   "type": "module",


### PR DESCRIPTION
## Release v0.1.69

### Fixed

- Platform-portable IRQ wrappers for critical sections - fixes Teensy 4.0 compilation (Issue #778, PR #782)
- Array member access without `this.` now resolves to scope prefix (Issue #779, PR #780)

### Changed

- Remove dead `GeneratorContext` class and compute unmodified params on-demand (PR #781)
- Make `CodeGenState.scopeMembers` private with accessor methods for encapsulation

---

**Checklist:**
- [x] Version bumped in `package.json`
- [x] `package-lock.json` updated
- [x] CHANGELOG.md updated with release notes
- [x] All tests passing (943 integration + 5055 unit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)