### PR TITLE
refactor(#794): extract ArgumentGenerator from CodeGenerator

### DIFF
--- a/src/transpiler/output/codegen/helpers/ArgumentGenerator.ts
+++ b/src/transpiler/output/codegen/helpers/ArgumentGenerator.ts
@@ -1,0 +1,236 @@
+/**
+ * ArgumentGenerator - Generates function arguments with proper ADR-006 semantics
+ *
+ * Issue #794: Extracted from CodeGenerator to reduce file size.
+ * Uses CodeGenState for state access and callbacks for CodeGenerator methods.
+ *
+ * Handles argument generation patterns:
+ * - Local variables get & (address-of) in C mode
+ * - Member access (cursor.x) gets & (address-of)
+ * - Array access (arr[i]) gets & (address-of)
+ * - Parameters are passed as-is (already pointers)
+ * - Arrays are passed as-is (naturally decay to pointers)
+ * - Literals use compound literals for pointer params: &(type){value}
+ * - Complex expressions are passed as-is
+ */
+
+import * as Parser from "../../../logic/parser/grammar/CNextParser.js";
+import CodeGenState from "../../../state/CodeGenState.js";
+import CppModeHelper from "./CppModeHelper.js";
+import TYPE_MAP from "../types/TYPE_MAP.js";
+import IArgumentGeneratorCallbacks from "./types/IArgumentGeneratorCallbacks.js";
+
+/**
+ * Generates function arguments with proper pass-by-reference semantics.
+ */
+class ArgumentGenerator {
+  /**
+   * Handle simple identifier argument (parameter, local array, scope member, or variable).
+   * This is a pure function that only reads from CodeGenState.
+   */
+  static handleIdentifierArg(id: string): string {
+    // Parameters are already pointers
+    if (CodeGenState.currentParameters.get(id)) {
+      return id;
+    }
+
+    // Local arrays decay to pointers
+    if (CodeGenState.localArrays.has(id)) {
+      return id;
+    }
+
+    // Global arrays also decay to pointers (check typeRegistry)
+    // But NOT strings - strings need & (they're char arrays but passed by reference)
+    const typeInfo = CodeGenState.getVariableTypeInfo(id);
+    if (typeInfo?.isArray && !typeInfo.isString) {
+      return id;
+    }
+
+    // Scope member - may need prefixing
+    if (CodeGenState.currentScope) {
+      const members = CodeGenState.getScopeMembers(CodeGenState.currentScope);
+      if (members?.has(id)) {
+        const scopedName = `${CodeGenState.currentScope}_${id}`;
+        return CppModeHelper.maybeAddressOf(scopedName);
+      }
+    }
+
+    // Local variable - add & (except in C++ mode)
+    return CppModeHelper.maybeAddressOf(id);
+  }
+
+  /**
+   * Handle rvalue argument (literals or complex expressions).
+   */
+  static handleRvalueArg(
+    ctx: Parser.ExpressionContext,
+    targetParamBaseType: string | undefined,
+    callbacks: IArgumentGeneratorCallbacks,
+  ): string {
+    if (!targetParamBaseType) {
+      return callbacks.generateExpression(ctx);
+    }
+
+    const cType = TYPE_MAP[targetParamBaseType];
+    if (!cType || cType === "void") {
+      return callbacks.generateExpression(ctx);
+    }
+
+    const value = callbacks.generateExpression(ctx);
+
+    // C++ mode: rvalues can bind to const T&
+    if (CodeGenState.cppMode) {
+      return value;
+    }
+
+    // C mode: Use compound literal syntax
+    return `&(${cType}){${value}}`;
+  }
+
+  /**
+   * Create temp variable for C++ member conversion.
+   */
+  static createCppMemberConversionTemp(
+    ctx: Parser.ExpressionContext,
+    targetParamBaseType: string,
+    callbacks: IArgumentGeneratorCallbacks,
+  ): string {
+    const cType = TYPE_MAP[targetParamBaseType] || "uint8_t";
+    const value = callbacks.generateExpression(ctx);
+    const tempName = `_cnx_tmp_${CodeGenState.tempVarCounter++}`;
+    const castExpr = CppModeHelper.cast(cType, value);
+    CodeGenState.pendingTempDeclarations.push(
+      `${cType} ${tempName} = ${castExpr};`,
+    );
+    return CppModeHelper.maybeAddressOf(tempName);
+  }
+
+  /**
+   * Maybe cast string subscript access for integer pointer parameters.
+   */
+  static maybeCastStringSubscript(
+    ctx: Parser.ExpressionContext,
+    expr: string,
+    targetParamBaseType: string | undefined,
+    callbacks: IArgumentGeneratorCallbacks,
+  ): string {
+    if (!targetParamBaseType || !callbacks.isStringSubscriptAccess(ctx)) {
+      return expr;
+    }
+
+    const cType = TYPE_MAP[targetParamBaseType];
+    if (cType && !["float", "double", "bool", "void"].includes(cType)) {
+      return CppModeHelper.reinterpretCast(`${cType}*`, expr);
+    }
+
+    return expr;
+  }
+
+  /**
+   * Handle member access argument - may need special handling for arrays or C++ conversions.
+   * Returns null if default lvalue handling should be used.
+   */
+  static handleMemberAccessArg(
+    ctx: Parser.ExpressionContext,
+    targetParamBaseType: string | undefined,
+    callbacks: IArgumentGeneratorCallbacks,
+  ): string | null {
+    const arrayStatus = callbacks.getMemberAccessArrayStatus(ctx);
+
+    // Array member - no address-of needed
+    if (arrayStatus === "array") {
+      return callbacks.generateExpression(ctx);
+    }
+
+    // C++ mode may need temp variable for type conversion
+    if (
+      arrayStatus === "not-array" &&
+      targetParamBaseType &&
+      callbacks.needsCppMemberConversion(ctx, targetParamBaseType)
+    ) {
+      return ArgumentGenerator.createCppMemberConversionTemp(
+        ctx,
+        targetParamBaseType,
+        callbacks,
+      );
+    }
+
+    return null; // Fall through to default lvalue handling
+  }
+
+  /**
+   * Handle lvalue argument (member access or array access).
+   */
+  static handleLvalueArg(
+    ctx: Parser.ExpressionContext,
+    lvalueType: "member" | "array",
+    targetParamBaseType: string | undefined,
+    callbacks: IArgumentGeneratorCallbacks,
+  ): string {
+    // Member access to array field - arrays decay to pointers
+    if (lvalueType === "member") {
+      const memberResult = ArgumentGenerator.handleMemberAccessArg(
+        ctx,
+        targetParamBaseType,
+        callbacks,
+      );
+      if (memberResult) return memberResult;
+    }
+
+    // Generate expression with address-of
+    const generatedExpr = callbacks.generateExpression(ctx);
+    const expr = CppModeHelper.maybeAddressOf(generatedExpr);
+
+    // String subscript access may need cast
+    if (lvalueType === "array") {
+      return ArgumentGenerator.maybeCastStringSubscript(
+        ctx,
+        expr,
+        targetParamBaseType,
+        callbacks,
+      );
+    }
+
+    return expr;
+  }
+
+  /**
+   * Main entry point: Generate a function argument with proper ADR-006 semantics.
+   *
+   * @param ctx - The expression context
+   * @param simpleId - The simple identifier if known (optimization to avoid re-parsing)
+   * @param targetParamBaseType - The target parameter's base type
+   * @param callbacks - Callbacks to CodeGenerator methods
+   */
+  static generateArg(
+    ctx: Parser.ExpressionContext,
+    simpleId: string | null,
+    targetParamBaseType: string | undefined,
+    callbacks: IArgumentGeneratorCallbacks,
+  ): string {
+    // Handle simple identifiers
+    if (simpleId) {
+      return ArgumentGenerator.handleIdentifierArg(simpleId);
+    }
+
+    // Check if expression is an lvalue
+    const lvalueType = callbacks.getLvalueType(ctx);
+    if (lvalueType) {
+      return ArgumentGenerator.handleLvalueArg(
+        ctx,
+        lvalueType,
+        targetParamBaseType,
+        callbacks,
+      );
+    }
+
+    // Handle rvalue (literals or complex expressions)
+    return ArgumentGenerator.handleRvalueArg(
+      ctx,
+      targetParamBaseType,
+      callbacks,
+    );
+  }
+}
+
+export default ArgumentGenerator;

--- a/src/transpiler/output/codegen/helpers/__tests__/ArgumentGenerator.test.ts
+++ b/src/transpiler/output/codegen/helpers/__tests__/ArgumentGenerator.test.ts
@@ -1,0 +1,521 @@
+/**
+ * Unit tests for ArgumentGenerator
+ * Issue #794: Extract Argument Generator from CodeGenerator
+ */
+
+import { describe, it, expect, beforeEach } from "vitest";
+import ArgumentGenerator from "../ArgumentGenerator";
+import CodeGenState from "../../../../state/CodeGenState";
+import IArgumentGeneratorCallbacks from "../types/IArgumentGeneratorCallbacks";
+
+describe("ArgumentGenerator", () => {
+  // Mock callbacks that return predictable values
+  const createMockCallbacks = (
+    overrides: Partial<IArgumentGeneratorCallbacks> = {},
+  ): IArgumentGeneratorCallbacks => ({
+    getLvalueType: () => null,
+    getMemberAccessArrayStatus: () => "not-array",
+    needsCppMemberConversion: () => false,
+    isStringSubscriptAccess: () => false,
+    generateExpression: (ctx) => ctx.getText(),
+    ...overrides,
+  });
+
+  beforeEach(() => {
+    CodeGenState.reset();
+  });
+
+  describe("handleIdentifierArg", () => {
+    describe("parameters", () => {
+      it("returns parameter name unchanged (already pointers)", () => {
+        CodeGenState.currentParameters.set("cfg", {
+          name: "cfg",
+          baseType: "Config",
+          isArray: false,
+          isStruct: true,
+          isConst: false,
+          isCallback: false,
+          isString: false,
+        });
+
+        const result = ArgumentGenerator.handleIdentifierArg("cfg");
+        expect(result).toBe("cfg");
+      });
+    });
+
+    describe("local arrays", () => {
+      it("returns array name unchanged (decay to pointers)", () => {
+        CodeGenState.localArrays.add("buffer");
+
+        const result = ArgumentGenerator.handleIdentifierArg("buffer");
+        expect(result).toBe("buffer");
+      });
+    });
+
+    describe("global arrays", () => {
+      it("returns global array name unchanged", () => {
+        CodeGenState.setVariableTypeInfo("globalArr", {
+          baseType: "u8",
+          bitWidth: 8,
+          isArray: true,
+          isConst: false,
+        });
+
+        const result = ArgumentGenerator.handleIdentifierArg("globalArr");
+        expect(result).toBe("globalArr");
+      });
+
+      it("adds & for global strings (char arrays passed by reference)", () => {
+        CodeGenState.cppMode = false;
+        CodeGenState.setVariableTypeInfo("name", {
+          baseType: "char",
+          bitWidth: 8,
+          isArray: true,
+          isConst: false,
+          isString: true,
+        });
+
+        const result = ArgumentGenerator.handleIdentifierArg("name");
+        expect(result).toBe("&name");
+      });
+    });
+
+    describe("scope members", () => {
+      it("prefixes scope member and adds & in C mode", () => {
+        CodeGenState.cppMode = false;
+        CodeGenState.currentScope = "LED";
+        CodeGenState.setScopeMembers("LED", new Set(["brightness"]));
+
+        const result = ArgumentGenerator.handleIdentifierArg("brightness");
+        expect(result).toBe("&LED_brightness");
+      });
+
+      it("prefixes scope member without & in C++ mode", () => {
+        CodeGenState.cppMode = true;
+        CodeGenState.currentScope = "LED";
+        CodeGenState.setScopeMembers("LED", new Set(["brightness"]));
+
+        const result = ArgumentGenerator.handleIdentifierArg("brightness");
+        expect(result).toBe("LED_brightness");
+      });
+    });
+
+    describe("local variables", () => {
+      it("adds & for local variable in C mode", () => {
+        CodeGenState.cppMode = false;
+
+        const result = ArgumentGenerator.handleIdentifierArg("value");
+        expect(result).toBe("&value");
+      });
+
+      it("returns local variable unchanged in C++ mode", () => {
+        CodeGenState.cppMode = true;
+
+        const result = ArgumentGenerator.handleIdentifierArg("value");
+        expect(result).toBe("value");
+      });
+    });
+  });
+
+  describe("handleRvalueArg", () => {
+    it("returns expression unchanged when no target type", () => {
+      const callbacks = createMockCallbacks({
+        generateExpression: () => "42",
+      });
+
+      const result = ArgumentGenerator.handleRvalueArg(
+        null as never, // ctx not used in this path
+        undefined,
+        callbacks,
+      );
+      expect(result).toBe("42");
+    });
+
+    it("returns expression unchanged for void target type", () => {
+      const callbacks = createMockCallbacks({
+        generateExpression: () => "doSomething()",
+      });
+
+      const result = ArgumentGenerator.handleRvalueArg(
+        null as never,
+        "void",
+        callbacks,
+      );
+      expect(result).toBe("doSomething()");
+    });
+
+    it("returns expression unchanged in C++ mode (rvalues bind to const T&)", () => {
+      CodeGenState.cppMode = true;
+      const callbacks = createMockCallbacks({
+        generateExpression: () => "42",
+      });
+
+      const result = ArgumentGenerator.handleRvalueArg(
+        null as never,
+        "u8",
+        callbacks,
+      );
+      expect(result).toBe("42");
+    });
+
+    it("wraps in compound literal for C mode", () => {
+      CodeGenState.cppMode = false;
+      const callbacks = createMockCallbacks({
+        generateExpression: () => "42",
+      });
+
+      const result = ArgumentGenerator.handleRvalueArg(
+        null as never,
+        "u8",
+        callbacks,
+      );
+      expect(result).toBe("&(uint8_t){42}");
+    });
+
+    it("uses correct C type for compound literal", () => {
+      CodeGenState.cppMode = false;
+      const callbacks = createMockCallbacks({
+        generateExpression: () => "1000",
+      });
+
+      const result = ArgumentGenerator.handleRvalueArg(
+        null as never,
+        "i32",
+        callbacks,
+      );
+      expect(result).toBe("&(int32_t){1000}");
+    });
+  });
+
+  describe("createCppMemberConversionTemp", () => {
+    it("creates temp variable with static_cast in C++ mode", () => {
+      CodeGenState.cppMode = true;
+      CodeGenState.tempVarCounter = 0;
+      const callbacks = createMockCallbacks({
+        generateExpression: () => "cfg.value",
+      });
+
+      const result = ArgumentGenerator.createCppMemberConversionTemp(
+        null as never,
+        "u8",
+        callbacks,
+      );
+
+      expect(result).toBe("_cnx_tmp_0");
+      expect(CodeGenState.pendingTempDeclarations).toContain(
+        "uint8_t _cnx_tmp_0 = static_cast<uint8_t>(cfg.value);",
+      );
+      expect(CodeGenState.tempVarCounter).toBe(1);
+    });
+
+    it("increments temp counter for multiple temps", () => {
+      CodeGenState.cppMode = true;
+      CodeGenState.tempVarCounter = 5;
+      const callbacks = createMockCallbacks({
+        generateExpression: () => "x",
+      });
+
+      const result = ArgumentGenerator.createCppMemberConversionTemp(
+        null as never,
+        "i16",
+        callbacks,
+      );
+
+      expect(result).toBe("_cnx_tmp_5");
+      expect(CodeGenState.tempVarCounter).toBe(6);
+    });
+  });
+
+  describe("maybeCastStringSubscript", () => {
+    it("returns expr unchanged when no target type", () => {
+      const callbacks = createMockCallbacks({
+        isStringSubscriptAccess: () => true,
+      });
+
+      const result = ArgumentGenerator.maybeCastStringSubscript(
+        null as never,
+        "&buf[0]",
+        undefined,
+        callbacks,
+      );
+      expect(result).toBe("&buf[0]");
+    });
+
+    it("returns expr unchanged when not string subscript", () => {
+      const callbacks = createMockCallbacks({
+        isStringSubscriptAccess: () => false,
+      });
+
+      const result = ArgumentGenerator.maybeCastStringSubscript(
+        null as never,
+        "&arr[0]",
+        "u8",
+        callbacks,
+      );
+      expect(result).toBe("&arr[0]");
+    });
+
+    it("casts string subscript to integer pointer type in C mode", () => {
+      CodeGenState.cppMode = false;
+      const callbacks = createMockCallbacks({
+        isStringSubscriptAccess: () => true,
+      });
+
+      const result = ArgumentGenerator.maybeCastStringSubscript(
+        null as never,
+        "&buf[0]",
+        "u8",
+        callbacks,
+      );
+      expect(result).toBe("(uint8_t*)&buf[0]");
+    });
+
+    it("casts string subscript with reinterpret_cast in C++ mode", () => {
+      CodeGenState.cppMode = true;
+      const callbacks = createMockCallbacks({
+        isStringSubscriptAccess: () => true,
+      });
+
+      const result = ArgumentGenerator.maybeCastStringSubscript(
+        null as never,
+        "&buf[0]",
+        "u8",
+        callbacks,
+      );
+      expect(result).toBe("reinterpret_cast<uint8_t*>(&buf[0])");
+    });
+
+    it("does not cast for float types", () => {
+      CodeGenState.cppMode = false;
+      const callbacks = createMockCallbacks({
+        isStringSubscriptAccess: () => true,
+      });
+
+      const result = ArgumentGenerator.maybeCastStringSubscript(
+        null as never,
+        "&buf[0]",
+        "f32",
+        callbacks,
+      );
+      expect(result).toBe("&buf[0]");
+    });
+
+    it("does not cast for bool type", () => {
+      CodeGenState.cppMode = false;
+      const callbacks = createMockCallbacks({
+        isStringSubscriptAccess: () => true,
+      });
+
+      const result = ArgumentGenerator.maybeCastStringSubscript(
+        null as never,
+        "&buf[0]",
+        "bool",
+        callbacks,
+      );
+      expect(result).toBe("&buf[0]");
+    });
+  });
+
+  describe("handleMemberAccessArg", () => {
+    it("returns expression unchanged for array member (no & needed)", () => {
+      const callbacks = createMockCallbacks({
+        getMemberAccessArrayStatus: () => "array",
+        generateExpression: () => "result.data",
+      });
+
+      const result = ArgumentGenerator.handleMemberAccessArg(
+        null as never,
+        "u8",
+        callbacks,
+      );
+      expect(result).toBe("result.data");
+    });
+
+    it("creates temp for C++ conversion when needed", () => {
+      CodeGenState.cppMode = true;
+      CodeGenState.tempVarCounter = 0;
+      const callbacks = createMockCallbacks({
+        getMemberAccessArrayStatus: () => "not-array",
+        needsCppMemberConversion: () => true,
+        generateExpression: () => "cfg.enabled",
+      });
+
+      const result = ArgumentGenerator.handleMemberAccessArg(
+        null as never,
+        "u8",
+        callbacks,
+      );
+
+      expect(result).toBe("_cnx_tmp_0");
+      expect(CodeGenState.pendingTempDeclarations).toHaveLength(1);
+    });
+
+    it("returns null for default lvalue handling", () => {
+      const callbacks = createMockCallbacks({
+        getMemberAccessArrayStatus: () => "not-array",
+        needsCppMemberConversion: () => false,
+      });
+
+      const result = ArgumentGenerator.handleMemberAccessArg(
+        null as never,
+        "u8",
+        callbacks,
+      );
+      expect(result).toBeNull();
+    });
+
+    it("returns null when array status is unknown", () => {
+      const callbacks = createMockCallbacks({
+        getMemberAccessArrayStatus: () => "unknown",
+        needsCppMemberConversion: () => false,
+      });
+
+      const result = ArgumentGenerator.handleMemberAccessArg(
+        null as never,
+        "u8",
+        callbacks,
+      );
+      expect(result).toBeNull();
+    });
+  });
+
+  describe("handleLvalueArg", () => {
+    it("delegates to handleMemberAccessArg for member access", () => {
+      const callbacks = createMockCallbacks({
+        getMemberAccessArrayStatus: () => "array",
+        generateExpression: () => "result.buffer",
+      });
+
+      const result = ArgumentGenerator.handleLvalueArg(
+        null as never,
+        "member",
+        "u8",
+        callbacks,
+      );
+      expect(result).toBe("result.buffer");
+    });
+
+    it("generates expression with & for member when not array", () => {
+      CodeGenState.cppMode = false;
+      const callbacks = createMockCallbacks({
+        getMemberAccessArrayStatus: () => "not-array",
+        needsCppMemberConversion: () => false,
+        generateExpression: () => "obj.field",
+      });
+
+      const result = ArgumentGenerator.handleLvalueArg(
+        null as never,
+        "member",
+        "u8",
+        callbacks,
+      );
+      expect(result).toBe("&obj.field");
+    });
+
+    it("handles array access with & and string subscript cast", () => {
+      CodeGenState.cppMode = false;
+      const callbacks = createMockCallbacks({
+        generateExpression: () => "buf[0]",
+        isStringSubscriptAccess: () => true,
+      });
+
+      const result = ArgumentGenerator.handleLvalueArg(
+        null as never,
+        "array",
+        "u8",
+        callbacks,
+      );
+      expect(result).toBe("(uint8_t*)&buf[0]");
+    });
+
+    it("returns expression with & for array without string cast", () => {
+      CodeGenState.cppMode = false;
+      const callbacks = createMockCallbacks({
+        generateExpression: () => "arr[i]",
+        isStringSubscriptAccess: () => false,
+      });
+
+      const result = ArgumentGenerator.handleLvalueArg(
+        null as never,
+        "array",
+        "u8",
+        callbacks,
+      );
+      expect(result).toBe("&arr[i]");
+    });
+  });
+
+  describe("generateArg (main dispatcher)", () => {
+    it("handles simple identifier", () => {
+      CodeGenState.cppMode = false;
+      const callbacks = createMockCallbacks({
+        getLvalueType: () => null,
+      });
+
+      const result = ArgumentGenerator.generateArg(
+        null as never,
+        "value",
+        "u8",
+        callbacks,
+      );
+      expect(result).toBe("&value");
+    });
+
+    it("handles parameter identifier", () => {
+      CodeGenState.currentParameters.set("cfg", {
+        name: "cfg",
+        baseType: "Config",
+        isArray: false,
+        isStruct: true,
+        isConst: false,
+        isCallback: false,
+        isString: false,
+      });
+      const callbacks = createMockCallbacks({
+        getLvalueType: () => null,
+      });
+
+      const result = ArgumentGenerator.generateArg(
+        null as never,
+        "cfg",
+        "Config",
+        callbacks,
+      );
+      expect(result).toBe("cfg");
+    });
+
+    it("handles lvalue expressions", () => {
+      CodeGenState.cppMode = false;
+      const callbacks = createMockCallbacks({
+        getLvalueType: () => "member",
+        getMemberAccessArrayStatus: () => "not-array",
+        needsCppMemberConversion: () => false,
+        generateExpression: () => "obj.field",
+      });
+
+      const result = ArgumentGenerator.generateArg(
+        null as never,
+        null, // no simple identifier
+        "u8",
+        callbacks,
+      );
+      expect(result).toBe("&obj.field");
+    });
+
+    it("handles rvalue expressions", () => {
+      CodeGenState.cppMode = false;
+      const callbacks = createMockCallbacks({
+        getLvalueType: () => null,
+        generateExpression: () => "42",
+      });
+
+      const result = ArgumentGenerator.generateArg(
+        null as never,
+        null, // no simple identifier
+        "u8",
+        callbacks,
+      );
+      expect(result).toBe("&(uint8_t){42}");
+    });
+  });
+});

--- a/src/transpiler/output/codegen/helpers/types/IArgumentGeneratorCallbacks.ts
+++ b/src/transpiler/output/codegen/helpers/types/IArgumentGeneratorCallbacks.ts
@@ -1,0 +1,32 @@
+/**
+ * Callbacks required for argument generation.
+ * These need CodeGenerator context and cannot be replaced with static state.
+ *
+ * Issue #794: Extracted from CodeGenerator to reduce file size.
+ */
+
+import * as Parser from "../../../../logic/parser/grammar/CNextParser.js";
+
+interface IArgumentGeneratorCallbacks {
+  /** Determine if expression is an lvalue (member access or array access) */
+  getLvalueType: (ctx: Parser.ExpressionContext) => "member" | "array" | null;
+
+  /** Check if member access is to an array field */
+  getMemberAccessArrayStatus: (
+    ctx: Parser.ExpressionContext,
+  ) => "array" | "not-array" | "unknown";
+
+  /** Check if C++ mode needs temp variable for type conversion */
+  needsCppMemberConversion: (
+    ctx: Parser.ExpressionContext,
+    targetType?: string,
+  ) => boolean;
+
+  /** Check if expression is subscript access on a string variable */
+  isStringSubscriptAccess: (ctx: Parser.ExpressionContext) => boolean;
+
+  /** Generate expression code */
+  generateExpression: (ctx: Parser.ExpressionContext) => string;
+}
+
+export default IArgumentGeneratorCallbacks;


### PR DESCRIPTION
## Summary

- **Extract ArgumentGenerator** from CodeGenerator.ts into `src/transpiler/output/codegen/helpers/ArgumentGenerator.ts`
- Reduces CodeGenerator from **~6658 → ~6483 lines** (~175 lines, ~2.6% reduction)
- Consolidates function argument generation logic with ADR-006 semantics

## What's Extracted

The ArgumentGenerator handles argument generation patterns:
- `handleIdentifierArg()` - Simple identifiers (parameters, arrays, scope members, variables)
- `handleLvalueArg()` - Member access and array access expressions
- `handleMemberAccessArg()` - Array member special cases
- `createCppMemberConversionTemp()` - C++ temp variable creation
- `maybeCastStringSubscript()` - String subscript casting
- `handleRvalueArg()` - Literals and complex expressions
- `generateArg()` - Main dispatcher

## Architecture

Uses the established helper pattern:
- Static class in `helpers/` directory
- `IArgumentGeneratorCallbacks` interface for CodeGenerator methods
- Direct access to `CodeGenState` for state
- Follows same pattern as `StringDeclHelper`

## Test plan

- [x] 33 new unit tests for ArgumentGenerator (100% line coverage, 95.74% branch coverage)
- [x] All 5109 existing unit tests pass
- [x] All 950 integration tests pass
- [x] Linting: 0 errors

Closes #794

🤖 Generated with [Claude Code](https://claude.ai/code)