### PR TITLE
Release v0.1.71

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.71] - 2026-02-14
+
+### Changed
+
+- Complete ADR-055 Phase 7: Remove legacy ISymbol type system (PR #814, #815)
+- Extract TypeRegistrationEngine from CodeGenerator for cleaner architecture (Issue #791)
+
+### Fixed
+
+- Remove redundant undefined argument in resolveBaseType (PR #815)
+- Move TypeRegistrationEngine to output/codegen/helpers for architecture compliance (PR #814)
+
 ## [0.1.70] - 2026-02-13
 
 ### Fixed
@@ -976,7 +988,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - 38 legacy ESLint errors (non-blocking, tracked for future cleanup)
 
-[Unreleased]: https://github.com/jlaustill/c-next/compare/v0.1.66...HEAD
+[Unreleased]: https://github.com/jlaustill/c-next/compare/v0.1.71...HEAD
+[0.1.71]: https://github.com/jlaustill/c-next/compare/v0.1.70...v0.1.71
+[0.1.70]: https://github.com/jlaustill/c-next/compare/v0.1.69...v0.1.70
+[0.1.69]: https://github.com/jlaustill/c-next/compare/v0.1.68...v0.1.69
+[0.1.68]: https://github.com/jlaustill/c-next/compare/v0.1.67...v0.1.68
+[0.1.67]: https://github.com/jlaustill/c-next/compare/v0.1.66...v0.1.67
 [0.1.66]: https://github.com/jlaustill/c-next/compare/v0.1.65...v0.1.66
 [0.1.65]: https://github.com/jlaustill/c-next/compare/v0.1.64...v0.1.65
 [0.1.64]: https://github.com/jlaustill/c-next/compare/v0.1.63...v0.1.64

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "c-next",
-  "version": "0.1.70",
+  "version": "0.1.71",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "c-next",
-      "version": "0.1.70",
+      "version": "0.1.71",
       "license": "MIT",
       "dependencies": {
         "@n1ru4l/toposort": "^0.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "c-next",
-  "version": "0.1.70",
+  "version": "0.1.71",
   "description": "A safer C for embedded systems development. Transpiles to clean, readable C.",
   "packageManager": "npm@11.9.0",
   "type": "module",


### PR DESCRIPTION
## Summary

- Bump version to 0.1.71
- Complete ADR-055 Phase 7: Remove legacy ISymbol type system
- Extract TypeRegistrationEngine from CodeGenerator for cleaner architecture

## Changes

### Changed
- Complete ADR-055 Phase 7: Remove legacy ISymbol type system (PR #814, #815)
- Extract TypeRegistrationEngine from CodeGenerator for cleaner architecture (Issue #791)

### Fixed
- Remove redundant undefined argument in resolveBaseType (PR #815)
- Move TypeRegistrationEngine to output/codegen/helpers for architecture compliance (PR #814)

## Test plan
- [x] TypeScript type checking passes
- [x] All 951 integration tests pass
- [x] All quality checks pass (prettier, spelling, oxlint, dead code)

🤖 Generated with [Claude Code](https://claude.com/claude-code)