### PR TITLE
docs: extend ADR-105 with automatic filename-based namespacing

### DIFF
--- a/docs/decisions/adr-105-prefixed-includes.md
+++ b/docs/decisions/adr-105-prefixed-includes.md
@@ -140,18 +140,21 @@ void main() {
 ```
 
 **Key behavior:**
+
 - `global.Serial` still works for unqualified access (backwards compatible)
 - Filename prefix is automatic — no new syntax needed
 - Enables disambiguation when two headers export the same symbol name
 - Prefix is stripped from filename: `<path/Arduino.h>` → `Arduino`
 
 **Transpilation rules:**
+
 1. `Arduino.Serial.begin()` → `Arduino_Serial_begin()`
 2. `Arduino.config.baudRate` → `Arduino_config.baudRate` (struct member access preserved)
 3. `Arduino.LED_PIN` → `Arduino_LED_PIN` (constant)
 4. `Arduino.ServoState` → `Arduino_ServoState` (type)
 
 **Open questions specific to this approach:**
+
 1. How to handle structs? Does `Arduino.Point p` become `Arduino_Point p`?
 2. What about `typedef`s that reference other types in the same header?
 3. Should `global.Serial` continue to work, or require qualification when ambiguous?
@@ -160,12 +163,14 @@ void main() {
 6. How to handle headers with no `.h` extension or unusual names like `Arduino.hpp`?
 
 **Pros:**
+
 - No new syntax — works with existing `#include`
 - Familiar to developers from Python/JavaScript module patterns
 - Enables same-name symbols from different libraries
 - Backwards compatible via `global.` prefix
 
 **Cons:**
+
 - Filename may not be ideal prefix (e.g., `some_vendor_lib_v2.h`)
 - Requires tracking symbol provenance through the transpiler
 - Generated C code has longer symbol names


### PR DESCRIPTION
## Summary
- Extends ADR-105 (Prefixed Includes) with a new approach for automatic filename-based namespacing
- Enables `Arduino.Serial.begin()` syntax instead of `global.Serial.begin()`
- Documents C transpilation challenges and research questions for v2

## Changes
- Added Approach D: Automatic Filename-Based Namespacing
- Added multi-library conflict example to Context section
- Added C transpilation research questions (symbol renaming, cosmetic vs true namespacing, provenance tracking)

## Test plan
- [ ] Documentation review only - no code changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)