### PR TITLE
docs: add ADR-110 for DO-178C compliance research

### DIFF
--- a/docs/decisions/adr-110-do178c-compliance.md
+++ b/docs/decisions/adr-110-do178c-compliance.md
@@ -16,25 +16,25 @@ Aviation software requires DO-178C certification. This ADR captures initial rese
 
 ## DO-178C vs MISRA: Key Differences
 
-| Aspect | MISRA C:2012 | DO-178C |
-|--------|--------------|---------|
-| **Focus** | Coding rules to prevent bugs | Full software lifecycle certification |
-| **Scope** | Source code only | Requirements → Design → Code → Testing → Deployment |
-| **Output** | Clean code | Documentation artifacts proving correctness |
-| **Verification** | Static analysis | MC/DC coverage, requirements traceability |
-| **Levels** | One standard | 5 Design Assurance Levels (DAL A-E) |
+| Aspect           | MISRA C:2012                 | DO-178C                                             |
+| ---------------- | ---------------------------- | --------------------------------------------------- |
+| **Focus**        | Coding rules to prevent bugs | Full software lifecycle certification               |
+| **Scope**        | Source code only             | Requirements → Design → Code → Testing → Deployment |
+| **Output**       | Clean code                   | Documentation artifacts proving correctness         |
+| **Verification** | Static analysis              | MC/DC coverage, requirements traceability           |
+| **Levels**       | One standard                 | 5 Design Assurance Levels (DAL A-E)                 |
 
 **Key insight**: MISRA says "don't do X", DO-178C says "prove you did Y correctly and document everything."
 
 ## DO-178C Coverage Requirements by DAL
 
-| DAL Level | Failure Impact | Coverage Requirement |
-|-----------|----------------|---------------------|
-| A | Catastrophic | MC/DC (Modified Condition/Decision Coverage) |
-| B | Hazardous | Decision + Statement Coverage |
-| C | Major | Statement Coverage |
-| D | Minor | Less stringent |
-| E | No effect | Minimal |
+| DAL Level | Failure Impact | Coverage Requirement                         |
+| --------- | -------------- | -------------------------------------------- |
+| A         | Catastrophic   | MC/DC (Modified Condition/Decision Coverage) |
+| B         | Hazardous      | Decision + Statement Coverage                |
+| C         | Major          | Statement Coverage                           |
+| D         | Minor          | Less stringent                               |
+| E         | No effect      | Minimal                                      |
 
 ## Potential Transpiler Features
 


### PR DESCRIPTION
## Summary

- Adds ADR-110 capturing initial research on DO-178C compliance support for C-Next
- Documents key differences between MISRA (coding rules) and DO-178C (lifecycle certification)
- Outlines feasible transpiler features vs complex additions vs out-of-scope items
- Lists open research questions for future investigation

## Test plan

- [ ] Verify ADR follows established format
- [ ] No code changes - documentation only

🤖 Generated with [Claude Code](https://claude.com/claude-code)