### PR TITLE
Release v0.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.1] - 2026-02-17
+
+### Added
+
+- Add `id` and `parentId` fields to `parseSymbols` JSON-RPC response for unambiguous symbol resolution (Issue #823, PR #824)
+- Emit struct fields as separate symbols in `parseSymbols` output (matching enum/bitmap/register behavior)
+- Extract `SymbolPathUtils` utility with `buildScopePath`, `getDotPathId`, `getParentId` helpers
+
 ## [0.2.0] - 2026-02-16
 
 ### Changed
@@ -1007,6 +1015,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - 38 legacy ESLint errors (non-blocking, tracked for future cleanup)
 
 [Unreleased]: https://github.com/jlaustill/c-next/compare/v0.2.0...HEAD
+[0.2.1]: https://github.com/jlaustill/c-next/compare/v0.2.0...v0.2.1
 [0.2.0]: https://github.com/jlaustill/c-next/compare/v0.1.72...v0.2.0
 [0.1.72]: https://github.com/jlaustill/c-next/compare/v0.1.71...v0.1.72
 [0.1.71]: https://github.com/jlaustill/c-next/compare/v0.1.70...v0.1.71

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "c-next",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "c-next",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "license": "MIT",
       "dependencies": {
         "@n1ru4l/toposort": "^0.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "c-next",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "A safer C for embedded systems development. Transpiles to clean, readable C.",
   "packageManager": "npm@11.9.0",
   "type": "module",


### PR DESCRIPTION
## Release v0.2.1

### Changes

- Add `id` and `parentId` fields to `parseSymbols` JSON-RPC response for unambiguous symbol resolution (Issue #823, PR #824)
- Emit struct fields as separate symbols in `parseSymbols` output (matching enum/bitmap/register behavior)
- Extract `SymbolPathUtils` utility with `buildScopePath`, `getDotPathId`, `getParentId` helpers

### Checklist

- [x] Version bumped in package.json
- [x] CHANGELOG.md updated
- [x] All tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)