### PR TITLE
fix(misra): exclude URI exception test from MISRA validation

### DIFF
--- a/scripts/batch-validate.mjs
+++ b/scripts/batch-validate.mjs
@@ -246,6 +246,13 @@ function runClangTidy() {
 }
 
 // --- MISRA (per-file, C only) ---
+// Files excluded from MISRA validation (contain valid exceptions or intentional violations)
+const MISRA_EXCLUDED_FILES = [
+  // uri-exception.test.c tests MISRA Amendment 4 URI exception (://);
+  // cppcheck doesn't implement Amendment 4, so it false-positives on Rule 3.1
+  "uri-exception.test.c",
+];
+
 function runMisra() {
   if (!hasCppcheck) {
     console.log("⊘ cppcheck not available (needed for MISRA addon), skipping");
@@ -253,7 +260,11 @@ function runMisra() {
   }
 
   // MISRA is C-only; skip files that need C++ compilation
-  const misraFiles = cFiles.filter((f) => !requiresCpp(f));
+  // Also exclude files testing valid MISRA exceptions
+  const misraFiles = cFiles.filter(
+    (f) =>
+      !requiresCpp(f) && !MISRA_EXCLUDED_FILES.some((exc) => f.endsWith(exc)),
+  );
   console.log(`Running MISRA on ${misraFiles.length} C files...`);
 
   for (const file of misraFiles) {


### PR DESCRIPTION
## Summary
- Excludes `uri-exception.test.c` from cppcheck MISRA validation
- This file tests MISRA Amendment 4 URI exception (which allows `://` patterns inside comments)
- cppcheck's MISRA addon doesn't implement Amendment 4 and falsely flags this as a Rule 3.1 violation

## Context
The transpiler already enforces MISRA Rule 3.1 at transpile time with proper URI exception handling (`CommentExtractor.ts:160-202`). The cppcheck finding is a false positive.

## Test plan
- [x] All unit tests pass (5337 tests)
- [x] Integration tests pass
- [x] `batch-validate.mjs` script runs without errors
- [x] `uri-exception.test.cnx` still compiles correctly

Fixes #856

🤖 Generated with [Claude Code](https://claude.com/claude-code)