### PR TITLE
Release v0.2.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.3] - 2026-02-20
+
+### Fixed
+
+- Use union-based type punning for float bit access to avoid undefined behavior (Issue #857)
+- Add default case to all switch statements for MISRA 16.4 compliance
+- Exclude URI exception test from cppcheck MISRA validation (Issue #856)
+- Add proper spacing in anonymous struct compound literals
+
+### Changed
+
+- Consolidate push calls for SonarCloud S7778 compliance
+
+### Added
+
+- Union type coverage for anonymous struct reconstruction tests
+
 ## [0.2.2] - 2026-02-20
 
 ### Fixed
@@ -1032,7 +1049,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - 38 legacy ESLint errors (non-blocking, tracked for future cleanup)
 
-[Unreleased]: https://github.com/jlaustill/c-next/compare/v0.2.0...HEAD
+[Unreleased]: https://github.com/jlaustill/c-next/compare/v0.2.3...HEAD
+[0.2.3]: https://github.com/jlaustill/c-next/compare/v0.2.2...v0.2.3
 [0.2.2]: https://github.com/jlaustill/c-next/compare/v0.2.1...v0.2.2
 [0.2.1]: https://github.com/jlaustill/c-next/compare/v0.2.0...v0.2.1
 [0.2.0]: https://github.com/jlaustill/c-next/compare/v0.1.72...v0.2.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "c-next",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "c-next",
-      "version": "0.2.2",
+      "version": "0.2.3",
       "license": "MIT",
       "dependencies": {
         "@n1ru4l/toposort": "^0.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "c-next",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "A safer C for embedded systems development. Transpiles to clean, readable C.",
   "packageManager": "npm@11.9.0",
   "type": "module",


### PR DESCRIPTION
## Summary

- Bump version to 0.2.3
- Update CHANGELOG with new entries for fixes since v0.2.2

### Changes since v0.2.2

**Fixed:**
- Use union-based type punning for float bit access to avoid undefined behavior (Issue #857)
- Add default case to all switch statements for MISRA 16.4 compliance
- Exclude URI exception test from cppcheck MISRA validation (Issue #856)
- Add proper spacing in anonymous struct compound literals

**Changed:**
- Consolidate push calls for SonarCloud S7778 compliance

**Added:**
- Union type coverage for anonymous struct reconstruction tests

## Test plan

- [x] `npm run unit` - 5337 tests pass
- [x] `npm run test:q` - 957 integration tests pass

---

Generated with [Claude Code](https://claude.com/claude-code)