### PR TITLE
fix: prevent concurrent builds in test workers

### DIFF
--- a/scripts/test-utils.ts
+++ b/scripts/test-utils.ts
@@ -60,8 +60,10 @@ function isDistFresh(): boolean {
   return !hasNewerSource(SRC_DIR);
 }
 
-// Auto-rebuild on module load to ensure tests always use fresh bundle
-if (existsSync(DIST_ENTRY) && !isDistFresh()) {
+// Auto-rebuild on module load to ensure tests always use fresh bundle.
+// Only the main process should rebuild — workers (created via fork()) have
+// process.send, so we skip the build check in them to avoid 24 concurrent builds.
+if (!process.send && existsSync(DIST_ENTRY) && !isDistFresh()) {
   console.warn("Warning: dist/index.js is stale. Rebuilding...");
   const buildResult = spawnSync("npm", ["run", "build"], {
     cwd: PROJECT_ROOT,


### PR DESCRIPTION
## Summary
- The build-if-stale check in `test-utils.ts` runs at module load time, meaning all 24 forked worker processes independently trigger `npm run build` when dist is stale
- Added `!process.send` guard so only the main process (which lacks an IPC channel) performs the build — workers just read the existing dist

## Test plan
- [x] Single test passes (`npm test -- tests/enum/basic-enum.test.cnx`)
- [x] All pre-push quality checks pass
- [ ] Verify with stale dist: touch a src file, run `npm test -- --update` and confirm only one "Rebuilding..." message appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)