### PR TITLE
chore: release v0.2.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.5] - 2026-02-22
+
+### Added
+
+- Centralized error code registry document (docs/error-codes.md)
+
+### Changed
+
+- Move `ExpressionUnwrapper` utility to `src/utils/` for layer compliance
+- Finalize ADR-054 Decision section for array index overflow semantics
+- Use self-hosted runner for trusted CI jobs
+- Split integration tests for parallel c-validation
+- Parallelize C static analysis with matrix strategy
+
+### Fixed
+
+- Fix callback functions generating wrong pointer signatures (#895)
+- Preserve const from callback typedef signatures (#895)
+- Detect C++ reference params in `hasCppFeatures()`
+
 ## [0.2.4] - 2026-02-22
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "c-next",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "c-next",
-      "version": "0.2.4",
+      "version": "0.2.5",
       "license": "MIT",
       "dependencies": {
         "@n1ru4l/toposort": "^0.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "c-next",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "description": "A safer C for embedded systems development. Transpiles to clean, readable C.",
   "packageManager": "npm@11.9.0",
   "type": "module",


### PR DESCRIPTION
## Summary

Release v0.2.5 with the following changes:

### Added
- Centralized error code registry document (docs/error-codes.md)

### Changed
- Move `ExpressionUnwrapper` utility to `src/utils/` for layer compliance
- Finalize ADR-054 Decision section for array index overflow semantics
- Use self-hosted runner for trusted CI jobs
- Split integration tests for parallel c-validation
- Parallelize C static analysis with matrix strategy

### Fixed
- Fix callback functions generating wrong pointer signatures (#895)
- Preserve const from callback typedef signatures (#895)
- Detect C++ reference params in `hasCppFeatures()`

## Test plan
- [x] All CI checks pass
- [x] Version bumped in package.json
- [x] CHANGELOG.md updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)