### PR TITLE
ci: use self-hosted runner for publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   publish:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
 
     permissions:
       contents: write # Required for creating GitHub releases


### PR DESCRIPTION
## Summary

Use self-hosted runner for the npm publish workflow, matching the approach used in PR checks.

Since publish only triggers on tag pushes (always trusted context), it can use `self-hosted` directly without the conditional fork check.

## Test plan
- [x] Workflow syntax is valid
- [ ] Next release will use self-hosted runner

🤖 Generated with [Claude Code](https://claude.com/claude-code)