### PR TITLE
fix: exclude error test files from MISRA validation (#853)

### DIFF
--- a/scripts/batch-validate.mjs
+++ b/scripts/batch-validate.mjs
@@ -189,7 +189,11 @@ function runCppcheck() {
   ];
 
   // Batch C files (excluding those that need C++ mode)
-  const pureCFiles = cFiles.filter((f) => !requiresCpp(f));
+  // Also exclude error test files (*-error.test.c) which intentionally contain
+  // invalid code to test transpiler error detection (e.g., shift beyond width)
+  const pureCFiles = cFiles.filter(
+    (f) => !requiresCpp(f) && !f.endsWith("-error.test.c"),
+  );
   const cppDetectedFiles = cFiles.filter((f) => requiresCpp(f));
 
   if (pureCFiles.length > 0) {
@@ -292,7 +296,7 @@ function runMisra() {
   const misraFiles = cFiles.filter(
     (f) =>
       !requiresCpp(f) &&
-      !f.includes("-error.test.c") &&
+      !f.endsWith("-error.test.c") &&
       !MISRA_EXCLUDED_FILES.some((exc) => f.endsWith(exc)),
   );
   console.log(`Running MISRA on ${misraFiles.length} C files...`);


### PR DESCRIPTION
## Summary

- Excludes `*-error.test.c` files from MISRA validation in batch-validate.mjs
- These files intentionally contain invalid C code to test transpiler error detection
- Fixes 4 MISRA Rule 12.2 violations (shift amounts beyond type width)

## Context

Error test files test that C-Next correctly rejects invalid code at compile time. The generated `.test.c` files contain the invalid C (e.g., `a << 32` on `uint32_t`) which MISRA rightfully flags — but these aren't bugs, they're intentional test cases.

## Test plan

- [x] All 972 integration tests pass
- [x] Verified exclusion logic filters the 4 affected files
- [ ] CI will verify MISRA validation passes when cppcheck is available

Closes #853

🤖 Generated with [Claude Code](https://claude.com/claude-code)