### PR TITLE
ci: move concurrency block to deploy-coverage job only

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -9,11 +9,6 @@ on:
 # Self-hosted runner for trusted code (your branches, pushes to main)
 # GitHub runners for untrusted code (fork PRs)
 
-# Prevent concurrent Pages deployments
-concurrency:
-  group: "pages"
-  cancel-in-progress: false
-
 jobs:
   # ============================================================================
   # STAGE 1 (parallel): Build + Lint
@@ -462,6 +457,10 @@ jobs:
     runs-on: ${{ (github.event_name == 'push' || !github.event.pull_request.head.repo.fork) && 'self-hosted' || 'ubuntu-latest' }}
     needs: [unit-tests]
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    # Prevent concurrent Pages deployments
+    concurrency:
+      group: "pages"
+      cancel-in-progress: false
     permissions:
       contents: read
       pages: write


### PR DESCRIPTION
## Summary

- Move workflow-level concurrency block to the `deploy-coverage` job only
- Allows PR workflow runs to execute in parallel across different PRs

## Problem

The concurrency block was at the workflow level with a static group name `"pages"`:

```yaml
concurrency:
  group: "pages"
  cancel-in-progress: false
```

This caused **all** workflow runs to share the same concurrency group, meaning PRs queued and ran one at a time instead of in parallel.

## Solution

Move the concurrency block into the `deploy-coverage` job where it actually belongs. The comment said "Prevent concurrent Pages deployments" but the placement affected the entire workflow.

Now:
- PR checks run in parallel across different PRs ✅
- Pages deployments are still serialized to prevent conflicts ✅

## Test plan

- [x] YAML syntax validated
- [x] Workflow structure unchanged except for concurrency scope

🤖 Generated with [Claude Code](https://claude.com/claude-code)