### PR TITLE
test: convert 10 Phase 1 transpile-only tests to executable (#916)

### DIFF
--- a/tests/cpp-mode/cross-file-const/Handler.expected.cpp
+++ b/tests/cpp-mode/cross-file-const/Handler.expected.cpp
@@ -6,7 +6,6 @@
 #include "Handler.test.h"
 
 // test-cpp-only
-// test-transpile-only
 // Bug #558: Cross-file const inference
 // Handler.reset passes cfg to Storage.loadDefaults which modifies it
 // Therefore cfg should NOT be const in Handler.reset

--- a/tests/cpp-mode/cross-file-const/Handler.test.cnx
+++ b/tests/cpp-mode/cross-file-const/Handler.test.cnx
@@ -1,5 +1,4 @@
 // test-cpp-only
-// test-transpile-only
 // Bug #558: Cross-file const inference
 // Handler.reset passes cfg to Storage.loadDefaults which modifies it
 // Therefore cfg should NOT be const in Handler.reset

--- a/tests/cpp-mode/cross-file-const/Handler.test.cpp
+++ b/tests/cpp-mode/cross-file-const/Handler.test.cpp
@@ -6,7 +6,6 @@
 #include "Handler.test.h"
 
 // test-cpp-only
-// test-transpile-only
 // Bug #558: Cross-file const inference
 // Handler.reset passes cfg to Storage.loadDefaults which modifies it
 // Therefore cfg should NOT be const in Handler.reset

--- a/tests/cpp-mode/issue-580-chain/Level1.expected.cpp
+++ b/tests/cpp-mode/issue-580-chain/Level1.expected.cpp
@@ -6,7 +6,6 @@
 #include "Level1.test.h"
 
 // test-cpp-only
-// test-transpile-only
 // Issue #580 chain test: 3-level deep pass-through chain
 // Level1 -> Level2 -> Level3 (modifies)
 #include "Config.h"

--- a/tests/cpp-mode/issue-580-chain/Level1.test.cnx
+++ b/tests/cpp-mode/issue-580-chain/Level1.test.cnx
@@ -1,5 +1,4 @@
 // test-cpp-only
-// test-transpile-only
 // Issue #580 chain test: 3-level deep pass-through chain
 // Level1 -> Level2 -> Level3 (modifies)
 

--- a/tests/cpp-mode/issue-580-chain/Level1.test.cpp
+++ b/tests/cpp-mode/issue-580-chain/Level1.test.cpp
@@ -6,7 +6,6 @@
 #include "Level1.test.h"
 
 // test-cpp-only
-// test-transpile-only
 // Issue #580 chain test: 3-level deep pass-through chain
 // Level1 -> Level2 -> Level3 (modifies)
 #include "Config.h"

--- a/tests/cpp-mode/issue-580-minimal/Handler.expected.cpp
+++ b/tests/cpp-mode/issue-580-minimal/Handler.expected.cpp
@@ -6,7 +6,6 @@
 #include "Handler.test.h"
 
 // test-cpp-only
-// test-transpile-only
 // Issue #580 minimal reproduction: function with ONLY a pass-through call
 #include "Config.h"
 #include "Modifier.h"

--- a/tests/cpp-mode/issue-580-minimal/Handler.test.cnx
+++ b/tests/cpp-mode/issue-580-minimal/Handler.test.cnx
@@ -1,5 +1,4 @@
 // test-cpp-only
-// test-transpile-only
 // Issue #580 minimal reproduction: function with ONLY a pass-through call
 
 #include "Config.cnx"

--- a/tests/cpp-mode/issue-580-minimal/Handler.test.cpp
+++ b/tests/cpp-mode/issue-580-minimal/Handler.test.cpp
@@ -6,7 +6,6 @@
 #include "Handler.test.h"
 
 // test-cpp-only
-// test-transpile-only
 // Issue #580 minimal reproduction: function with ONLY a pass-through call
 #include "Config.h"
 #include "Modifier.h"

--- a/tests/cpp-mode/issue-580-order/AHandler.expected.cpp
+++ b/tests/cpp-mode/issue-580-order/AHandler.expected.cpp
@@ -6,7 +6,6 @@
 #include "AHandler.test.h"
 
 // test-cpp-only
-// test-transpile-only
 // Issue #580 order test: AHandler comes before ZModifier alphabetically
 // Tests if file order affects const inference
 #include "Config.h"

--- a/tests/cpp-mode/issue-580-order/AHandler.test.cnx
+++ b/tests/cpp-mode/issue-580-order/AHandler.test.cnx
@@ -1,5 +1,4 @@
 // test-cpp-only
-// test-transpile-only
 // Issue #580 order test: AHandler comes before ZModifier alphabetically
 // Tests if file order affects const inference
 

--- a/tests/cpp-mode/issue-580-order/AHandler.test.cpp
+++ b/tests/cpp-mode/issue-580-order/AHandler.test.cpp
@@ -6,7 +6,6 @@
 #include "AHandler.test.h"
 
 // test-cpp-only
-// test-transpile-only
 // Issue #580 order test: AHandler comes before ZModifier alphabetically
 // Tests if file order affects const inference
 #include "Config.h"

--- a/tests/cpp-mode/issue-580/SerialHandler.expected.cpp
+++ b/tests/cpp-mode/issue-580/SerialHandler.expected.cpp
@@ -6,7 +6,6 @@
 #include "SerialHandler.test.h"
 
 // test-cpp-only
-// test-transpile-only
 // Issue #580: Incorrect const inference when parameter is only passed to mutating function
 // handleReset was incorrectly marked const even though it passes config to reset() which mutates it
 #include "Config.h"

--- a/tests/cpp-mode/issue-580/SerialHandler.test.cnx
+++ b/tests/cpp-mode/issue-580/SerialHandler.test.cnx
@@ -1,5 +1,4 @@
 // test-cpp-only
-// test-transpile-only
 // Issue #580: Incorrect const inference when parameter is only passed to mutating function
 // handleReset was incorrectly marked const even though it passes config to reset() which mutates it
 

--- a/tests/cpp-mode/issue-580/SerialHandler.test.cpp
+++ b/tests/cpp-mode/issue-580/SerialHandler.test.cpp
@@ -6,7 +6,6 @@
 #include "SerialHandler.test.h"
 
 // test-cpp-only
-// test-transpile-only
 // Issue #580: Incorrect const inference when parameter is only passed to mutating function
 // handleReset was incorrectly marked const even though it passes config to reset() which mutates it
 #include "Config.h"

--- a/tests/cpp-mode/primitive-ref-deref.expected.cpp
+++ b/tests/cpp-mode/primitive-ref-deref.expected.cpp
@@ -8,7 +8,6 @@
 #include <stdint.h>
 
 // test-cpp-only
-// test-transpile-only
 // Bug #558: Primitive parameter reassigned should not use pointer dereference in C++ mode
 // When a primitive is reassigned, it becomes a reference (uint32_t&)
 // The body should use 'val' directly, not '(*val)'
@@ -24,5 +23,8 @@ uint32_t Test_process(uint32_t& val) {
 }
 
 int main(void) {
-    uint32_t result = Test_process(5U);
+    uint32_t input = 5U;
+    uint32_t result = Test_process(input);
+    if (result != 6) return 1;
+    return 0;
 }

--- a/tests/cpp-mode/primitive-ref-deref.test.cnx
+++ b/tests/cpp-mode/primitive-ref-deref.test.cnx
@@ -1,5 +1,4 @@
 // test-cpp-only
-// test-transpile-only
 // Bug #558: Primitive parameter reassigned should not use pointer dereference in C++ mode
 // When a primitive is reassigned, it becomes a reference (uint32_t&)
 // The body should use 'val' directly, not '(*val)'
@@ -15,6 +14,10 @@ scope Test {
     }
 }
 
-void main() {
-    u32 result <- global.Test.process(5);
+u32 main() {
+    u32 input <- 5;
+    u32 result <- global.Test.process(input);
+    // process calls helper(5) which returns 6, then assigns to val
+    if (result != 6) return 1;
+    return 0;
 }

--- a/tests/cpp-mode/primitive-ref-deref.test.cpp
+++ b/tests/cpp-mode/primitive-ref-deref.test.cpp
@@ -8,7 +8,6 @@
 #include <stdint.h>
 
 // test-cpp-only
-// test-transpile-only
 // Bug #558: Primitive parameter reassigned should not use pointer dereference in C++ mode
 // When a primitive is reassigned, it becomes a reference (uint32_t&)
 // The body should use 'val' directly, not '(*val)'
@@ -24,5 +23,8 @@ uint32_t Test_process(uint32_t& val) {
 }
 
 int main(void) {
-    uint32_t result = Test_process(5U);
+    uint32_t input = 5U;
+    uint32_t result = Test_process(input);
+    if (result != 6) return 1;
+    return 0;
 }

--- a/tests/cpp-mode/private-const-inference/SerialHandler.expected.cpp
+++ b/tests/cpp-mode/private-const-inference/SerialHandler.expected.cpp
@@ -6,7 +6,6 @@
 #include "SerialHandler.test.h"
 
 // test-cpp-only
-// test-transpile-only
 // Bug #561: Private function const inference
 // handleSet is a PRIVATE function that passes config to CommandHandler.setValue
 // which modifies cfg.value. Therefore:

--- a/tests/cpp-mode/private-const-inference/SerialHandler.test.cnx
+++ b/tests/cpp-mode/private-const-inference/SerialHandler.test.cnx
@@ -1,5 +1,4 @@
 // test-cpp-only
-// test-transpile-only
 // Bug #561: Private function const inference
 // handleSet is a PRIVATE function that passes config to CommandHandler.setValue
 // which modifies cfg.value. Therefore:

--- a/tests/cpp-mode/private-const-inference/SerialHandler.test.cpp
+++ b/tests/cpp-mode/private-const-inference/SerialHandler.test.cpp
@@ -6,7 +6,6 @@
 #include "SerialHandler.test.h"
 
 // test-cpp-only
-// test-transpile-only
 // Bug #561: Private function const inference
 // handleSet is a PRIVATE function that passes config to CommandHandler.setValue
 // which modifies cfg.value. Therefore:

--- a/tests/enum-external/multiple-external-enums.expected.c
+++ b/tests/enum-external/multiple-external-enums.expected.c
@@ -3,7 +3,6 @@
  * A safer C for embedded systems
  */
 
-// test-transpile-only
 // Issue #465: Test multiple external enums from different files
 // Verifies that enum prefixing works when including multiple files with enums
 #include "types.h"

--- a/tests/enum-external/multiple-external-enums.expected.cpp
+++ b/tests/enum-external/multiple-external-enums.expected.cpp
@@ -3,7 +3,6 @@
  * A safer C for embedded systems
  */
 
-// test-transpile-only
 // Issue #465: Test multiple external enums from different files
 // Verifies that enum prefixing works when including multiple files with enums
 #include "types.h"

--- a/tests/enum-external/multiple-external-enums.test.c
+++ b/tests/enum-external/multiple-external-enums.test.c
@@ -3,7 +3,6 @@
  * A safer C for embedded systems
  */
 
-// test-transpile-only
 // Issue #465: Test multiple external enums from different files
 // Verifies that enum prefixing works when including multiple files with enums
 #include "types.h"

--- a/tests/enum-external/multiple-external-enums.test.cnx
+++ b/tests/enum-external/multiple-external-enums.test.cnx
@@ -1,4 +1,3 @@
-// test-transpile-only
 // Issue #465: Test multiple external enums from different files
 // Verifies that enum prefixing works when including multiple files with enums
 

--- a/tests/enum-external/multiple-external-enums.test.cpp
+++ b/tests/enum-external/multiple-external-enums.test.cpp
@@ -3,7 +3,6 @@
  * A safer C for embedded systems
  */
 
-// test-transpile-only
 // Issue #465: Test multiple external enums from different files
 // Verifies that enum prefixing works when including multiple files with enums
 #include "types.h"

--- a/tests/enum-external/nested/nested-include-enum.expected.c
+++ b/tests/enum-external/nested/nested-include-enum.expected.c
@@ -3,7 +3,6 @@
  * A safer C for embedded systems
  */
 
-// test-transpile-only
 // Issue #465: Test nested includes with enum at deepest level
 // A includes B, B includes C (with enum) - C's enum should work in A
 // Note: transpile-only because header generation for transitive includes is a separate issue

--- a/tests/enum-external/nested/nested-include-enum.expected.cpp
+++ b/tests/enum-external/nested/nested-include-enum.expected.cpp
@@ -3,7 +3,6 @@
  * A safer C for embedded systems
  */
 
-// test-transpile-only
 // Issue #465: Test nested includes with enum at deepest level
 // A includes B, B includes C (with enum) - C's enum should work in A
 // Note: transpile-only because header generation for transitive includes is a separate issue

--- a/tests/enum-external/nested/nested-include-enum.test.c
+++ b/tests/enum-external/nested/nested-include-enum.test.c
@@ -3,7 +3,6 @@
  * A safer C for embedded systems
  */
 
-// test-transpile-only
 // Issue #465: Test nested includes with enum at deepest level
 // A includes B, B includes C (with enum) - C's enum should work in A
 // Note: transpile-only because header generation for transitive includes is a separate issue

--- a/tests/enum-external/nested/nested-include-enum.test.cnx
+++ b/tests/enum-external/nested/nested-include-enum.test.cnx
@@ -1,4 +1,3 @@
-// test-transpile-only
 // Issue #465: Test nested includes with enum at deepest level
 // A includes B, B includes C (with enum) - C's enum should work in A
 // Note: transpile-only because header generation for transitive includes is a separate issue

--- a/tests/enum-external/nested/nested-include-enum.test.cpp
+++ b/tests/enum-external/nested/nested-include-enum.test.cpp
@@ -3,7 +3,6 @@
  * A safer C for embedded systems
  */
 
-// test-transpile-only
 // Issue #465: Test nested includes with enum at deepest level
 // A includes B, B includes C (with enum) - C's enum should work in A
 // Note: transpile-only because header generation for transitive includes is a separate issue

--- a/tests/explicit-length/element_count/args-element-count.expected.c
+++ b/tests/explicit-length/element_count/args-element-count.expected.c
@@ -6,7 +6,6 @@
 #include <stdint.h>
 #include <string.h>
 
-// test-transpile-only
 // Tests args.element_count property (ADR-058)
 // args.element_count returns argc
 int main(int argc, char *argv[]) {

--- a/tests/explicit-length/element_count/args-element-count.expected.cpp
+++ b/tests/explicit-length/element_count/args-element-count.expected.cpp
@@ -6,7 +6,6 @@
 #include <stdint.h>
 #include <string.h>
 
-// test-transpile-only
 // Tests args.element_count property (ADR-058)
 // args.element_count returns argc
 int main(int argc, char *argv[]) {

--- a/tests/explicit-length/element_count/args-element-count.test.c
+++ b/tests/explicit-length/element_count/args-element-count.test.c
@@ -6,7 +6,6 @@
 #include <stdint.h>
 #include <string.h>
 
-// test-transpile-only
 // Tests args.element_count property (ADR-058)
 // args.element_count returns argc
 int main(int argc, char *argv[]) {

--- a/tests/explicit-length/element_count/args-element-count.test.cnx
+++ b/tests/explicit-length/element_count/args-element-count.test.cnx
@@ -1,4 +1,3 @@
-// test-transpile-only
 // Tests args.element_count property (ADR-058)
 // args.element_count returns argc
 

--- a/tests/explicit-length/element_count/args-element-count.test.cpp
+++ b/tests/explicit-length/element_count/args-element-count.test.cpp
@@ -6,7 +6,6 @@
 #include <stdint.h>
 #include <string.h>
 
-// test-transpile-only
 // Tests args.element_count property (ADR-058)
 // args.element_count returns argc
 int main(int argc, char *argv[]) {


### PR DESCRIPTION
## Summary

- Convert 10 transpile-only tests that already had `main()` functions to fully executable tests
- These tests now compile and run with GCC, providing stronger verification of transpiler correctness
- Fixed `primitive-ref-deref` test that was passing a literal to a reference parameter (invalid C++)

## Tests Converted

- `cpp-mode/cross-file-const/Handler`
- `cpp-mode/issue-580-chain/Level1`
- `cpp-mode/issue-580-minimal/Handler`
- `cpp-mode/issue-580-order/AHandler`
- `cpp-mode/issue-580/SerialHandler`
- `cpp-mode/primitive-ref-deref` (also fixed to use variable instead of literal)
- `cpp-mode/private-const-inference/SerialHandler`
- `enum-external/multiple-external-enums`
- `enum-external/nested/nested-include-enum`
- `explicit-length/element_count/args-element-count`

## Impact

- Transpile-only tests: 37 → 27 remaining
- All 975 tests passing

## Test plan

- [x] All 10 converted tests compile and execute successfully
- [x] Full test suite passes (975/975)

🤖 Generated with [Claude Code](https://claude.com/claude-code)