### PR TITLE
fix: cast bitwise NOT on unsigned types for MISRA compliance (#915)

### DIFF
--- a/src/transpiler/output/codegen/generators/expressions/__tests__/UnaryExprGenerator.test.ts
+++ b/src/transpiler/output/codegen/generators/expressions/__tests__/UnaryExprGenerator.test.ts
@@ -1,0 +1,196 @@
+/**
+ * Unit tests for UnaryExprGenerator
+ *
+ * Tests bitwise NOT (~) MISRA-compliant cast generation:
+ * - Unsigned types get cast back to original type (MISRA 10.1/10.3)
+ * - Signed types and unresolvable types are unchanged
+ * - C++ mode uses static_cast
+ */
+
+import { describe, it, expect, vi, afterEach } from "vitest";
+import generateUnaryExpr from "../UnaryExprGenerator";
+import type { UnaryExpressionContext } from "../../../../../logic/parser/grammar/CNextParser";
+import type IGeneratorInput from "../../IGeneratorInput";
+import type IGeneratorState from "../../IGeneratorState";
+import type IOrchestrator from "../../IOrchestrator";
+import CodeGenState from "../../../../../state/CodeGenState";
+
+vi.mock("../../../TypeResolver", () => {
+  return {
+    default: {
+      getUnaryExpressionType: vi.fn(),
+      isUnsignedType: vi.fn(),
+    },
+  };
+});
+
+import TypeResolver from "../../../TypeResolver";
+
+// ========================================================================
+// Test Helpers
+// ========================================================================
+
+/**
+ * Create a mock UnaryExpressionContext for a prefix unary expression.
+ * The node has no postfixExpression (prefix case) and a child unaryExpression.
+ */
+function createMockUnaryNode(fullText: string): UnaryExpressionContext {
+  const innerUnary = {} as UnaryExpressionContext;
+  return {
+    postfixExpression: () => null,
+    unaryExpression: () => innerUnary,
+    getText: () => fullText,
+  } as unknown as UnaryExpressionContext;
+}
+
+const mockInput = {} as IGeneratorInput;
+const mockState = {} as IGeneratorState;
+
+function createMockOrchestrator(innerResult: string): IOrchestrator {
+  return {
+    generateUnaryExpr: () => innerResult,
+    generatePostfixExpr: () => "",
+  } as unknown as IOrchestrator;
+}
+
+// ========================================================================
+// Tests
+// ========================================================================
+
+describe("UnaryExprGenerator", () => {
+  afterEach(() => {
+    vi.mocked(TypeResolver.getUnaryExpressionType).mockReset();
+    vi.mocked(TypeResolver.isUnsignedType).mockReset();
+    CodeGenState.cppMode = false;
+  });
+
+  describe("bitwise NOT on unsigned types", () => {
+    it("should cast ~u8 to (uint8_t)~c in C mode", () => {
+      vi.mocked(TypeResolver.getUnaryExpressionType).mockReturnValue("u8");
+      vi.mocked(TypeResolver.isUnsignedType).mockReturnValue(true);
+
+      const node = createMockUnaryNode("~c");
+      const orchestrator = createMockOrchestrator("c");
+      const result = generateUnaryExpr(
+        node,
+        mockInput,
+        mockState,
+        orchestrator,
+      );
+
+      expect(result.code).toBe("(uint8_t)~c");
+      expect(result.effects).toEqual([]);
+    });
+
+    it("should cast ~u16 to (uint16_t)~c in C mode", () => {
+      vi.mocked(TypeResolver.getUnaryExpressionType).mockReturnValue("u16");
+      vi.mocked(TypeResolver.isUnsignedType).mockReturnValue(true);
+
+      const node = createMockUnaryNode("~c");
+      const orchestrator = createMockOrchestrator("c");
+      const result = generateUnaryExpr(
+        node,
+        mockInput,
+        mockState,
+        orchestrator,
+      );
+
+      expect(result.code).toBe("(uint16_t)~c");
+      expect(result.effects).toEqual([]);
+    });
+
+    it("should use static_cast in C++ mode", () => {
+      CodeGenState.cppMode = true;
+      vi.mocked(TypeResolver.getUnaryExpressionType).mockReturnValue("u8");
+      vi.mocked(TypeResolver.isUnsignedType).mockReturnValue(true);
+
+      const node = createMockUnaryNode("~c");
+      const orchestrator = createMockOrchestrator("c");
+      const result = generateUnaryExpr(
+        node,
+        mockInput,
+        mockState,
+        orchestrator,
+      );
+
+      expect(result.code).toBe("static_cast<uint8_t>(~c)");
+      expect(result.effects).toEqual([]);
+    });
+  });
+
+  describe("bitwise NOT on signed/unresolvable types", () => {
+    it("should not cast ~i8 (signed type)", () => {
+      vi.mocked(TypeResolver.getUnaryExpressionType).mockReturnValue("i8");
+      vi.mocked(TypeResolver.isUnsignedType).mockReturnValue(false);
+
+      const node = createMockUnaryNode("~c");
+      const orchestrator = createMockOrchestrator("c");
+      const result = generateUnaryExpr(
+        node,
+        mockInput,
+        mockState,
+        orchestrator,
+      );
+
+      expect(result.code).toBe("~c");
+      expect(result.effects).toEqual([]);
+    });
+
+    it("should not cast when type is unresolvable", () => {
+      vi.mocked(TypeResolver.getUnaryExpressionType).mockReturnValue(null);
+
+      const node = createMockUnaryNode("~expr");
+      const orchestrator = createMockOrchestrator("expr");
+      const result = generateUnaryExpr(
+        node,
+        mockInput,
+        mockState,
+        orchestrator,
+      );
+
+      expect(result.code).toBe("~expr");
+      expect(result.effects).toEqual([]);
+    });
+  });
+
+  describe("other unary operators", () => {
+    it("should generate logical NOT unchanged", () => {
+      const node = createMockUnaryNode("!flag");
+      const orchestrator = createMockOrchestrator("flag");
+      const result = generateUnaryExpr(
+        node,
+        mockInput,
+        mockState,
+        orchestrator,
+      );
+
+      expect(result.code).toBe("!flag");
+    });
+
+    it("should generate negation unchanged", () => {
+      const node = createMockUnaryNode("-x");
+      const orchestrator = createMockOrchestrator("x");
+      const result = generateUnaryExpr(
+        node,
+        mockInput,
+        mockState,
+        orchestrator,
+      );
+
+      expect(result.code).toBe("-x");
+    });
+
+    it("should generate address-of unchanged", () => {
+      const node = createMockUnaryNode("&x");
+      const orchestrator = createMockOrchestrator("x");
+      const result = generateUnaryExpr(
+        node,
+        mockInput,
+        mockState,
+        orchestrator,
+      );
+
+      expect(result.code).toBe("&x");
+    });
+  });
+});

--- a/tests/basics/simple-bitwise.expected.c
+++ b/tests/basics/simple-bitwise.expected.c
@@ -19,7 +19,7 @@ int main(void) {
     result = a ^ b;
     if (result != 0b01011010) return 3;
     uint8_t c = 0b00001111U;
-    uint8_t notC = ~c;
+    uint8_t notC = (uint8_t)~c;
     if (notC != 0b11110000) return 4;
     uint8_t d = 0b00000001U;
     uint8_t shifted = d << 4U;

--- a/tests/basics/simple-bitwise.expected.cpp
+++ b/tests/basics/simple-bitwise.expected.cpp
@@ -19,7 +19,7 @@ int main(void) {
     result = a ^ b;
     if (result != 0b01011010) return 3;
     uint8_t c = 0b00001111U;
-    uint8_t notC = ~c;
+    uint8_t notC = static_cast<uint8_t>(~c);
     if (notC != 0b11110000) return 4;
     uint8_t d = 0b00000001U;
     uint8_t shifted = d << 4U;

--- a/tests/basics/simple-bitwise.test.c
+++ b/tests/basics/simple-bitwise.test.c
@@ -19,7 +19,7 @@ int main(void) {
     result = a ^ b;
     if (result != 0b01011010) return 3;
     uint8_t c = 0b00001111U;
-    uint8_t notC = ~c;
+    uint8_t notC = (uint8_t)~c;
     if (notC != 0b11110000) return 4;
     uint8_t d = 0b00000001U;
     uint8_t shifted = d << 4U;

--- a/tests/basics/simple-bitwise.test.cpp
+++ b/tests/basics/simple-bitwise.test.cpp
@@ -19,7 +19,7 @@ int main(void) {
     result = a ^ b;
     if (result != 0b01011010) return 3;
     uint8_t c = 0b00001111U;
-    uint8_t notC = ~c;
+    uint8_t notC = static_cast<uint8_t>(~c);
     if (notC != 0b11110000) return 4;
     uint8_t d = 0b00000001U;
     uint8_t shifted = d << 4U;

--- a/tests/bitwise/complex-combinations.expected.c
+++ b/tests/bitwise/complex-combinations.expected.c
@@ -17,7 +17,7 @@ int main(void) {
     uint16_t d = 0xFFU;
     uint16_t shift_and_mask = (d << 8U) & 0xF000U;
     uint8_t e = 0b11110000U;
-    uint8_t not_and_shift = (~e) << 2U;
+    uint8_t not_and_shift = ((uint8_t)~e) << 2U;
     uint32_t flags = 0b11001100U;
     uint32_t toggle = flags ^ 0b00110011U;
     uint32_t toggle_back = toggle ^ 0b00110011U;

--- a/tests/bitwise/complex-combinations.expected.cpp
+++ b/tests/bitwise/complex-combinations.expected.cpp
@@ -17,7 +17,7 @@ int main(void) {
     uint16_t d = 0xFFU;
     uint16_t shift_and_mask = (d << 8U) & 0xF000U;
     uint8_t e = 0b11110000U;
-    uint8_t not_and_shift = (~e) << 2U;
+    uint8_t not_and_shift = (static_cast<uint8_t>(~e)) << 2U;
     uint32_t flags = 0b11001100U;
     uint32_t toggle = flags ^ 0b00110011U;
     uint32_t toggle_back = toggle ^ 0b00110011U;

--- a/tests/bitwise/complex-combinations.test.c
+++ b/tests/bitwise/complex-combinations.test.c
@@ -17,7 +17,7 @@ int main(void) {
     uint16_t d = 0xFFU;
     uint16_t shift_and_mask = (d << 8U) & 0xF000U;
     uint8_t e = 0b11110000U;
-    uint8_t not_and_shift = (~e) << 2U;
+    uint8_t not_and_shift = ((uint8_t)~e) << 2U;
     uint32_t flags = 0b11001100U;
     uint32_t toggle = flags ^ 0b00110011U;
     uint32_t toggle_back = toggle ^ 0b00110011U;

--- a/tests/bitwise/complex-combinations.test.cpp
+++ b/tests/bitwise/complex-combinations.test.cpp
@@ -17,7 +17,7 @@ int main(void) {
     uint16_t d = 0xFFU;
     uint16_t shift_and_mask = (d << 8U) & 0xF000U;
     uint8_t e = 0b11110000U;
-    uint8_t not_and_shift = (~e) << 2U;
+    uint8_t not_and_shift = (static_cast<uint8_t>(~e)) << 2U;
     uint32_t flags = 0b11001100U;
     uint32_t toggle = flags ^ 0b00110011U;
     uint32_t toggle_back = toggle ^ 0b00110011U;

--- a/tests/bitwise/u16-bitwise-ops.expected.c
+++ b/tests/bitwise/u16-bitwise-ops.expected.c
@@ -16,14 +16,14 @@ int main(void) {
     uint16_t or_result = a | b;
     uint16_t xor_result = a ^ b;
     uint16_t c = 0xAAAAU;
-    uint16_t not_result = ~c;
+    uint16_t not_result = (uint16_t)~c;
     uint16_t bin_a = 0b1111111100000000U;
     uint16_t bin_b = 0b1010101010101010U;
     uint16_t bin_and = bin_a & bin_b;
     uint16_t dec_and = 65280U & 43690U;
     uint16_t dec_or = 65280U | 43690U;
     uint16_t all_bits = 0xFFFFU;
-    uint16_t not_all = ~all_bits;
+    uint16_t not_all = (uint16_t)~all_bits;
     if (and_result == 43520 && or_result == 65450 && xor_result == 21930 && not_result == 21845) {
         if (bin_and == 43520 && dec_and == 43520 && dec_or == 65450 && not_all == 0) {
             return 0;

--- a/tests/bitwise/u16-bitwise-ops.expected.cpp
+++ b/tests/bitwise/u16-bitwise-ops.expected.cpp
@@ -16,14 +16,14 @@ int main(void) {
     uint16_t or_result = a | b;
     uint16_t xor_result = a ^ b;
     uint16_t c = 0xAAAAU;
-    uint16_t not_result = ~c;
+    uint16_t not_result = static_cast<uint16_t>(~c);
     uint16_t bin_a = 0b1111111100000000U;
     uint16_t bin_b = 0b1010101010101010U;
     uint16_t bin_and = bin_a & bin_b;
     uint16_t dec_and = 65280U & 43690U;
     uint16_t dec_or = 65280U | 43690U;
     uint16_t all_bits = 0xFFFFU;
-    uint16_t not_all = ~all_bits;
+    uint16_t not_all = static_cast<uint16_t>(~all_bits);
     if (and_result == 43520 && or_result == 65450 && xor_result == 21930 && not_result == 21845) {
         if (bin_and == 43520 && dec_and == 43520 && dec_or == 65450 && not_all == 0) {
             return 0;

--- a/tests/bitwise/u16-bitwise-ops.test.c
+++ b/tests/bitwise/u16-bitwise-ops.test.c
@@ -16,14 +16,14 @@ int main(void) {
     uint16_t or_result = a | b;
     uint16_t xor_result = a ^ b;
     uint16_t c = 0xAAAAU;
-    uint16_t not_result = ~c;
+    uint16_t not_result = (uint16_t)~c;
     uint16_t bin_a = 0b1111111100000000U;
     uint16_t bin_b = 0b1010101010101010U;
     uint16_t bin_and = bin_a & bin_b;
     uint16_t dec_and = 65280U & 43690U;
     uint16_t dec_or = 65280U | 43690U;
     uint16_t all_bits = 0xFFFFU;
-    uint16_t not_all = ~all_bits;
+    uint16_t not_all = (uint16_t)~all_bits;
     if (and_result == 43520 && or_result == 65450 && xor_result == 21930 && not_result == 21845) {
         if (bin_and == 43520 && dec_and == 43520 && dec_or == 65450 && not_all == 0) {
             return 0;

--- a/tests/bitwise/u16-bitwise-ops.test.cpp
+++ b/tests/bitwise/u16-bitwise-ops.test.cpp
@@ -16,14 +16,14 @@ int main(void) {
     uint16_t or_result = a | b;
     uint16_t xor_result = a ^ b;
     uint16_t c = 0xAAAAU;
-    uint16_t not_result = ~c;
+    uint16_t not_result = static_cast<uint16_t>(~c);
     uint16_t bin_a = 0b1111111100000000U;
     uint16_t bin_b = 0b1010101010101010U;
     uint16_t bin_and = bin_a & bin_b;
     uint16_t dec_and = 65280U & 43690U;
     uint16_t dec_or = 65280U | 43690U;
     uint16_t all_bits = 0xFFFFU;
-    uint16_t not_all = ~all_bits;
+    uint16_t not_all = static_cast<uint16_t>(~all_bits);
     if (and_result == 43520 && or_result == 65450 && xor_result == 21930 && not_result == 21845) {
         if (bin_and == 43520 && dec_and == 43520 && dec_or == 65450 && not_all == 0) {
             return 0;

--- a/tests/bitwise/u64-bitwise-ops.expected.c
+++ b/tests/bitwise/u64-bitwise-ops.expected.c
@@ -16,13 +16,13 @@ int main(void) {
     uint64_t or_result = a | b;
     uint64_t xor_result = a ^ b;
     uint64_t c = 0xAAAAAAAAAAAAAAAAULL;
-    uint64_t not_result = ~c;
+    uint64_t not_result = (uint64_t)~c;
     uint64_t small_a = 0xFFA0ULL;
     uint64_t small_b = 0xAAULL;
     uint64_t small_and = small_a & small_b;
     uint64_t small_or = small_a | small_b;
     uint64_t all_bits = 0xFFFFFFFFFFFFFFFFULL;
-    uint64_t not_all = ~all_bits;
+    uint64_t not_all = (uint64_t)~all_bits;
     uint64_t lower32 = 0x12345678ULL;
     uint64_t mask32 = 0x00000000FFFFFFFFULL;
     uint64_t masked = lower32 & mask32;

--- a/tests/bitwise/u64-bitwise-ops.expected.cpp
+++ b/tests/bitwise/u64-bitwise-ops.expected.cpp
@@ -16,13 +16,13 @@ int main(void) {
     uint64_t or_result = a | b;
     uint64_t xor_result = a ^ b;
     uint64_t c = 0xAAAAAAAAAAAAAAAAULL;
-    uint64_t not_result = ~c;
+    uint64_t not_result = static_cast<uint64_t>(~c);
     uint64_t small_a = 0xFFA0ULL;
     uint64_t small_b = 0xAAULL;
     uint64_t small_and = small_a & small_b;
     uint64_t small_or = small_a | small_b;
     uint64_t all_bits = 0xFFFFFFFFFFFFFFFFULL;
-    uint64_t not_all = ~all_bits;
+    uint64_t not_all = static_cast<uint64_t>(~all_bits);
     uint64_t lower32 = 0x12345678ULL;
     uint64_t mask32 = 0x00000000FFFFFFFFULL;
     uint64_t masked = lower32 & mask32;

--- a/tests/bitwise/u64-bitwise-ops.test.c
+++ b/tests/bitwise/u64-bitwise-ops.test.c
@@ -16,13 +16,13 @@ int main(void) {
     uint64_t or_result = a | b;
     uint64_t xor_result = a ^ b;
     uint64_t c = 0xAAAAAAAAAAAAAAAAULL;
-    uint64_t not_result = ~c;
+    uint64_t not_result = (uint64_t)~c;
     uint64_t small_a = 0xFFA0ULL;
     uint64_t small_b = 0xAAULL;
     uint64_t small_and = small_a & small_b;
     uint64_t small_or = small_a | small_b;
     uint64_t all_bits = 0xFFFFFFFFFFFFFFFFULL;
-    uint64_t not_all = ~all_bits;
+    uint64_t not_all = (uint64_t)~all_bits;
     uint64_t lower32 = 0x12345678ULL;
     uint64_t mask32 = 0x00000000FFFFFFFFULL;
     uint64_t masked = lower32 & mask32;

--- a/tests/bitwise/u64-bitwise-ops.test.cpp
+++ b/tests/bitwise/u64-bitwise-ops.test.cpp
@@ -16,13 +16,13 @@ int main(void) {
     uint64_t or_result = a | b;
     uint64_t xor_result = a ^ b;
     uint64_t c = 0xAAAAAAAAAAAAAAAAULL;
-    uint64_t not_result = ~c;
+    uint64_t not_result = static_cast<uint64_t>(~c);
     uint64_t small_a = 0xFFA0ULL;
     uint64_t small_b = 0xAAULL;
     uint64_t small_and = small_a & small_b;
     uint64_t small_or = small_a | small_b;
     uint64_t all_bits = 0xFFFFFFFFFFFFFFFFULL;
-    uint64_t not_all = ~all_bits;
+    uint64_t not_all = static_cast<uint64_t>(~all_bits);
     uint64_t lower32 = 0x12345678ULL;
     uint64_t mask32 = 0x00000000FFFFFFFFULL;
     uint64_t masked = lower32 & mask32;

--- a/tests/bitwise/u8-bitwise-ops.expected.c
+++ b/tests/bitwise/u8-bitwise-ops.expected.c
@@ -16,7 +16,7 @@ int main(void) {
     uint8_t or_result = a | b;
     uint8_t xor_result = a ^ b;
     uint8_t c = 0b10101010U;
-    uint8_t not_result = ~c;
+    uint8_t not_result = (uint8_t)~c;
     uint8_t hex_a = 0xF0U;
     uint8_t hex_b = 0xAAU;
     uint8_t hex_and = hex_a & hex_b;

--- a/tests/bitwise/u8-bitwise-ops.expected.cpp
+++ b/tests/bitwise/u8-bitwise-ops.expected.cpp
@@ -16,7 +16,7 @@ int main(void) {
     uint8_t or_result = a | b;
     uint8_t xor_result = a ^ b;
     uint8_t c = 0b10101010U;
-    uint8_t not_result = ~c;
+    uint8_t not_result = static_cast<uint8_t>(~c);
     uint8_t hex_a = 0xF0U;
     uint8_t hex_b = 0xAAU;
     uint8_t hex_and = hex_a & hex_b;

--- a/tests/bitwise/u8-bitwise-ops.test.c
+++ b/tests/bitwise/u8-bitwise-ops.test.c
@@ -16,7 +16,7 @@ int main(void) {
     uint8_t or_result = a | b;
     uint8_t xor_result = a ^ b;
     uint8_t c = 0b10101010U;
-    uint8_t not_result = ~c;
+    uint8_t not_result = (uint8_t)~c;
     uint8_t hex_a = 0xF0U;
     uint8_t hex_b = 0xAAU;
     uint8_t hex_and = hex_a & hex_b;

--- a/tests/bitwise/u8-bitwise-ops.test.cpp
+++ b/tests/bitwise/u8-bitwise-ops.test.cpp
@@ -16,7 +16,7 @@ int main(void) {
     uint8_t or_result = a | b;
     uint8_t xor_result = a ^ b;
     uint8_t c = 0b10101010U;
-    uint8_t not_result = ~c;
+    uint8_t not_result = static_cast<uint8_t>(~c);
     uint8_t hex_a = 0xF0U;
     uint8_t hex_b = 0xAAU;
     uint8_t hex_and = hex_a & hex_b;


### PR DESCRIPTION
## Summary

- Cast `~expr` back to its original unsigned type when the operand is an unsigned type (u8, u16, u32, u64), preventing MISRA C:2012 Rule 10.1/10.3 violations caused by C's integer promotion rules
- C mode: `~c` → `(uint8_t)~c`; C++ mode: `~c` → `static_cast<uint8_t>(~c)`
- Signed types and unresolvable types (e.g., literals) are unchanged

## Test plan

- [x] 8 new unit tests for UnaryExprGenerator (unsigned cast, signed no-cast, unresolvable no-cast, C++ mode)
- [x] All 975 integration tests pass
- [x] All 5468 unit tests pass
- [x] `cppcheck --addon=misra` reports no violations on `tests/bitwise/complex-combinations.test.c` (the original trigger case)
- [x] No new MISRA validation failures introduced

Closes #915

🤖 Generated with [Claude Code](https://claude.com/claude-code)