### PR TITLE
Release v0.2.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.8] - 2026-02-23
+
+### Fixed
+
+- Pass callback-promoted params directly to pointer-expecting functions (Issue #937)
+- Remove stale binary .o file from test artifacts (Issue #937)
+
+### Tests
+
+- Add unit test for callback-promoted parameter passing (Issue #937)
+
 ## [0.2.7] - 2026-02-23
 
 ### Added
@@ -1129,7 +1140,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - 38 legacy ESLint errors (non-blocking, tracked for future cleanup)
 
-[Unreleased]: https://github.com/jlaustill/c-next/compare/v0.2.6...HEAD
+[Unreleased]: https://github.com/jlaustill/c-next/compare/v0.2.8...HEAD
+[0.2.8]: https://github.com/jlaustill/c-next/compare/v0.2.7...v0.2.8
 [0.2.7]: https://github.com/jlaustill/c-next/compare/v0.2.6...v0.2.7
 [0.2.6]: https://github.com/jlaustill/c-next/compare/v0.2.5...v0.2.6
 [0.2.5]: https://github.com/jlaustill/c-next/compare/v0.2.4...v0.2.5

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "c-next",
-  "version": "0.2.7",
+  "version": "0.2.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "c-next",
-      "version": "0.2.7",
+      "version": "0.2.8",
       "license": "MIT",
       "dependencies": {
         "@n1ru4l/toposort": "^0.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "c-next",
-  "version": "0.2.7",
+  "version": "0.2.8",
   "description": "A safer C for embedded systems development. Transpiles to clean, readable C.",
   "packageManager": "npm@11.9.0",
   "type": "module",


### PR DESCRIPTION
## Summary

- Fix callback-promoted params being incorrectly dereferenced when passed to pointer-expecting functions (Issue #937)
- Remove stale binary `.o` file from test artifacts
- Add unit test for callback-promoted parameter passing

## Test plan

- [x] All 941 integration tests pass
- [x] Unit tests pass
- [x] Pre-push quality checks (prettier, spelling, oxlint, dead code, typecheck, grammar coverage) all pass
- [x] Version bumped to 0.2.8
- [x] CHANGELOG updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)