### PR TITLE
Release v0.2.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.9] - 2026-02-23
+
+### Fixed
+
+- Unify include extension path - produce correct `.hpp` extension in C++ mode (Issue #941)
+- Revert unintended behavioral change - bare enums in function args require qualified access (Issue #872)
+
+### Tests
+
+- Add C/C++ parity checking for dual-mode tests (Issue #922)
+
+### Changed
+
+- Remove unreachable edge case in formatParityError
+
 ## [0.2.8] - 2026-02-23
 
 ### Fixed
@@ -1140,7 +1155,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - 38 legacy ESLint errors (non-blocking, tracked for future cleanup)
 
-[Unreleased]: https://github.com/jlaustill/c-next/compare/v0.2.8...HEAD
+[Unreleased]: https://github.com/jlaustill/c-next/compare/v0.2.9...HEAD
+[0.2.9]: https://github.com/jlaustill/c-next/compare/v0.2.8...v0.2.9
 [0.2.8]: https://github.com/jlaustill/c-next/compare/v0.2.7...v0.2.8
 [0.2.7]: https://github.com/jlaustill/c-next/compare/v0.2.6...v0.2.7
 [0.2.6]: https://github.com/jlaustill/c-next/compare/v0.2.5...v0.2.6

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "c-next",
-  "version": "0.2.8",
+  "version": "0.2.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "c-next",
-      "version": "0.2.8",
+      "version": "0.2.9",
       "license": "MIT",
       "dependencies": {
         "@n1ru4l/toposort": "^0.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "c-next",
-  "version": "0.2.8",
+  "version": "0.2.9",
   "description": "A safer C for embedded systems development. Transpiles to clean, readable C.",
   "packageManager": "npm@11.9.0",
   "type": "module",


### PR DESCRIPTION
## Summary

- Fix `.hpp` include extension in C++ mode (Issue #941)
- Fix bare enum behavior in function args (Issue #872)
- Add C/C++ parity checking for dual-mode tests (Issue #922)

## Test plan

- [x] All 941 integration tests pass
- [x] Pre-push quality checks pass
- [ ] Review CHANGELOG entries

🤖 Generated with [Claude Code](https://claude.ai/code)