### PR TITLE
chore: release v0.2.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.11] - 2026-02-24
+
+### Fixed
+
+- Pointer typedefs (`typedef struct X *Y`) incorrectly marked as opaque (Issue #957)
+- Complete struct types with cross-file definitions generate by-value instead of by-pointer (Issue #958)
+
+### Changed
+
+- Refactor StructCollector to use options objects for cleaner parameter passing
+
 ## [0.2.10] - 2026-02-24
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "c-next",
-  "version": "0.2.10",
+  "version": "0.2.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "c-next",
-      "version": "0.2.10",
+      "version": "0.2.11",
       "license": "MIT",
       "dependencies": {
         "@n1ru4l/toposort": "^0.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "c-next",
-  "version": "0.2.10",
+  "version": "0.2.11",
   "description": "A safer C for embedded systems development. Transpiles to clean, readable C.",
   "packageManager": "npm@11.9.0",
   "type": "module",


### PR DESCRIPTION
## Release v0.2.11

### Fixed

- Pointer typedefs (`typedef struct X *Y`) incorrectly marked as opaque (Issue #957)
- Complete struct types with cross-file definitions generate by-value instead of by-pointer (Issue #958)

### Changed

- Refactor StructCollector to use options objects for cleaner parameter passing

---

**Full Changelog**: https://github.com/jlaustill/c-next/compare/v0.2.10...release/v0.2.11

🤖 Generated with [Claude Code](https://claude.com/claude-code)