### PR TITLE
fix: exclude scoped C-Next symbols from cross-language conflict detection (issue #967)

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -357,7 +357,9 @@
     "LVGL",
     "FreeRTOS",
     "unmarks",
-    "unmarking"
+    "unmarking",
+    "pthread",
+    "ssize"
   ],
   "ignorePaths": [
     "node_modules/**",


### PR DESCRIPTION
## Summary

- Fix false symbol conflicts between scoped C-Next methods and C functions
- Scoped symbols live in a namespace and don't compete with C's global symbols

## Problem

With caching enabled, compiling files that include LVGL headers failed with:
```
Symbol conflict: 'read' is defined in multiple languages:
  CNEXT (touch_cst820.cnx:28)
  C (lv_pthread.h:80)
```

`Touch.read()` transpiles to `Touch_read()` which doesn't conflict with POSIX `read()`, but the conflict detection compared bare names.

## Solution

Filter C-Next symbols by `scope.name === ""` (global scope) before cross-language conflict checks. Scoped symbols are in a namespace and cannot conflict with C's global symbols.

This keeps the logic on the input/semantic layer rather than computing output names.

## Test plan

- [x] Added unit test: scoped C-Next method vs C function → no conflict
- [x] Added unit test: global C-Next function vs C function → conflict detected
- [x] All 5552 unit tests pass
- [x] All 950 integration tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)