### PR TITLE
Release v0.2.14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.14] - 2026-02-26
+
+### Fixed
+
+- Generated `.hpp` headers incorrectly used `.h` extension for `.cnx` include directives in C++ mode (PR #976)
+- `--pio-install` generated build script used outdated per-file glob pattern instead of entry-point approach (PR #976)
+- CLI help text and ADR docs updated to reflect single entry-point usage (PR #976)
+
 ## [0.2.13] - 2026-02-25
 
 ### Added
@@ -1223,6 +1231,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - 38 legacy ESLint errors (non-blocking, tracked for future cleanup)
 
 [Unreleased]: https://github.com/jlaustill/c-next/compare/v0.2.13...HEAD
+[0.2.14]: https://github.com/jlaustill/c-next/compare/v0.2.13...v0.2.14
 [0.2.13]: https://github.com/jlaustill/c-next/compare/v0.2.12...v0.2.13
 [0.2.12]: https://github.com/jlaustill/c-next/compare/v0.2.11...v0.2.12
 [0.2.11]: https://github.com/jlaustill/c-next/compare/v0.2.10...v0.2.11

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "c-next",
-  "version": "0.2.13",
+  "version": "0.2.14",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "c-next",
-      "version": "0.2.13",
+      "version": "0.2.14",
       "license": "MIT",
       "dependencies": {
         "@n1ru4l/toposort": "^0.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "c-next",
-  "version": "0.2.13",
+  "version": "0.2.14",
   "description": "A safer C for embedded systems development. Transpiles to clean, readable C.",
   "packageManager": "npm@11.9.0",
   "type": "module",


### PR DESCRIPTION
## Summary
- Patch release fixing `.hpp` include extension bugs and PlatformIO tooling

## Changes (from PR #976)
- **Fix**: Generated `.hpp` headers used `.h` for `.cnx` include directives in C++ mode
- **Fix**: `--pio-install` generated build script used outdated per-file glob pattern
- **Fix**: CLI help text and ADR docs updated for single entry-point usage

## Test plan
- [x] All pre-push quality checks pass
- [x] 950/950 integration tests pass
- [x] 5564 unit tests pass
- [x] Version bumped to 0.2.14
- [x] CHANGELOG updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)