### PR TITLE
chore: release v0.2.15

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.15] - 2026-02-26
+
+### Fixed
+
+- External global struct variables passed by value instead of by reference when calling C functions expecting pointers (Issue #978, PR #979)
+- C variable resolver now detects pointer types from declarators, preventing incorrect `&` insertion on pointer-typed extern variables (PR #979)
+
 ## [0.2.14] - 2026-02-26
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "c-next",
-  "version": "0.2.14",
+  "version": "0.2.15",
   "description": "A safer C for embedded systems development. Transpiles to clean, readable C.",
   "packageManager": "npm@11.9.0",
   "type": "module",


### PR DESCRIPTION
## Summary
- Bump version to 0.2.15
- Update CHANGELOG with fix for issue #978 (extern struct globals passed by value instead of by reference)

## Changes since v0.2.14
- fix: insert address-of for extern struct globals passed to pointer params (#978, PR #979)
- fix: C variable resolver detects pointer types from declarators (PR #979)

🤖 Generated with [Claude Code](https://claude.com/claude-code)