### PR TITLE
Release v0.2.16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.16] - 2026-02-28
+
+### Changed
+
+- Scope visibility defaults now member-type-aware: functions are public by default, variables/types are private by default (ADR-016, PR #983)
+
+### Fixed
+
+- Macro-sized array dimensions in C struct fields now parsed correctly (Issue #981)
+
 ## [0.2.15] - 2026-02-26
 
 ### Fixed
@@ -1237,7 +1247,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - 38 legacy ESLint errors (non-blocking, tracked for future cleanup)
 
-[Unreleased]: https://github.com/jlaustill/c-next/compare/v0.2.13...HEAD
+[Unreleased]: https://github.com/jlaustill/c-next/compare/v0.2.16...HEAD
+[0.2.16]: https://github.com/jlaustill/c-next/compare/v0.2.15...v0.2.16
+[0.2.15]: https://github.com/jlaustill/c-next/compare/v0.2.14...v0.2.15
 [0.2.14]: https://github.com/jlaustill/c-next/compare/v0.2.13...v0.2.14
 [0.2.13]: https://github.com/jlaustill/c-next/compare/v0.2.12...v0.2.13
 [0.2.12]: https://github.com/jlaustill/c-next/compare/v0.2.11...v0.2.12

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "c-next",
-  "version": "0.2.15",
+  "version": "0.2.16",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "c-next",
-      "version": "0.2.15",
+      "version": "0.2.16",
       "license": "MIT",
       "dependencies": {
         "@n1ru4l/toposort": "^0.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "c-next",
-  "version": "0.2.15",
+  "version": "0.2.16",
   "description": "A safer C for embedded systems development. Transpiles to clean, readable C.",
   "packageManager": "npm@11.9.0",
   "type": "module",


### PR DESCRIPTION
## Release v0.2.16

### Changed

- Scope visibility defaults now member-type-aware: functions are public by default, variables/types are private by default (ADR-016, PR #983)

### Fixed

- Macro-sized array dimensions in C struct fields now parsed correctly (Issue #981)

## Release Checklist

- [x] Version bumped in `package.json`
- [x] `package-lock.json` updated
- [x] CHANGELOG.md updated with release date
- [x] All tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)