### PR TITLE
docs: make "if you touch it, you fix it" explicit for duplicate code paths

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,9 +21,12 @@ There are NO exceptions. Do not ignore, dismiss, or defer bugs without creating 
 
 **NEVER create or perpetuate duplicate code paths.** If changing something in one place requires a corresponding change in another place, that is a bug in the architecture. Fix it immediately.
 
+**This applies whether the duplication is newly introduced OR pre-existing — if you touch code containing a duplicate path, you fix it.** "It pre-dates this change," "it follows an existing pattern," and "it's really just a misleading comment" are NOT reasons to defer, downgrade, or merge around it. Touching it means owning it.
+
 - If two interfaces need the same fields, extract a shared type or push the data onto the shared model (e.g., `IParameterSymbol`)
 - If two code paths must produce identical output, they MUST share the same logic — not copy it
 - When fixing a bug caused by divergent paths, **unify the paths** rather than patching both independently
+- **Single source of truth means the _decision_, not just the data.** Sharing one detection function (or setting one flag on a shared model) is NOT enough if each path then re-derives the _consequences_ independently. Paths that agree only "by coincidence" — e.g. because some unrelated predicate currently happens to hold — are a latent divergence, not a unified path
 - **Example (Issue #914):** `.c` and `.h` generation had separate callback-handling logic. The fix resolved callback info ONCE onto `IParameterSymbol`, eliminating the duplicate path entirely
 
 Having to update something in 2 places instead of 1 is the WORST anti-pattern in this project. When you find it, fix it.


### PR DESCRIPTION
## Summary

Strengthens the **No Duplicate Code Paths — ZERO EXCEPTIONS** rule in `CLAUDE.md` so it explicitly covers *pre-existing* duplication and the "single source of truth is the decision, not just the data" distinction.

The rule already said "never create **or perpetuate**," but "perpetuate" left enough ambiguity that a reviewer (human or agent) could rationalize deferring a pre-existing duplicate path when touching it — "it pre-dates this change," "it follows an existing pattern," "it's just a misleading comment."

## Why (evidence)

While reviewing PR #1001 I initially downgraded an in-diff dual code path to "documentation accuracy" and excused it as following prior precedent — exactly the rationalization this clause forbids. To check whether the gap was in tooling or in the wording, I ran a controlled experiment: the same subtle dual-path diff reviewed under four configurations.

| Scenario | Rule wording | Result |
| --- | --- | --- |
| Blatant duplication | explicit | Important / fix |
| Subtle, divergence handed to reviewer | explicit "if you touch it" | Important / fix |
| Subtle, must discover divergence | explicit "if you touch it" | Important / request changes |
| Subtle, must discover | **current (implicit) wording** | softened → "Moderate / track a follow-up" |

The only variable that moved reviewers from "fix before merge" to "defer to a follow-up" was the rule's explicitness about pre-existing duplication. This PR closes that gap.

## Changes

- Add an explicit sentence: applies whether duplication is newly introduced **or** pre-existing; "pre-existing," "follows an existing pattern," and "just a misleading comment" are not reasons to defer/downgrade.
- Add a bullet clarifying that **single source of truth means the *decision*, not just the data** — sharing one detection function or one flag is not enough if each path re-derives the consequences; paths that agree only "by coincidence" are a latent divergence.

Documentation only — no code, behavior, or C-Next syntax change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)