### PR TITLE
fix: add test-link marker for issue-986 helper file

### DIFF
--- a/bugs/issue-986-const-array-param/const-array-param.expected.c
+++ b/bugs/issue-986-const-array-param/const-array-param.expected.c
@@ -6,6 +6,7 @@
 #include "const-array-param.test.h"
 
 // test-execution
+// test-link: fake_lib.c
 // Issue #986: Array params transpile as const when passed to C APIs
 // ADR-006 says all params are pass-by-reference as mutable, but array params
 // that are not directly modified get auto-const, breaking C API compatibility.

--- a/bugs/issue-986-const-array-param/const-array-param.expected.cpp
+++ b/bugs/issue-986-const-array-param/const-array-param.expected.cpp
@@ -6,6 +6,7 @@
 #include "const-array-param.test.hpp"
 
 // test-execution
+// test-link: fake_lib.c
 // Issue #986: Array params transpile as const when passed to C APIs
 // ADR-006 says all params are pass-by-reference as mutable, but array params
 // that are not directly modified get auto-const, breaking C API compatibility.
@@ -20,7 +21,7 @@ void Handler_process(uint8_t data[8]) {
 }
 
 int main(void) {
-    uint8_t buffer[8] = {0};
+    uint8_t buffer[8] = {};
     buffer[0] = 0U;
     buffer[1] = 0U;
     Handler_process(buffer);

--- a/bugs/issue-986-const-array-param/const-array-param.test.c
+++ b/bugs/issue-986-const-array-param/const-array-param.test.c
@@ -6,6 +6,7 @@
 #include "const-array-param.test.h"
 
 // test-execution
+// test-link: fake_lib.c
 // Issue #986: Array params transpile as const when passed to C APIs
 // ADR-006 says all params are pass-by-reference as mutable, but array params
 // that are not directly modified get auto-const, breaking C API compatibility.

--- a/bugs/issue-986-const-array-param/const-array-param.test.cnx
+++ b/bugs/issue-986-const-array-param/const-array-param.test.cnx
@@ -1,4 +1,5 @@
 // test-execution
+// test-link: fake_lib.c
 // Issue #986: Array params transpile as const when passed to C APIs
 // ADR-006 says all params are pass-by-reference as mutable, but array params
 // that are not directly modified get auto-const, breaking C API compatibility.

--- a/bugs/issue-986-const-array-param/const-array-param.test.cpp
+++ b/bugs/issue-986-const-array-param/const-array-param.test.cpp
@@ -6,6 +6,7 @@
 #include "const-array-param.test.hpp"
 
 // test-execution
+// test-link: fake_lib.c
 // Issue #986: Array params transpile as const when passed to C APIs
 // ADR-006 says all params are pass-by-reference as mutable, but array params
 // that are not directly modified get auto-const, breaking C API compatibility.
@@ -20,7 +21,7 @@ void Handler_process(uint8_t data[8]) {
 }
 
 int main(void) {
-    uint8_t buffer[8] = {0};
+    uint8_t buffer[8] = {};
     buffer[0] = 0U;
     buffer[1] = 0U;
     Handler_process(buffer);


### PR DESCRIPTION
## Summary

Closes #1006

Fixes the linker error in the `issue-986-const-array-param` regression test by using the test framework's existing `// test-link:` marker.

## Problem

The test calls `process_data()` which is implemented in a sibling `fake_lib.c` file, but the test framework wasn't linking that file:

```
/usr/bin/ld: undefined reference to `process_data'
collect2: error: ld returned 1 exit status
```

## Solution

The test framework already supports linking additional C files via a `// test-link:` marker (see `TestUtils.findLinkedSourceFiles()` in test-utils.ts:588-601). This marker tells the runner to compile and link the specified files during test execution.

Added the marker to the test:
```c-next
// test-execution
// test-link: fake_lib.c
```

## Verification

The #986 fix (array params not marked as const when passed to C APIs) is now fully verified at runtime:
- `Handler_process()` receives `uint8_t data[8]` (not `const uint8_t data[8]`)
- Calls `process_data(data)` which modifies the buffer
- Test verifies the modifications persist

## Test plan

- [x] `npm test -- bugs/issue-986-const-array-param` passes with [C+C++ PARITY]
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)