### PR TITLE
Release v0.2.17

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.17] - 2026-06-21
+
+### Changed
+
+- Array declarations now reject C-style bracket syntax — trailing `[N]` and multi-dimensional `[N][M]` brackets are errors; use C-Next prefix array syntax (Issues #1014–#1017)
+- `break` and `continue` are now rejected; they are not part of the C-Next spec (Issue #1011)
+- Float division/modulo by a literal zero is now a compile error (E0800, Issue #1010)
+- Signed compound shift-assignment (`<<<-`, `>><-`) is now rejected (E0805, Issue #1008)
+- Use-before-init analysis (E0381) now covers compound assignments and struct-member compound shift-assignments
+
+### Fixed
+
+- String variable initialization now generates `strcpy` rather than an invalid direct assignment (Issue #1030)
+- `string<N>[M]` arrays register type info and generate correct dimensions (Issue #1029)
+- Scope-member string initialization and use-before-init handled correctly (Issue #1019)
+- Scoped-type arrays now allowed in struct fields (Issue #1038)
+- Size inference corrected for prefix `arrayType` syntax
+- Arrays of opaque handles no longer mis-generate initialization or element address-of (Issue #996)
+- Array parameters no longer receive automatic `const`, per ADR-006 (Issue #986)
+- Opaque-handle parameters: type resolved onto the parameter symbol so `.c` and `.h` paths agree; auto-const skipped (Issue #995)
+- Signed comparison literals and C++ callback typedefs generate correctly (Issue #1032)
+- C++ struct/array zero-initialization emits `{}` instead of `{0}` (Issue #1004)
+- `atomic` scope variables emit the `volatile` modifier (Issue #998)
+- Undeclared `global.` function calls are detected, and `global.`-prefixed locals report "called before definition" (Issue #985)
+- Global struct initializers emitted as constants; declarations use designated initializers instead of compound literals
+- Value semantics restored via query-time resolution (Issue #948)
+- MISRA: clamp minimum cast to the target unsigned type; `floatConversionOverflow` false positive suppressed in the MISRA runner (Issue #990)
+
 ## [0.2.16] - 2026-02-28
 
 ### Changed
@@ -1248,6 +1276,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - 38 legacy ESLint errors (non-blocking, tracked for future cleanup)
 
 [Unreleased]: https://github.com/jlaustill/c-next/compare/v0.2.16...HEAD
+[0.2.17]: https://github.com/jlaustill/c-next/compare/v0.2.16...v0.2.17
 [0.2.16]: https://github.com/jlaustill/c-next/compare/v0.2.15...v0.2.16
 [0.2.15]: https://github.com/jlaustill/c-next/compare/v0.2.14...v0.2.15
 [0.2.14]: https://github.com/jlaustill/c-next/compare/v0.2.13...v0.2.14

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "c-next",
-  "version": "0.2.16",
+  "version": "0.2.17",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "c-next",
-      "version": "0.2.16",
+      "version": "0.2.17",
       "license": "MIT",
       "dependencies": {
         "@n1ru4l/toposort": "^0.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "c-next",
-  "version": "0.2.16",
+  "version": "0.2.17",
   "description": "A safer C for embedded systems development. Transpiles to clean, readable C.",
   "packageManager": "npm@11.9.0",
   "type": "module",


### PR DESCRIPTION
## Release v0.2.17 (patch)

Bumps `0.2.16 → 0.2.17` and populates the previously-empty CHANGELOG `[Unreleased]` section from 96 commits of merged work (**42 fixes; zero `feat:`, zero breaking-by-design → patch**).

### Highlights (full list in the CHANGELOG diff)

**Changed — stricter validation** (code that used to compile may now error):
- Reject C-style array brackets `[N]` / `[N][M]` (#1014–#1017)
- Reject `break` / `continue` — not part of the spec (#1011)
- Float division/modulo by literal zero → compile error E0800 (#1010)
- Reject signed compound shift-assign `<<<-` / `>><-` → E0805 (#1008)
- Extend use-before-init (E0381) to compound + struct-member shift-assign

**Fixed:** string `strcpy` init (#1030), `string<N>[M]` arrays (#1029), scope-member string init (#1019), scoped-type arrays in struct fields (#1038), opaque-handle params/arrays (#995, #996), array-param auto-const per ADR-006 (#986), C++ zero-init `{}` not `{0}` (#1004), `atomic`→`volatile` (#998), `global.` call resolution (#985), and more.

### Verification

| Gate | Result |
|------|--------|
| `npm test` (integration) | ✅ 966 passed, 0 failed |
| `npm run typecheck` | ✅ clean |
| `npm run analyze` | ⚠️ 1 error — pre-existing, see below |

`npm run analyze` reports a `missingReturn` error in generated `examples/teensy4/blink.c`. This is a **pre-existing** C-Next gap (no all-paths-return diagnostic), red since **2026-01-03** — every `v0.2.x` release shipped with it. It is **not a regression** from this release and is now tracked in **#1040** (with a minimal repro). Fixing it is a behavior change requiring an ADR, scoped to a future minor; the broken example is intentionally left red until then.

### After merge — tag to publish

```bash
git checkout main && git pull
git tag v0.2.17 && git push origin v0.2.17   # CI auto-publishes to npm
```

This PR is the version + CHANGELOG cut only; the 42 referenced issues were already closed via their individual fix PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
