### PR TITLE
docs: promote ADR-112 (all-paths-return) to Implemented

### DIFF
--- a/docs/architecture-decisions.md
+++ b/docs/architecture-decisions.md
@@ -46,14 +46,14 @@ ADRs are stored in [`docs/decisions/`](decisions/) and document significant desi
 | [ADR-057](decisions/adr-057-implicit-scope-resolution.md)        | Implicit Scope Resolution  | Bare identifiers resolve local -> scope -> global            |
 | [ADR-055](decisions/adr-055-symbol-parser-architecture.md)       | Symbol Parser Architecture | Unified symbol resolution with composable collectors         |
 | [ADR-058](decisions/adr-058-explicit-length-properties.md)       | Explicit Length Properties | `.bit_length`/`.byte_length`/`.element_count`/`.char_count`  |
+| [ADR-112](decisions/adr-112-all-paths-return.md)                 | All-Paths-Return           | Reject non-void functions that can fall off the end (E0704)  |
 
 ## Accepted
 
-| ADR                                                             | Title                 | Description                                                 |
-| --------------------------------------------------------------- | --------------------- | ----------------------------------------------------------- |
-| [ADR-051](decisions/adr-051-division-by-zero.md)                | Division by Zero      | Compile-time and runtime division-by-zero detection         |
-| [ADR-052](decisions/adr-052-safe-numeric-literal-generation.md) | Safe Numeric Literals | `type_MIN`/`type_MAX` constants + safe hex conversion       |
-| [ADR-112](decisions/adr-112-all-paths-return.md)                | All-Paths-Return      | Reject non-void functions that can fall off the end (E0704) |
+| ADR                                                             | Title                 | Description                                           |
+| --------------------------------------------------------------- | --------------------- | ----------------------------------------------------- |
+| [ADR-051](decisions/adr-051-division-by-zero.md)                | Division by Zero      | Compile-time and runtime division-by-zero detection   |
+| [ADR-052](decisions/adr-052-safe-numeric-literal-generation.md) | Safe Numeric Literals | `type_MIN`/`type_MAX` constants + safe hex conversion |
 
 ## Superseded
 

--- a/docs/decisions/adr-112-all-paths-return.md
+++ b/docs/decisions/adr-112-all-paths-return.md
@@ -1,6 +1,6 @@
 # ADR-112: All-Paths-Return Diagnostic
 
-**Status:** Accepted
+**Status:** Implemented
 **Date:** 2026-06-25
 **Decision Makers:** Language Design Team
 **Related ADRs:** ADR-022 (Conditional Expressions), ADR-025 (Switch Statements), ADR-026 (Break and Continue), ADR-027 (Do-While)


### PR DESCRIPTION
Per maintainer direction, now that the E0704 all-paths-return diagnostic has shipped (#1049), promote **ADR-112** from `Accepted` to `Implemented`.

- `docs/decisions/adr-112-all-paths-return.md`: **Status: Accepted → Implemented**
- `docs/architecture-decisions.md`: moved ADR-112 from the *Accepted* section to *Implemented* (sync order: ADR file first, then index).

Docs-only; no code or behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)