### PR TITLE
docs: ADR-113 (forever loops) + ADR-114 (dead-code/reachability)

### DIFF
--- a/docs/architecture-decisions.md
+++ b/docs/architecture-decisions.md
@@ -63,15 +63,17 @@ ADRs are stored in [`docs/decisions/`](decisions/) and document significant desi
 
 ## Research (v1 Roadmap)
 
-| ADR                                                         | Title                         | Description                                      |
-| ----------------------------------------------------------- | ----------------------------- | ------------------------------------------------ |
-| [ADR-008](decisions/adr-008-language-bug-prevention.md)     | Language-Level Bug Prevention | Top 15 embedded bugs and prevention              |
-| [ADR-009](decisions/adr-009-isr-safety.md)                  | ISR Safety                    | Safe interrupts without `unsafe` blocks          |
-| [ADR-054](decisions/adr-054-array-index-overflow.md)        | Array Index Overflow          | Overflow semantics for array index expressions   |
-| [ADR-056](decisions/adr-056-cast-overflow-behavior.md)      | Cast Overflow Behavior        | Consistent overflow semantics for type casts     |
-| [ADR-060](decisions/adr-060-vscode-extension-separation.md) | VS Code Extension Separation  | Separate repository for VS Code extension        |
-| [ADR-109](decisions/adr-109-codegenerator-decomposition.md) | CodeGenerator Decomposition   | Breaking down CodeGenerator into modules         |
-| [ADR-110](decisions/adr-110-do178c-compliance.md)           | DO-178C Compliance            | Safety-critical software certification framework |
+| ADR                                                         | Title                         | Description                                       |
+| ----------------------------------------------------------- | ----------------------------- | ------------------------------------------------- |
+| [ADR-008](decisions/adr-008-language-bug-prevention.md)     | Language-Level Bug Prevention | Top 15 embedded bugs and prevention               |
+| [ADR-009](decisions/adr-009-isr-safety.md)                  | ISR Safety                    | Safe interrupts without `unsafe` blocks           |
+| [ADR-054](decisions/adr-054-array-index-overflow.md)        | Array Index Overflow          | Overflow semantics for array index expressions    |
+| [ADR-056](decisions/adr-056-cast-overflow-behavior.md)      | Cast Overflow Behavior        | Consistent overflow semantics for type casts      |
+| [ADR-060](decisions/adr-060-vscode-extension-separation.md) | VS Code Extension Separation  | Separate repository for VS Code extension         |
+| [ADR-109](decisions/adr-109-codegenerator-decomposition.md) | CodeGenerator Decomposition   | Breaking down CodeGenerator into modules          |
+| [ADR-110](decisions/adr-110-do178c-compliance.md)           | DO-178C Compliance            | Safety-critical software certification framework  |
+| [ADR-113](decisions/adr-113-forever-loops.md)               | Forever Loops                 | `forever { }` divergent infinite loop (void-only) |
+| [ADR-114](decisions/adr-114-dead-code-reachability.md)      | Dead-Code / Reachability      | Reject unreachable code (MISRA 2.1/2.2, DO-178C)  |
 
 ## Research (v2 Roadmap)
 

--- a/docs/decisions/adr-113-forever-loops.md
+++ b/docs/decisions/adr-113-forever-loops.md
@@ -145,7 +145,7 @@ ADRs sharing a single divergence primitive**:
   pass (unreachable code after `return`, after fully-returning `if`/`else`, etc.). It is a
   **breaking** change and is independently motivated by MISRA 2.1/2.2 and DO-178C.
 
-Holding to one shared primitive (rather than ADR-114 re-deriving reachability) is required by
+Adhering to a single shared primitive (rather than ADR-114 re-deriving reachability) is required by
 the project's "No Duplicate Code Paths" rule.
 
 ## Migration Impact
@@ -193,6 +193,9 @@ transpiles correctly.)
   rewrite and the `void` conversion?
 - **Grammar placement:** add `foreverStatement` as a new alternative in the `statement` rule
   (alongside `whileStatement`/`forStatement`); new keyword token `FOREVER`.
+- **Back-reference ADR-112.** When this ADR is accepted/implemented, update ADR-112's
+  _Related ADRs_ to include ADR-113 — this ADR introduces the "divergent statement" concept into
+  ADR-112's `definitelyReturns` machinery. (Documentation counterpart, not a code change.)
 
 ## References
 

--- a/docs/decisions/adr-113-forever-loops.md
+++ b/docs/decisions/adr-113-forever-loops.md
@@ -1,0 +1,203 @@
+# ADR-113: Forever Loops
+
+**Status:** Research
+**Date:** 2026-06-26
+**Decision Makers:** Language Design Team
+**Related ADRs:** ADR-026 (Break and Continue), ADR-027 (Do-While), ADR-112 (All-Paths-Return), ADR-114 (Dead-Code / Reachability Analysis)
+
+## Context
+
+C-Next has no dedicated construct for an intentionally infinite loop. Because loop
+conditions must be explicit comparisons (E0701 — bare booleans and bare constants are
+rejected), the only way to write "loop forever" today is a hack:
+
+```cnx
+while (1 = 1) {   // `1 = 1` is equality in C-Next, i.e. `1 == 1`
+    loop();
+}
+```
+
+which transpiles to:
+
+```c
+while (1 == 1) {
+    Main_loop();
+}
+```
+
+This is unsatisfying for a "safer C": the intent (_this loop never ends_) is buried in
+an arithmetic identity that the transpiler cannot recognize as deliberate. Two concrete
+problems follow from the transpiler not understanding the loop is infinite:
+
+1. **It forces dead code.** `ReturnPathAnalyzer` (ADR-112) treats a `while` body as
+   _possibly skipped_, so a non-void function whose only terminal path is `while (1 = 1)`
+   fails with **E0704** unless an unreachable trailing `return` is added. The project's own
+   flagship example ships exactly this dead code:
+
+   ```cnx
+   // examples/nucleo-f446re/blink.cnx:286
+   i32 main() {
+       setup();
+       while (1 = 1) {
+           loop();
+       }
+       return 0;          // unreachable — present only to satisfy E0704
+   }
+   ```
+
+2. **It cannot express divergence.** There is no way to tell the compiler "control never
+   leaves this loop," so the compiler cannot reason about the code around it (see ADR-114).
+
+### Relevant existing constraints
+
+- **No `break` / `continue` (ADR-026).** A loop body has no structural early exit. The
+  _only_ way out of any loop is a `return` from the enclosing function. This makes a
+  conditionless loop **unconditionally divergent** — a stronger guarantee than in C or Rust,
+  where `break` can escape. There are zero edge cases for the analyzer to consider.
+- **All-paths-return (ADR-112).** A `do-while` counts as a guaranteed return (its body always
+  runs at least once); `while`/`for` never do. The analyzer makes no attempt to prove a loop
+  is infinite.
+
+### How other languages model "never returns"
+
+Research across seven languages (Rust, Ada, C/C++, Zig, Kotlin, Swift, Verilog) found that
+**no mainstream typed language syntactically restricts its infinite-loop construct by the
+enclosing function's return type.** They split into two camps:
+
+| Mechanism                                              | Languages                                                 | How an infinite loop fits a value-returning function                                                                            |
+| ------------------------------------------------------ | --------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------- |
+| **Bottom / never type** (coerces to every type)        | Rust `!`, Zig `noreturn`, Kotlin `Nothing`, Swift `Never` | The loop expression has a bottom type that is a subtype of all types, so it is valid in any return context with no special rule |
+| **Out-of-band contract** (attribute / aspect / pragma) | C `_Noreturn`, C++ `[[noreturn]]`, Ada `No_Return`        | The loop itself is unrestricted; a function with an infinite loop is allowed under any return type                              |
+
+- Swift deliberately **removed** its `@noreturn` _attribute_ (SE-0102) in favor of the `Never`
+  _type_, because the attribute did not compose with the rest of the type system. This is the
+  clearest industry signal that the bottom-type approach is the converged-upon design.
+- Verilog is the only surveyed language that uses the **keyword `forever`** — it confirms the
+  word reads naturally, but offers no guidance on return types (hardware has none).
+
+The proposed C-Next rule below (`forever` only in `void` functions) is therefore **novel**.
+The justification is that it is the _simplest sound_ option and, per the repo audit, costs
+nothing today (see "Migration Impact").
+
+## Decision (Proposed — Research)
+
+> This ADR is in **Research** status. The direction below reflects the current design
+> conversation; nothing here is approved or implemented. Open questions are listed explicitly.
+
+Add a dedicated infinite-loop statement:
+
+```cnx
+forever {
+    loop();
+}
+```
+
+### Proposed semantics
+
+1. **Lowering.** `forever { … }` transpiles to `for (;;) { … }` — the idiom MISRA C:2012
+   explicitly permits as an infinite loop (Rule 14.3 carve-out), with no controlling
+   expression to be flagged as invariant.
+2. **Divergent.** Because C-Next has no `break`/`continue` (ADR-026), `forever` never completes.
+   The all-paths-return analyzer (ADR-112) treats it as a **divergent statement** — a terminal
+   path, like an unconditional `return`. A function whose every path either returns a value or
+   diverges via `forever` satisfies E0704 with **no dead trailing return**.
+3. **`void`-only.** A `forever` loop may appear **only in a function with a `void` return
+   type** (proposed **E0705**). A value-returning function that loops forever can never honor
+   its return type; rather than silently accept it (Rust) or force dead code (today), C-Next
+   rejects the combination outright. Functions that "loop until they have a value to return"
+   are _not_ forever loops — by ADR-026's own philosophy they express the exit as a `while`
+   condition:
+
+   ```cnx
+   u8 readUntilNonzero() {
+       u8 b <- 0;
+       while (b = 0) {        // the trigger is explicit
+           b <- readByte();
+       }
+       return b;              // reachable, not dead
+   }
+   ```
+
+4. **No code after `forever`.** Any statement following a `forever` loop in the same block is
+   unreachable and is an error. This is the first concrete consumer of the divergence primitive
+   that ADR-114 (Dead-Code / Reachability Analysis) generalizes — see "Relationship to ADR-114."
+
+### Proposed error codes (not yet allocated)
+
+| Code  | Meaning                                                                                        |
+| ----- | ---------------------------------------------------------------------------------------------- |
+| E0705 | `forever` loop in a non-`void` function (use `while` + condition, or make the function `void`) |
+
+(Unreachable-code-after-`forever` is proposed to be reported by ADR-114's reachability code,
+under the same code that flags all unreachable statements, rather than a `forever`-specific one.)
+
+## Relationship to ADR-114
+
+`forever` and general dead-code detection are **independent** (neither strictly requires the
+other) but **share one primitive**. The decision (recorded in the design discussion) is **two
+ADRs sharing a single divergence primitive**:
+
+- **This ADR (113)** introduces the **"divergent statement"** concept into `ReturnPathAnalyzer`
+  (a `forever` loop is divergent) and the minimal rule "no code after `forever`." Small,
+  self-contained, **non-breaking** (it only accepts more programs — those that previously
+  needed a dead trailing return).
+- **ADR-114** _generalizes the consumption_ of that same primitive into a full reachability
+  pass (unreachable code after `return`, after fully-returning `if`/`else`, etc.). It is a
+  **breaking** change and is independently motivated by MISRA 2.1/2.2 and DO-178C.
+
+Holding to one shared primitive (rather than ADR-114 re-deriving reachability) is required by
+the project's "No Duplicate Code Paths" rule.
+
+## Migration Impact
+
+A full audit of the repository (1,028 `.cnx` files in `examples/` and `tests/`) found
+**exactly one** infinite loop: `examples/nucleo-f446re/blink.cnx`, the `i32 main()` shown
+above. Every Arduino `setup`/`loop` and FreeRTOS task is already `void`. That single case
+converts to `void main()` with zero loss of meaning:
+
+```cnx
+void main() {
+    setup();
+    forever {
+        loop();
+    }
+}                          // no return type to honor, no dead code
+```
+
+So the `void`-only restriction costs nothing in the current codebase. (`void main()` already
+transpiles correctly.)
+
+## Alternatives Considered
+
+1. **A `never` / bottom type (Rust `!`, Swift `Never`).** The idiomatic modern choice; lets a
+   `forever` — or a future `panic()`-style diverging function — appear in any return context,
+   compose in expressions, and drive exhaustiveness checks. **Deferred, not rejected:** it
+   requires adding a real bottom type to the type system and specifying its coercion against
+   every other feature (overflow modes, atomics, structs-by-ref) — a large, safety-sensitive
+   surface. If diverging functions (panic handlers, fault traps, non-returning ISR dispatchers)
+   land on the roadmap, the `void`-only rule becomes a stepping-stone to revisit. Recorded here
+   so that decision is explicit.
+2. **Pure syntactic sugar.** `forever` lowers to a loop but flow analysis is unchanged, so a
+   non-void function still needs a dead trailing return. Rejected: it leaves the E0704
+   dead-code wart in place, which is half the motivation.
+3. **Keyword `loop` (Rust/CoffeeScript) instead of `forever` (Verilog).** Open question — see
+   below.
+
+## Open Questions
+
+- **Keyword:** `forever` vs `loop`. `forever` matches Verilog and is unambiguous; `loop`
+  matches Rust/Ada/CoffeeScript and is shorter. Needs a decision.
+- **`void`-only vs bottom type:** confirm the `void`-only rule for v1, with the bottom type as
+  a documented future fork (Alternative 1).
+- **Diagnostic wording for E0705:** should it actively suggest the `while`-with-condition
+  rewrite and the `void` conversion?
+- **Grammar placement:** add `foreverStatement` as a new alternative in the `statement` rule
+  (alongside `whileStatement`/`forStatement`); new keyword token `FOREVER`.
+
+## References
+
+- ADR-026 (Break/Continue rejected — why a conditionless loop is unconditionally divergent)
+- ADR-112 (All-Paths-Return — the analyzer this extends with a divergence primitive)
+- ADR-114 (Dead-Code / Reachability Analysis — generalizes the divergence primitive)
+- MISRA C:2012 Rule 14.3 (infinite-loop idiom carve-out for `for(;;)`)
+- Swift SE-0102 (removal of `@noreturn` in favor of the `Never` bottom type)

--- a/docs/decisions/adr-114-dead-code-reachability.md
+++ b/docs/decisions/adr-114-dead-code-reachability.md
@@ -1,0 +1,135 @@
+# ADR-114: Dead-Code / Reachability Analysis
+
+**Status:** Research
+**Date:** 2026-06-26
+**Decision Makers:** Language Design Team
+**Related ADRs:** ADR-112 (All-Paths-Return), ADR-110 (DO-178C Compliance), ADR-113 (Forever Loops)
+**Related Issues:** #849 (MISRA C:2012 Rule 2.2 — No dead code), #839 (MISRA breakdown parent)
+
+## Context
+
+C-Next performs **no control-flow-reachability analysis today** (stated outright in ADR-112:
+"There is no control-flow-reachability analysis in the transpiler today."). The transpiler
+silently accepts — and emits — unreachable code:
+
+```cnx
+u8 f() {
+    return 1;
+    side();        // unreachable
+}
+```
+
+transpiles (verified) to:
+
+```c
+uint8_t Main_f(void) {
+    return 1;
+    Main_side();   // dead code, passed straight through
+}
+```
+
+This violates two MISRA C:2012 rules, both currently marked **Not Enforced** in
+`docs/misra-compliance.md`:
+
+- **Rule 2.1** — _A project shall not contain unreachable code._
+- **Rule 2.2 (Mandatory)** — _There shall be no dead code._ (Tracked in **Issue #849**.)
+
+It also blocks the **Dead Code Detection** feature that **ADR-110 (DO-178C, Research)** lists as
+a feasible addition — DO-178C prohibits deactivated code at _all_ design assurance levels.
+
+A "safer C" emitting dead code that downstream MISRA tooling then flags is backwards: the
+language should reject it at the source.
+
+### The dual already exists
+
+The machinery is mostly present. `ReturnPathAnalyzer` (ADR-112) already computes the **dual**
+of reachability: `blockDefinitelyReturns` is true iff any contained statement
+`definitelyReturns`, with the explicit note that _"statements after an unconditional return are
+unreachable."_ Reachability is the inverse question over the same structural walk:
+
+> A statement is **unreachable** iff some earlier statement in its block is a **divergent
+> statement** (an unconditional `return`, a fully-returning `if`/`else` or `switch`, or — once
+> ADR-113 lands — a `forever` loop).
+
+So a reachability pass can reuse ~90% of `ReturnPathAnalyzer`'s logic rather than re-deriving it.
+
+## Decision (Proposed — Research)
+
+> This ADR is in **Research** status. The direction below reflects the current design
+> conversation; nothing here is approved or implemented.
+
+Add a compile-time **reachability analysis** that rejects any statement which cannot be reached
+on any control-flow path from the function entry (proposed **E0706 — unreachable code**).
+
+### Coverage
+
+- code after an unconditional `return`;
+- code after a `forever` loop (ADR-113);
+- code after an `if`/`else` where both branches diverge;
+- code after a `switch` with a `default` where every case diverges.
+
+### Architecture (proposed)
+
+- New analyzer `ReachabilityAnalyzer` in `src/transpiler/logic/analysis/`, registered in
+  `runAnalyzers.ts` like the existing analyzers (listener + `analyze(tree)` returning
+  `IAnalyzerError[]`).
+- **Single source of truth for divergence.** The "is this statement divergent?" decision is
+  owned by **one** primitive (the `statementDefinitelyReturns` / divergence logic that ADR-113
+  introduces into `ReturnPathAnalyzer`). This analyzer _consumes_ that primitive; it does not
+  re-implement it. If sharing requires it, the divergence helpers are extracted into a shared
+  `logic/analysis/` control-flow module that both `ReturnPathAnalyzer` and `ReachabilityAnalyzer`
+  import. This is mandatory under the project's "No Duplicate Code Paths" rule — two passes that
+  each decide "what diverges" independently would be a latent divergence bug.
+- Layer constraint respected: `logic/analysis/` does not import from `output/`.
+
+### Proposed error codes (not yet allocated)
+
+| Code  | Meaning          |
+| ----- | ---------------- |
+| E0706 | Unreachable code |
+
+## Relationship to ADR-113
+
+`forever` (ADR-113) and this analysis are **independent** — neither strictly requires the other:
+
+- A reachability pass can already analyze a constant-true loop (`while (1 = 1)`) without the
+  `forever` keyword.
+- `forever`'s own "no code after the loop" rule needs only the **minimal** divergence check, not
+  this full pass.
+
+But they **share the divergence primitive**, and the agreed sequencing is:
+
+1. **ADR-113 first** — introduces the divergence primitive and ships `forever`. Small,
+   **non-breaking** (only accepts more programs).
+2. **ADR-114 second (this ADR)** — generalizes consumption of that primitive into the full
+   reachability pass. **Breaking.**
+
+## Breaking-Change Note
+
+Turning unreachable code into an error is a **breaking change**: any existing code with a dead
+trailing statement starts failing. The known instance is the dead `return 0;` in
+`examples/nucleo-f446re/blink.cnx` — which **ADR-113 already removes** by converting that
+function to `void main()` with a `forever` loop. Sequencing ADR-113 before ADR-114 means the one
+known offender is gone before the rule that would flag it turns on. A repo-wide `npm run unit`
+(which transpiles every example via `scripts/__tests__/examples-transpile.test.ts`) should gate
+the rule's introduction.
+
+## Open Questions
+
+- **Function calls that never return.** Without a `never`/bottom type (see ADR-113,
+  Alternative 1), a call like a future `panic()` cannot be treated as divergent, so code after
+  it would be wrongly considered reachable. Scope this ADR to _structural_ divergence
+  (`return` / `forever` / exhaustive `if`/`switch`) for v1, and revisit if a bottom type lands.
+- **Conditional compilation interaction.** Code removed by preprocessor flags is a separate
+  mechanism (configuration variance) from control-flow unreachability; confirm the analyzer
+  runs on the post-preprocessor tree so flagged-out code is not analyzed.
+- **Rollout.** Land behind a flag first, or straight to an error once the examples are clean?
+- **Error code:** confirm **E0706** (next free after E0704; E0705 is reserved by ADR-113).
+
+## References
+
+- ADR-112 (All-Paths-Return — provides the dual `definitelyReturns` machinery)
+- ADR-113 (Forever Loops — provides the divergence primitive this pass consumes)
+- ADR-110 (DO-178C Compliance — frames dead-code detection as a certification requirement)
+- Issue #849 (MISRA C:2012 Rule 2.2 — No dead code)
+- `docs/misra-compliance.md` (Rules 2.1 and 2.2, both "Not Enforced")

--- a/docs/decisions/adr-114-dead-code-reachability.md
+++ b/docs/decisions/adr-114-dead-code-reachability.md
@@ -4,7 +4,7 @@
 **Date:** 2026-06-26
 **Decision Makers:** Language Design Team
 **Related ADRs:** ADR-112 (All-Paths-Return), ADR-110 (DO-178C Compliance), ADR-113 (Forever Loops)
-**Related Issues:** #849 (MISRA C:2012 Rule 2.2 — No dead code), #839 (MISRA breakdown parent)
+**Related Issues:** #849 (MISRA 2.1/2.2 — No unreachable / dead code; the active issue) — formerly part of the now-closed #839 MISRA-breakdown parent
 
 ## Context
 
@@ -125,6 +125,9 @@ the rule's introduction.
   runs on the post-preprocessor tree so flagged-out code is not analyzed.
 - **Rollout.** Land behind a flag first, or straight to an error once the examples are clean?
 - **Error code:** confirm **E0706** (next free after E0704; E0705 is reserved by ADR-113).
+- **Back-reference ADR-112.** When this ADR is accepted/implemented, update ADR-112's
+  _Related ADRs_ to include ADR-114 — this pass reuses (the dual of) ADR-112's `definitelyReturns`
+  machinery. (Documentation counterpart, not a code change.)
 
 ## References
 


### PR DESCRIPTION
Two **Research**-status ADRs capturing the forever-loop design discussion. Nothing here changes the language yet — both are proposals ready to be worked.

## ADR-113 — Forever Loops
Proposes a `forever { }` divergent infinite loop:
- Lowers to `for (;;)` (MISRA 14.3 infinite-loop carve-out).
- **Divergent** — since C-Next has no `break`/`continue` (ADR-026), it never completes, so it satisfies all-paths-return (ADR-112) with **no dead trailing return**.
- **`void`-only** (proposed E0705): a value-returning function that loops forever can't honor its return type. Loop-until-return stays a `while` with an explicit condition.
- Cross-language research: no surveyed language (Rust, Ada, C/C++, Zig, Kotlin, Swift, Verilog) gates its infinite-loop construct by return type — they use a bottom/never type or a noreturn attribute. The `void`-only rule is novel but, per a full repo audit (exactly **one** infinite loop: `blink.cnx`'s `i32 main`), costs nothing today. A `never`/bottom type is recorded as a documented future fork.

## ADR-114 — Dead-Code / Reachability Analysis
Proposes general unreachable-code detection (proposed E0706) for **MISRA 2.1/2.2** and **DO-178C** (ADR-110):
- C-Next has no reachability analysis today (`return 1; side();` passes straight through).
- Built by **extending ADR-113's divergence primitive** — one shared code path, not two (per the project's no-duplicate-paths rule).
- Breaking change; sequenced **after** ADR-113 (which removes the one known offender, blink.cnx's dead `return 0;`).

## Notes
- Both indexed under *Research (v1 Roadmap)* in `docs/architecture-decisions.md`.
- Cross-referenced from issue #849 (MISRA 2.2).
- No error codes allocated yet (E0705/E0706 are proposals).

🤖 Generated with [Claude Code](https://claude.com/claude-code)