### PR TITLE
fix: make validate:c MISRA check actually detect violations (#1057)

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -371,7 +371,8 @@
     "unmarks",
     "unmarking",
     "pthread",
-    "ssize"
+    "ssize",
+    "baselined"
   ],
   "ignorePaths": [
     "node_modules/**",

--- a/docs/misra-compliance.md
+++ b/docs/misra-compliance.md
@@ -26,6 +26,26 @@ This document tracks C-Next's compliance with MISRA C:2012 guidelines. MISRA C i
 
 ---
 
+## How violations are validated
+
+`npm run validate:c` runs cppcheck's MISRA addon over every generated C test
+file via `scripts/batch-validate.mjs`. cppcheck emits all MISRA findings at
+`style` severity, so the runner passes `--enable=style` — omitting it makes the
+check a silent no-op (issue #1057).
+
+The failure decision lives in `scripts/misra-baseline.mjs`:
+
+- **Generated-only**: cppcheck also flags transitively-included third-party libs
+  and hand-written fixtures; only violations in C-Next-generated output
+  (`*.test.c` / generated `*.test.h`) count.
+- **Per-rule baseline**: every rule that currently has generated violations is
+  listed in `BASELINE`, mapped to its tracking issue (#841–#869, #1059–#1072).
+  Baselined rules do not fail the build, so the check is green today but fails
+  on any **new** rule class. When a rule's issue is fixed, remove its entry from
+  `BASELINE` to start enforcing it.
+
+---
+
 ## Directives
 
 ### Dir 1 - Implementation Compliance

--- a/docs/misra-compliance.md
+++ b/docs/misra-compliance.md
@@ -39,8 +39,8 @@ The failure decision lives in `scripts/misra-baseline.mjs`:
   and hand-written fixtures; only violations in C-Next-generated output
   (`*.test.c` / generated `*.test.h`) count.
 - **Per-rule baseline**: every rule that currently has generated violations is
-  listed in `BASELINE`, mapped to its tracking issue (#841–#869, #1059–#1072).
-  Baselined rules do not fail the build, so the check is green today but fails
+  listed in `BASELINE`, each mapped to its tracking issue. Baselined rules do
+  not fail the build, so the check is green today but fails
   on any **new** rule class. When a rule's issue is fixed, remove its entry from
   `BASELINE` to start enforcing it.
 

--- a/scripts/__tests__/misra-baseline.test.ts
+++ b/scripts/__tests__/misra-baseline.test.ts
@@ -44,7 +44,7 @@ describe("parseViolations", () => {
 
   it("returns an empty array when there are no MISRA findings", () => {
     const noise =
-      "probe.c:1:1: style: Variable unused. [unreadVariable]\nn" +
+      "probe.c:1:1: style: Variable unused. [unreadVariable]\n" +
       "probe.c:2:2: warning: something. [someWarning]";
     expect(MisraBaseline.parseViolations(noise)).toEqual([]);
   });

--- a/scripts/__tests__/misra-baseline.test.ts
+++ b/scripts/__tests__/misra-baseline.test.ts
@@ -1,0 +1,91 @@
+/**
+ * Unit tests for misra-baseline.mjs
+ *
+ * Regression guard for #1057: the MISRA portion of `validate:c` was a silent
+ * no-op because runMisra() invoked cppcheck without `--enable=style`, and
+ * cppcheck emits all MISRA findings at `style` severity. These tests lock in:
+ *   1. the cppcheck argv always enables style (so MISRA findings appear),
+ *   2. MISRA violations are parsed from output (ignoring non-MISRA noise),
+ *   3. only violations of un-baselined rules are treated as failures.
+ */
+
+import MisraBaseline from "../misra-baseline.mjs";
+
+// Real cppcheck output captured with `--enable=style`. Mixes MISRA findings
+// with non-MISRA style findings to prove the parser ignores the latter.
+const SAMPLE_OUTPUT = `probe.c:3:14: style: Assignment of function parameter has no effect outside the function. [uselessAssignmentArg]
+probe.c:3:16: style: Variable 'x' is assigned a value that is never used. [unreadVariable]
+probe.c:2:6: style: misra violation (use --rule-texts=<file> to get proper output) [misra-c2012-8.4]
+probe.c:3:8: style: misra violation (use --rule-texts=<file> to get proper output) [misra-c2012-14.4]
+probe.c:4:8: style: misra violation (use --rule-texts=<file> to get proper output) [misra-c2012-14.4]`;
+
+describe("buildArgs", () => {
+  it("enables style so cppcheck emits MISRA findings (the #1057 bug)", () => {
+    const args = MisraBaseline.buildArgs("foo.test.c", "tests/include");
+    expect(args).toContain("--enable=style");
+  });
+
+  it("loads the MISRA addon and targets the given file", () => {
+    const args = MisraBaseline.buildArgs("foo.test.c", "tests/include");
+    expect(args).toContain("--addon=misra");
+    expect(args).toContain("foo.test.c");
+  });
+});
+
+describe("parseViolations", () => {
+  it("extracts MISRA rule IDs and ignores non-MISRA style findings", () => {
+    const violations = MisraBaseline.parseViolations(SAMPLE_OUTPUT);
+    expect(violations.map((v) => v.ruleId)).toEqual([
+      "misra-c2012-8.4",
+      "misra-c2012-14.4",
+      "misra-c2012-14.4",
+    ]);
+  });
+
+  it("returns an empty array when there are no MISRA findings", () => {
+    const noise =
+      "probe.c:1:1: style: Variable unused. [unreadVariable]\nn" +
+      "probe.c:2:2: warning: something. [someWarning]";
+    expect(MisraBaseline.parseViolations(noise)).toEqual([]);
+  });
+});
+
+describe("isGenerated", () => {
+  it("treats *.test.c and *.test.h as C-Next-generated", () => {
+    expect(MisraBaseline.isGenerated("tests/foo/bar.test.c")).toBe(true);
+    expect(MisraBaseline.isGenerated("tests/foo/bar.test.h")).toBe(true);
+  });
+
+  it("treats hand-written fixtures and third-party headers as external", () => {
+    // cppcheck reports violations in transitively-included headers; these are
+    // NOT C-Next output and must not gate the build (#1057 refinement).
+    expect(MisraBaseline.isGenerated("tests/libs/cJSON/cJSON.h")).toBe(false);
+    expect(MisraBaseline.isGenerated("tests/include/c-interop/enums.h")).toBe(
+      false,
+    );
+  });
+});
+
+describe("findFailures", () => {
+  it("fails only on un-baselined rules in generated files", () => {
+    const violations = [
+      { file: "a.test.c", ruleId: "misra-c2012-10.4", raw: "x" }, // baselined (#858)
+      { file: "a.test.c", ruleId: "misra-c2012-99.9", raw: "y" }, // new rule → fail
+      { file: "cJSON.h", ruleId: "misra-c2012-99.9", raw: "z" }, // external → ignore
+    ];
+    const failures = MisraBaseline.findFailures(violations);
+    expect(failures.map((v) => v.raw)).toEqual(["y"]);
+  });
+});
+
+describe("BASELINE integrity", () => {
+  it("baselines a rule that currently has violations (10.4 → #858)", () => {
+    expect(MisraBaseline.BASELINE.has("misra-c2012-10.4")).toBe(true);
+  });
+
+  it("does NOT baseline a rule with zero current violations (10.3)", () => {
+    // #845 tracks Rule 10.3 but it no longer fires; the check must still catch
+    // it if it ever reappears, so it must stay out of the baseline.
+    expect(MisraBaseline.BASELINE.has("misra-c2012-10.3")).toBe(false);
+  });
+});

--- a/scripts/batch-validate.mjs
+++ b/scripts/batch-validate.mjs
@@ -20,6 +20,7 @@ import { execFileSync } from "node:child_process";
 import { existsSync, readFileSync, readdirSync } from "node:fs";
 import { join, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
+import MisraBaseline from "./misra-baseline.mjs";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const ROOT = join(__dirname, "..");
@@ -319,36 +320,46 @@ function runMisra() {
   );
   console.log(`Running MISRA on ${misraFiles.length} C files...`);
 
+  // MisraBaseline owns the cppcheck invocation and the failure decision:
+  //   - buildArgs() enables `--enable=style` so the addon actually reports (#1057)
+  //   - findFailures() fails only on un-baselined rules in C-Next-generated code
+  // cppcheck exits 1 on ANY enabled finding (including non-MISRA style noise),
+  // so every match throws; we parse the captured output and decide ourselves.
   for (const file of misraFiles) {
+    let output;
     try {
-      execFileSync(
-        "cppcheck",
-        [
-          "--addon=misra",
-          "--inline-suppr",
-          "--error-exitcode=1",
-          "--suppress=missingIncludeSystem",
-          "--suppress=unusedFunction",
-          // Float clamp ternary guards that cppcheck can't reason through
-          // (same suppression as the cppcheck runner above)
-          "--suppress=floatConversionOverflow",
-          "--quiet",
-          "-I",
-          INCLUDE_DIR,
-          "-I",
-          dirname(file),
-          file,
-        ],
-        { encoding: "utf-8", timeout: 60000, stdio: "pipe" },
-      );
+      execFileSync("cppcheck", MisraBaseline.buildArgs(file, INCLUDE_DIR), {
+        encoding: "utf-8",
+        timeout: 60000,
+        stdio: "pipe",
+      });
+      continue; // exit 0 → no findings at all
     } catch (error) {
-      const output = error.stderr || error.stdout || error.message;
-      const issues = output
-        .split("\n")
-        .filter((line) => line.includes("misra") || line.includes("MISRA"))
-        .slice(0, 5)
-        .join("\n");
-      reportFailure("MISRA", file, issues);
+      // Exit 1 is the expected "findings present" signal; any other status
+      // means cppcheck itself failed to run, which must not pass silently.
+      if (error.status !== 1) {
+        reportFailure(
+          "MISRA",
+          file,
+          error.stderr || error.stdout || error.message,
+        );
+        continue;
+      }
+      output = `${error.stdout || ""}\n${error.stderr || ""}`;
+    }
+
+    const failures = MisraBaseline.findFailures(
+      MisraBaseline.parseViolations(output),
+    );
+    if (failures.length > 0) {
+      reportFailure(
+        "MISRA",
+        file,
+        failures
+          .slice(0, 5)
+          .map((violation) => violation.raw)
+          .join("\n"),
+      );
     }
   }
 }

--- a/scripts/misra-baseline.mjs
+++ b/scripts/misra-baseline.mjs
@@ -68,6 +68,9 @@ const BASELINE = new Map([
 
 // Matches a cppcheck finding line and captures the file path and MISRA rule id:
 //   path/to/file.test.c:12:8: style: misra violation ... [misra-c2012-14.4]
+// Paths in this suite are POSIX (the runner globs tests/), so the non-greedy
+// `(.+?)` up to the first `:` captures the whole path unambiguously. A Windows
+// drive-letter path (`C:\...`) would need a more specific anchor.
 const MISRA_LINE = /^(.+?):\d+:\d+:.*\[(misra-c2012-\d+\.\d+)\]/;
 
 class MisraBaseline {

--- a/scripts/misra-baseline.mjs
+++ b/scripts/misra-baseline.mjs
@@ -1,0 +1,125 @@
+/**
+ * MISRA baseline + parsing helpers for batch-validate.mjs.
+ *
+ * Background (#1057): the MISRA portion of `validate:c` was a silent no-op
+ * because runMisra() invoked cppcheck WITHOUT `--enable=style`. cppcheck emits
+ * every MISRA finding at `style` severity, so without that flag the addon
+ * reports nothing and exits 0 — the check "passed" by never checking.
+ *
+ * This module owns the cppcheck invocation and the failure decision so both the
+ * runner and its unit tests share one source of truth:
+ *   - buildArgs()      — cppcheck argv (always enables style).
+ *   - parseViolations()— extract MISRA findings from cppcheck output.
+ *   - isGenerated()    — is a file C-Next-generated output?
+ *   - findFailures()   — violations that should fail the build.
+ *
+ * Failure policy (per-rule allowlist baseline):
+ *   A violation fails the build only when it is in C-Next-GENERATED code
+ *   (`*.test.c` / generated `*.test.h`) AND its rule is NOT in BASELINE.
+ *   - Generated-only: cppcheck also flags transitively-included third-party
+ *     libs (cJSON) and hand-written fixtures (widget.h, c-interop headers);
+ *     those are not C-Next output and must never gate the build.
+ *   - Per-rule baseline: every rule that currently has generated violations is
+ *     listed below, mapped to its tracking issue. This keeps the check green
+ *     today while failing on any NEW rule class (or any baselined rule once its
+ *     issue is fixed and the entry is removed). Remove a rule from BASELINE as
+ *     part of resolving its issue to start enforcing it.
+ */
+
+import { dirname } from "node:path";
+
+// rule id -> tracking issue. Generated from the suite via:
+//   cppcheck --addon=misra --enable=style --inline-suppr ... | grep misra-c2012
+// (see scripts/misra-baseline.test.ts for the integrity guards).
+const BASELINE = new Map([
+  // --- rules with pre-existing tracking issues (#841–#869) ---
+  ["misra-c2012-2.2", "#849"],
+  ["misra-c2012-2.3", "#869"],
+  ["misra-c2012-2.5", "#863"],
+  ["misra-c2012-2.7", "#862"],
+  ["misra-c2012-7.4", "#844"],
+  ["misra-c2012-8.4", "#841"],
+  ["misra-c2012-8.7", "#864"],
+  ["misra-c2012-8.9", "#866"],
+  ["misra-c2012-10.4", "#858"],
+  ["misra-c2012-10.6", "#860"],
+  ["misra-c2012-10.8", "#846"],
+  ["misra-c2012-11.4", "#867"],
+  ["misra-c2012-12.1", "#865"],
+  ["misra-c2012-15.5", "#861"],
+  ["misra-c2012-17.7", "#847"],
+  ["misra-c2012-18.4", "#859"],
+  // --- rules surfaced by #1057, newly tracked (#1059–#1072) ---
+  ["misra-c2012-8.6", "#1059"],
+  ["misra-c2012-5.9", "#1060"],
+  ["misra-c2012-5.6", "#1061"],
+  ["misra-c2012-7.2", "#1062"],
+  ["misra-c2012-5.8", "#1063"],
+  ["misra-c2012-8.5", "#1064"],
+  ["misra-c2012-12.2", "#1065"],
+  ["misra-c2012-20.1", "#1066"],
+  ["misra-c2012-19.2", "#1067"],
+  ["misra-c2012-5.7", "#1068"],
+  ["misra-c2012-21.7", "#1069"],
+  ["misra-c2012-10.1", "#1070"],
+  ["misra-c2012-14.1", "#1071"],
+  ["misra-c2012-9.2", "#1072"],
+]);
+
+// Matches a cppcheck finding line and captures the file path and MISRA rule id:
+//   path/to/file.test.c:12:8: style: misra violation ... [misra-c2012-14.4]
+const MISRA_LINE = /^(.+?):\d+:\d+:.*\[(misra-c2012-\d+\.\d+)\]/;
+
+class MisraBaseline {
+  static BASELINE = BASELINE;
+
+  /** cppcheck argv for a single C file. Always enables style (the #1057 fix). */
+  static buildArgs(file, includeDir) {
+    return [
+      "--addon=misra",
+      // REQUIRED: cppcheck emits MISRA findings only at `style` severity.
+      // Without this the MISRA addon is a silent no-op (#1057).
+      "--enable=style",
+      "--inline-suppr",
+      "--error-exitcode=1",
+      "--suppress=missingIncludeSystem",
+      "--suppress=unusedFunction",
+      // Float clamp ternary guards that cppcheck can't reason through.
+      "--suppress=floatConversionOverflow",
+      "--quiet",
+      "-I",
+      includeDir,
+      "-I",
+      dirname(file),
+      file,
+    ];
+  }
+
+  /** Parse MISRA violations from cppcheck output (ignores non-MISRA findings). */
+  static parseViolations(output) {
+    const violations = [];
+    for (const line of output.split("\n")) {
+      const match = MISRA_LINE.exec(line);
+      if (match !== null) {
+        violations.push({ file: match[1], ruleId: match[2], raw: line });
+      }
+    }
+    return violations;
+  }
+
+  /** True for C-Next-generated output (*.test.c / *.test.h), false for fixtures. */
+  static isGenerated(file) {
+    return /\.test\.(c|h)$/.test(file);
+  }
+
+  /** Violations that should fail the build: generated code, un-baselined rule. */
+  static findFailures(violations) {
+    return violations.filter(
+      (violation) =>
+        MisraBaseline.isGenerated(violation.file) &&
+        !BASELINE.has(violation.ruleId),
+    );
+  }
+}
+
+export default MisraBaseline;


### PR DESCRIPTION
## Summary

The MISRA portion of `npm run validate:c` was a **silent no-op**. `runMisra()` invoked cppcheck's MISRA addon without `--enable=style`; cppcheck emits every MISRA finding at `style` severity, so the addon reported nothing and exited 0. The check "passed" by never checking anything — none of the tracked MISRA issues (#841–#869) were actually being detected.

Verified with cppcheck 2.13.0: the exact flags `runMisra()` used exit 0 with no output on a file with real Rule 14.4/8.4 violations; adding `--enable=style` surfaces them.

## What changed

- **New shared module `scripts/misra-baseline.mjs`** (unit-tested) owns the cppcheck invocation and the failure decision — single source of truth for the runner and tests, removing the duplicate inline arg list.
  - `buildArgs()` always passes `--enable=style` (the fix).
  - `parseViolations()` extracts MISRA findings, ignoring non-MISRA style noise.
  - `findFailures()` gates only on **C-Next-generated** output (`*.test.c` / generated `*.test.h`) and **un-baselined** rules.
- **Generated-only scope**: cppcheck also flags transitively-included third-party libs (cJSON, FreeRTOS) and hand-written fixtures (`widget.h`, c-interop headers). Those are not C-Next's code and must never gate the build.
- **Per-rule baseline**: every rule with current generated violations is allow-listed and mapped to its tracking issue. The check is **green today** but **fails on any new rule class** (or any baselined rule once its entry is removed as the issue is fixed).
- Real cppcheck execution failures (exit status ≠ 1) are now surfaced instead of swallowed.

## Bug tracking

Enabling detection surfaced **14 previously-untracked** MISRA rules with violations in generated code. Per the project's zero-exceptions bug-tracking rule, filed one issue per rule and added each to the baseline:

| Rule | Issue | Rule | Issue |
|------|-------|------|-------|
| 8.6 | #1059 | 19.2 | #1067 |
| 5.9 | #1060 | 5.7 | #1068 |
| 5.6 | #1061 | 21.7 | #1069 |
| 7.2 | #1062 | 10.1 | #1070 |
| 5.8 | #1063 | 14.1 | #1071 |
| 8.5 | #1064 | 9.2 | #1072 |
| 12.2 | #1065 | | |
| 20.1 | #1066 | | |

The 16 rules already tracked by #841–#869 are referenced in the baseline. Rules whose issues are effectively resolved (10.3 → #845, 2.4 → #868) have **0** current violations and stay **out** of the baseline, so they remain enforced.

## Verification

- New unit tests `scripts/__tests__/misra-baseline.test.ts` (9 tests, written test-first).
- Full unit suite: 5764 passing.
- `npm run validate:c -- --tool misra` exits 0 with all firing rules baselined (688 files).
- End-to-end: injecting a temporary un-baselined Rule 14.4 violation makes the check fail with exit 1 — proving it is no longer a no-op.
- prettier / oxlint / cspell / jscpd (0.82% < 3%) all clean.

Closes #1057.

🤖 Generated with [Claude Code](https://claude.com/claude-code)