### PR TITLE
feat: forbid disguised infinite loops (E0707, ADR-113 / #1075)

### DIFF
--- a/docs/decisions/adr-113-forever-loops.md
+++ b/docs/decisions/adr-113-forever-loops.md
@@ -333,6 +333,21 @@ surfaces. This is exactly the shared decision ADR-114 must reuse rather than re-
 Scope held: the unreachable-code-after-`forever` diagnostic (E0706) is **not** part of #1074 — it
 belongs to ADR-114's reachability pass. #1074 delivers only the divergence primitive + E0704 relief.
 
+## Implementation Notes (Issue #1075, 2026-06-27)
+
+The v0.2.18 **disguised-loop slice** shipped as **E0707** (E0706 stays reserved for ADR-114):
+
+- **`for (;;)`** — a for-loop with no controlling expression is rejected in `generateFor`.
+- **Always-true literal conditions** — `while`/`for`/`do-while` conditions that are a single
+  comparison of integer/bool literals evaluating to true (`1 = 1`, `5 > 3`, `true = true`,
+  `1 != 2`) are rejected via `TypeValidator.validateLoopConditionNotAlwaysTrue`.
+
+Strictly the **literal** slice (no symbol resolution): named constants, non-literal/compound
+operands, floats, and always-**false** conditions are deliberately _not_ flagged — deferred to the
+full MISRA 14.3 effort (#1076). MISRA 14.3 moves Not Enforced → **Partial**. Repo audit confirmed
+zero pre-existing `for (;;)` or `while (1 = 1)` in source (only the one already migrated in #1074),
+so this breaking change flags nothing existing.
+
 ## Remaining
 
 - **Back-reference ADR-112:** ADR-113 added to ADR-112's _Related ADRs_ (2026-06-27, on

--- a/docs/error-codes.md
+++ b/docs/error-codes.md
@@ -12,10 +12,10 @@ This document is the authoritative registry of all C-Next compiler error codes. 
 | E04xx     | Symbol Resolution       | 3      |
 | E05xx     | Include/Preprocessor    | 4      |
 | E06xx     | Sizeof Expressions      | 2      |
-| E07xx     | Control Flow            | 5      |
+| E07xx     | Control Flow            | 6      |
 | E08xx     | Arithmetic/Array Safety | 9      |
 | E09xx     | NULL Safety             | 8      |
-| **Total** |                         | **34** |
+| **Total** |                         | **35** |
 
 ---
 
@@ -80,15 +80,16 @@ This document is the authoritative registry of all C-Next compiler error codes. 
 
 ## E07xx — Control Flow Validation
 
-| Code  | Message                                    | Help                                                                          | Source                                                         |
-| ----- | ------------------------------------------ | ----------------------------------------------------------------------------- | -------------------------------------------------------------- |
-| E0701 | Condition must be a boolean expression     | Use explicit comparison: `expr > 0` or `expr != 0`                            | `output/codegen/TypeValidator.ts`                              |
-| E0702 | Function call in condition not allowed     | Store function result in a variable first                                     | `output/codegen/TypeValidator.ts`, `ControlFlowGenerator.ts`   |
-| E0703 | `break`/`continue` not supported           | Use structured conditions instead                                             | `output/codegen/CodeGenerator.ts`                              |
-| E0704 | Non-void function must return on all paths | Add an explicit `return <value>;` so every path returns a value               | `logic/analysis/ReturnPathAnalyzer.ts`                         |
-| E0705 | `forever` loop in non-void function        | Make the function return `void`, or use a `while` loop with an exit condition | `output/codegen/generators/statements/ControlFlowGenerator.ts` |
+| Code  | Message                                                             | Help                                                                          | Source                                                         |
+| ----- | ------------------------------------------------------------------- | ----------------------------------------------------------------------------- | -------------------------------------------------------------- |
+| E0701 | Condition must be a boolean expression                              | Use explicit comparison: `expr > 0` or `expr != 0`                            | `output/codegen/TypeValidator.ts`                              |
+| E0702 | Function call in condition not allowed                              | Store function result in a variable first                                     | `output/codegen/TypeValidator.ts`, `ControlFlowGenerator.ts`   |
+| E0703 | `break`/`continue` not supported                                    | Use structured conditions instead                                             | `output/codegen/CodeGenerator.ts`                              |
+| E0704 | Non-void function must return on all paths                          | Add an explicit `return <value>;` so every path returns a value               | `logic/analysis/ReturnPathAnalyzer.ts`                         |
+| E0705 | `forever` loop in non-void function                                 | Make the function return `void`, or use a `while` loop with an exit condition | `output/codegen/generators/statements/ControlFlowGenerator.ts` |
+| E0707 | Disguised infinite loop (`for(;;)` / always-true literal condition) | Write `forever { ... }` for an intentional infinite loop                      | `output/codegen/TypeValidator.ts`, `ControlFlowGenerator.ts`   |
 
-**Related:** MISRA C:2012 Rule 14.4 (E0701), Rule 13.5 / Issue #254 (E0702), ADR-026 / Issue #1011 (E0703), ADR-112 / Issue #1040 (E0704), ADR-113 / Issue #1074 (E0705)
+**Related:** MISRA C:2012 Rule 14.4 (E0701), Rule 13.5 / Issue #254 (E0702), ADR-026 / Issue #1011 (E0703), ADR-112 / Issue #1040 (E0704), ADR-113 / Issue #1074 (E0705), ADR-113 / Issue #1075 (E0707; E0706 reserved for ADR-114 unreachable code)
 
 ---
 

--- a/docs/learn-cnext-in-y-minutes.md
+++ b/docs/learn-cnext-in-y-minutes.md
@@ -163,6 +163,11 @@ void main() {
 }
 // i32 main() { forever { } }   // ERROR E0705: forever in non-void function
 
+// `forever` is the ONLY way to write an infinite loop. The disguised forms are
+// rejected (E0707) and steered to `forever`:
+// for (;;) { }            // ERROR E0707: no controlling expression
+// while (1 = 1) { }       // ERROR E0707: loop condition is always true
+
 // Switch - braces replace break, no fallthrough, no colons!
 switch (state) {
     case State.IDLE {

--- a/docs/misra-compliance.md
+++ b/docs/misra-compliance.md
@@ -21,7 +21,7 @@ This document tracks C-Next's compliance with MISRA C:2012 guidelines. MISRA C i
 | Directives (1-4) | 0        | 2         | 0       | 2   | 0            |
 | Rules 1-5        | 3        | 5         | 1       | 8   | 6            |
 | Rules 6-10       | 2        | 3         | 2       | 5   | 8            |
-| Rules 11-15      | 1        | 12        | 1       | 8   | 5            |
+| Rules 11-15      | 1        | 12        | 2       | 8   | 4            |
 | Rules 16-22      | 4        | 8         | 2       | 12  | 6            |
 
 ---
@@ -252,12 +252,12 @@ The failure decision lives in `scripts/misra-baseline.mjs`:
 
 ## Rule 14 - Control Statement Expressions
 
-| Rule | Description                                | Status        | Reference                                                                                       |
-| ---- | ------------------------------------------ | ------------- | ----------------------------------------------------------------------------------------------- |
-| 14.1 | Loop counter float                         | **By Design** | Loop validation                                                                                 |
-| 14.2 | For loop well-formed                       | Partial       | Some validation                                                                                 |
-| 14.3 | Controlling expression not invariant       | Not Enforced  | ADR-113 adds `forever` (compliant `for(;;)` idiom); forbidding disguised loops tracked in #1075 |
-| 14.4 | Controlling expression essentially boolean | Partial       | E0701 for do-while only                                                                         |
+| Rule | Description                                | Status        | Reference                                                                                                                                                |
+| ---- | ------------------------------------------ | ------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 14.1 | Loop counter float                         | **By Design** | Loop validation                                                                                                                                          |
+| 14.2 | For loop well-formed                       | Partial       | Some validation                                                                                                                                          |
+| 14.3 | Controlling expression not invariant       | Partial       | E0707 forbids `for(;;)` and always-true literal loop conditions (ADR-113 / #1075); named-constant/non-literal invariants + always-false tracked in #1076 |
+| 14.4 | Controlling expression essentially boolean | Partial       | E0701 for do-while only                                                                                                                                  |
 
 ---
 

--- a/src/transpiler/output/codegen/CodeGenerator.ts
+++ b/src/transpiler/output/codegen/CodeGenerator.ts
@@ -1130,6 +1130,14 @@ export default class CodeGenerator implements IOrchestrator {
   }
 
   /**
+   * ADR-113 / #1075: reject an always-true literal loop condition (E0707).
+   * Part of IOrchestrator interface.
+   */
+  validateLoopConditionNotAlwaysTrue(ctx: Parser.ExpressionContext): void {
+    TypeValidator.validateLoopConditionNotAlwaysTrue(ctx);
+  }
+
+  /**
    * Issue #254: Validate no function calls in condition (E0702).
    * Part of IOrchestrator interface (ADR-053 A3).
    */

--- a/src/transpiler/output/codegen/TypeValidator.ts
+++ b/src/transpiler/output/codegen/TypeValidator.ts
@@ -852,8 +852,8 @@ class TypeValidator {
     // OCTAL constant, so a decimal parse would diverge from the generated code's
     // value. Skip it (defer to #1076) rather than risk a wrong verdict. `0x`/`0b`
     // and a bare `0` are unambiguous and still handled.
-    if (/^0[0-9]/.test(text)) return null;
-    if (/^(0[xX][0-9a-fA-F]+|0[bB][01]+|\d+)([uUiI]\d+)?$/.test(text)) {
+    if (/^0\d/.test(text)) return null;
+    if (/^(0[xX][\da-fA-F]+|0[bB][01]+|\d+)([uUiI]\d+)?$/.test(text)) {
       return LiteralEvaluator.parseLiteral(text);
     }
     return null;

--- a/src/transpiler/output/codegen/TypeValidator.ts
+++ b/src/transpiler/output/codegen/TypeValidator.ts
@@ -761,6 +761,122 @@ class TypeValidator {
     );
   }
 
+  // ========================================================================
+  // Disguised Infinite Loop Validation (ADR-113 / #1075, E0707)
+  // ========================================================================
+
+  /**
+   * ADR-113 / #1075 (E0707): reject a loop whose controlling expression is an
+   * always-TRUE comparison of literal operands (`while (1 = 1)`, `5 > 3`,
+   * `true = true`). C-Next has one source form for an intentional infinite loop —
+   * `forever`. This is the v0.2.18 *literal* slice only: named constants and
+   * non-literal operands need symbol resolution (out of scope), and always-FALSE
+   * conditions are a separate MISRA 14.3 case — both tracked in #1076.
+   *
+   * Runs after the E0701 boolean check, so the condition is already a comparison.
+   */
+  static validateLoopConditionNotAlwaysTrue(
+    ctx: Parser.ExpressionContext,
+  ): void {
+    const comparison = TypeValidator._asSingleLiteralComparison(ctx);
+    if (comparison && TypeValidator._comparisonIsAlwaysTrue(comparison)) {
+      throw new Error(
+        `Error E0707: loop condition '${ctx.getText()}' is always true\n` +
+          "  help: write 'forever { ... }' for an intentional infinite loop",
+      );
+    }
+  }
+
+  /**
+   * If `ctx` is a single comparison of two literal operands (no `||`/`&&`, no
+   * ternary, no chaining), return its operator and the two literal values.
+   * Otherwise null — anything involving identifiers, floats, or sub-expressions
+   * is left to the full MISRA 14.3 effort (#1076).
+   */
+  private static _asSingleLiteralComparison(
+    ctx: Parser.ExpressionContext,
+  ): { operator: string; left: number; right: number } | null {
+    const orExprs = ctx.ternaryExpression().orExpression();
+    if (orExprs.length !== 1) return null;
+    const andExprs = orExprs[0].andExpression();
+    if (andExprs.length !== 1) return null;
+    const equalityExprs = andExprs[0].equalityExpression();
+    if (equalityExprs.length !== 1) return null;
+    const equalityExpr = equalityExprs[0];
+
+    const relationalExprs = equalityExpr.relationalExpression();
+    if (relationalExprs.length === 2) {
+      // Equality comparison: relExpr ('=' | '!=') relExpr
+      return TypeValidator._buildLiteralComparison(
+        equalityExpr.getChild(1)?.getText(),
+        relationalExprs[0].getText(),
+        relationalExprs[1].getText(),
+      );
+    }
+    if (relationalExprs.length === 1) {
+      const bitwiseOrExprs = relationalExprs[0].bitwiseOrExpression();
+      if (bitwiseOrExprs.length === 2) {
+        // Relational comparison: orExpr ('<' | '>' | '<=' | '>=') orExpr
+        return TypeValidator._buildLiteralComparison(
+          relationalExprs[0].getChild(1)?.getText(),
+          bitwiseOrExprs[0].getText(),
+          bitwiseOrExprs[1].getText(),
+        );
+      }
+    }
+    return null;
+  }
+
+  private static _buildLiteralComparison(
+    operator: string | undefined,
+    leftText: string,
+    rightText: string,
+  ): { operator: string; left: number; right: number } | null {
+    const left = TypeValidator._literalValue(leftText);
+    const right = TypeValidator._literalValue(rightText);
+    if (operator === undefined || left === null || right === null) return null;
+    return { operator, left, right };
+  }
+
+  /**
+   * Strict literal-to-number for the E0707 literal slice: integer literals
+   * (decimal/hex/binary, optional type suffix) and `true`/`false`. Floats,
+   * strings, chars, identifiers, and any compound text return null so they are
+   * not treated as compile-time-known.
+   */
+  private static _literalValue(text: string): number | null {
+    if (text === "true") return 1;
+    if (text === "false") return 0;
+    if (text.includes(".")) return null;
+    if (/^(0[xX][0-9a-fA-F]+|0[bB][01]+|\d+)([uUiI]\d+)?$/.test(text)) {
+      return LiteralEvaluator.parseLiteral(text);
+    }
+    return null;
+  }
+
+  private static _comparisonIsAlwaysTrue(comparison: {
+    operator: string;
+    left: number;
+    right: number;
+  }): boolean {
+    switch (comparison.operator) {
+      case "=":
+        return comparison.left === comparison.right;
+      case "!=":
+        return comparison.left !== comparison.right;
+      case "<":
+        return comparison.left < comparison.right;
+      case ">":
+        return comparison.left > comparison.right;
+      case "<=":
+        return comparison.left <= comparison.right;
+      case ">=":
+        return comparison.left >= comparison.right;
+      default:
+        return false;
+    }
+  }
+
   /**
    * Builds a context-aware "help" suggestion for a rejected condition. For a
    * boolean operand the correct explicit form is `flag = true` (or `flag = false`

--- a/src/transpiler/output/codegen/TypeValidator.ts
+++ b/src/transpiler/output/codegen/TypeValidator.ts
@@ -848,6 +848,11 @@ class TypeValidator {
     if (text === "true") return 1;
     if (text === "false") return 0;
     if (text.includes(".")) return null;
+    // A leading-zero integer (`0777`) is emitted verbatim and read by C as an
+    // OCTAL constant, so a decimal parse would diverge from the generated code's
+    // value. Skip it (defer to #1076) rather than risk a wrong verdict. `0x`/`0b`
+    // and a bare `0` are unambiguous and still handled.
+    if (/^0[0-9]/.test(text)) return null;
     if (/^(0[xX][0-9a-fA-F]+|0[bB][01]+|\d+)([uUiI]\d+)?$/.test(text)) {
       return LiteralEvaluator.parseLiteral(text);
     }

--- a/src/transpiler/output/codegen/__tests__/TypeValidator.alwaysTrueLoop.test.ts
+++ b/src/transpiler/output/codegen/__tests__/TypeValidator.alwaysTrueLoop.test.ts
@@ -1,0 +1,87 @@
+/**
+ * Unit tests for TypeValidator.validateLoopConditionNotAlwaysTrue
+ * ADR-113 / Issue #1075: reject always-true literal loop conditions (E0707).
+ *
+ * Only the v0.2.18 literal slice — integer/bool literal comparisons decided
+ * without symbol resolution. Named constants, non-literal operands, and
+ * always-false conditions are out of scope (#1076).
+ */
+import { describe, it, expect } from "vitest";
+import { CharStream, CommonTokenStream } from "antlr4ng";
+import { CNextLexer } from "../../../logic/parser/grammar/CNextLexer";
+import { CNextParser } from "../../../logic/parser/grammar/CNextParser";
+import TypeValidator from "../TypeValidator";
+
+function parseCondition(text: string) {
+  const charStream = CharStream.fromString(text);
+  const lexer = new CNextLexer(charStream);
+  const tokenStream = new CommonTokenStream(lexer);
+  const parser = new CNextParser(tokenStream);
+  return parser.expression();
+}
+
+function isFlaggedAlwaysTrue(text: string): boolean {
+  try {
+    TypeValidator.validateLoopConditionNotAlwaysTrue(parseCondition(text));
+    return false;
+  } catch (error) {
+    return /E0707/.test((error as Error).message);
+  }
+}
+
+describe("TypeValidator.validateLoopConditionNotAlwaysTrue (E0707)", () => {
+  describe("flags always-true literal comparisons", () => {
+    it.each([
+      "1 = 1",
+      "true = true",
+      "false = false",
+      "1 != 2",
+      "5 > 3",
+      "3 < 5",
+      "3 >= 3",
+      "5 <= 5",
+      "0x10 = 16",
+      "0b10 = 2",
+    ])("flags %s", (condition) => {
+      expect(isFlaggedAlwaysTrue(condition)).toBe(true);
+    });
+
+    it("includes the condition text and steers to forever", () => {
+      let message = "";
+      try {
+        TypeValidator.validateLoopConditionNotAlwaysTrue(
+          parseCondition("1 = 1"),
+        );
+      } catch (error) {
+        message = (error as Error).message;
+      }
+      expect(message).toContain(
+        "Error E0707: loop condition '1=1' is always true",
+      );
+      expect(message).toContain("forever { ... }");
+    });
+  });
+
+  describe("does NOT flag always-false comparisons (out of scope, #1076)", () => {
+    it.each(["1 = 2", "true = false", "1 != 1", "5 < 3", "3 > 5", "5 <= 3"])(
+      "allows %s",
+      (condition) => {
+        expect(isFlaggedAlwaysTrue(condition)).toBe(false);
+      },
+    );
+  });
+
+  describe("does NOT flag non-literal or compound conditions (needs folding, #1076)", () => {
+    it.each([
+      "x = 1", // identifier operand
+      "MAX > 0", // named constant
+      "a = b", // two identifiers
+      "5.0 > 3.0", // float operands
+      "1 + 0 = 1", // compound left operand
+      "1 = 1 || 0 > 5", // logical-or combination
+      "1 = 1 && 2 = 2", // logical-and combination
+    ])("allows %s", (condition) => {
+      expect(isFlaggedAlwaysTrue(condition)).toBe(false);
+    });
+  });
+});

--- a/src/transpiler/output/codegen/__tests__/TypeValidator.alwaysTrueLoop.test.ts
+++ b/src/transpiler/output/codegen/__tests__/TypeValidator.alwaysTrueLoop.test.ts
@@ -41,7 +41,9 @@ describe("TypeValidator.validateLoopConditionNotAlwaysTrue (E0707)", () => {
       "3 >= 3",
       "5 <= 5",
       "0x10 = 16",
+      "0XFF = 255", // uppercase hex prefix
       "0b10 = 2",
+      "5u8 = 5", // type-suffixed literal
     ])("flags %s", (condition) => {
       expect(isFlaggedAlwaysTrue(condition)).toBe(true);
     });
@@ -80,6 +82,8 @@ describe("TypeValidator.validateLoopConditionNotAlwaysTrue (E0707)", () => {
       "1 + 0 = 1", // compound left operand
       "1 = 1 || 0 > 5", // logical-or combination
       "1 = 1 && 2 = 2", // logical-and combination
+      "0777 = 777", // leading-zero literal: C reads it as octal (511), so a
+      // decimal parse (777) would diverge — skipped, not wrongly flagged
     ])("allows %s", (condition) => {
       expect(isFlaggedAlwaysTrue(condition)).toBe(false);
     });

--- a/src/transpiler/output/codegen/generators/IOrchestrator.ts
+++ b/src/transpiler/output/codegen/generators/IOrchestrator.ts
@@ -214,6 +214,9 @@ interface IOrchestrator {
     conditionType: string,
   ): void;
 
+  /** Reject an always-true literal loop condition (ADR-113 / #1075, E0707) */
+  validateLoopConditionNotAlwaysTrue(ctx: Parser.ExpressionContext): void;
+
   /** Validate no function calls in condition (Issue #254, E0702) */
   validateConditionNoFunctionCall(
     ctx: Parser.ExpressionContext,

--- a/src/transpiler/output/codegen/generators/statements/ControlFlowGenerator.ts
+++ b/src/transpiler/output/codegen/generators/statements/ControlFlowGenerator.ts
@@ -329,18 +329,20 @@ const generateFor = (
   // Issue #250: Flush temps from init before generating condition
   const initTemps = orchestrator.flushPendingTempDeclarations();
 
-  let condition = "";
-  if (node.expression()) {
-    // Issue #254: Validate no function calls in condition (E0702)
-    orchestrator.validateConditionNoFunctionCall(node.expression()!, "for");
+  // The empty-header case (`for (;;)`) already threw E0707 above, so the
+  // controlling expression is guaranteed present here.
+  const conditionExpr = node.expression()!;
 
-    // Issue #884: Validate condition is a boolean expression (E0701)
-    orchestrator.validateConditionIsBoolean(node.expression()!, "for");
+  // Issue #254: Validate no function calls in condition (E0702)
+  orchestrator.validateConditionNoFunctionCall(conditionExpr, "for");
 
-    // ADR-113 / #1075: reject always-true literal condition (E0707)
-    orchestrator.validateLoopConditionNotAlwaysTrue(node.expression()!);
-    condition = orchestrator.generateExpression(node.expression()!);
-  }
+  // Issue #884: Validate condition is a boolean expression (E0701)
+  orchestrator.validateConditionIsBoolean(conditionExpr, "for");
+
+  // ADR-113 / #1075: reject always-true literal condition (E0707)
+  orchestrator.validateLoopConditionNotAlwaysTrue(conditionExpr);
+
+  const condition = orchestrator.generateExpression(conditionExpr);
 
   // Issue #250: Flush temps from condition before generating update
   const conditionTemps = orchestrator.flushPendingTempDeclarations();

--- a/src/transpiler/output/codegen/generators/statements/ControlFlowGenerator.ts
+++ b/src/transpiler/output/codegen/generators/statements/ControlFlowGenerator.ts
@@ -168,6 +168,9 @@ const generateWhile = (
   // Issue #884: Validate condition is a boolean expression (E0701)
   orchestrator.validateConditionIsBoolean(node.expression(), "while");
 
+  // ADR-113 / #1075: reject always-true literal condition (E0707)
+  orchestrator.validateLoopConditionNotAlwaysTrue(node.expression());
+
   const condition = orchestrator.generateExpression(node.expression());
 
   // Issue #250: Flush any temp vars from condition BEFORE generating body
@@ -201,6 +204,9 @@ const generateDoWhile = (
 
   // Issue #884: Validate condition is a boolean expression (E0701)
   orchestrator.validateConditionIsBoolean(node.expression(), "do-while");
+
+  // ADR-113 / #1075: reject always-true literal condition (E0707)
+  orchestrator.validateLoopConditionNotAlwaysTrue(node.expression());
 
   const body = orchestrator.generateBlock(node.block());
   const condition = orchestrator.generateExpression(node.expression());
@@ -287,6 +293,15 @@ const generateFor = (
 ): IGeneratorOutput => {
   const effects: TGeneratorEffect[] = [];
 
+  // ADR-113 / #1075 E0707: a for-loop with no controlling expression (`for (;;)`)
+  // is a disguised infinite loop. C-Next has one source form for that — `forever`.
+  if (!node.expression()) {
+    throw new Error(
+      "Error E0707: for-loop has no controlling expression (infinite loop)\n" +
+        "  help: write 'forever { ... }' for an intentional infinite loop",
+    );
+  }
+
   let init = "";
   const forInit = node.forInit();
   if (forInit) {
@@ -321,6 +336,9 @@ const generateFor = (
 
     // Issue #884: Validate condition is a boolean expression (E0701)
     orchestrator.validateConditionIsBoolean(node.expression()!, "for");
+
+    // ADR-113 / #1075: reject always-true literal condition (E0707)
+    orchestrator.validateLoopConditionNotAlwaysTrue(node.expression()!);
     condition = orchestrator.generateExpression(node.expression()!);
   }
 

--- a/src/transpiler/output/codegen/generators/statements/__tests__/ControlFlowGenerator.test.ts
+++ b/src/transpiler/output/codegen/generators/statements/__tests__/ControlFlowGenerator.test.ts
@@ -365,6 +365,7 @@ function createMockOrchestrator(options?: {
     flushPendingTempDeclarations: vi.fn(() => options?.tempDeclarations ?? ""),
     validateConditionNoFunctionCall: vi.fn(),
     validateConditionIsBoolean: vi.fn(),
+    validateLoopConditionNotAlwaysTrue: vi.fn(),
     countStringLengthAccesses: vi.fn(() => new Map()),
     countBlockLengthAccesses: vi.fn(),
     setupLengthCache: vi.fn(() => options?.lengthCacheDecls ?? ""),
@@ -898,15 +899,15 @@ describe("ControlFlowGenerator", () => {
   // ========================================================================
 
   describe("generateFor", () => {
-    it("generates empty for loop (infinite loop)", () => {
-      const ctx = createMockForStatement();
+    it("rejects an empty for(;;) header as a disguised infinite loop (ADR-113 / #1075, E0707)", () => {
+      const ctx = createMockForStatement(); // no controlling expression
       const input = createMockInput();
       const state = createMockState();
       const orchestrator = createMockOrchestrator({ statementCode: "{ }" });
 
-      const result = generateFor(ctx, input, state, orchestrator);
-
-      expect(result.code).toBe("for (; ; ) { }");
+      expect(() => generateFor(ctx, input, state, orchestrator)).toThrow(
+        /E0707: for-loop has no controlling expression/,
+      );
     });
 
     it("generates for loop with all parts", () => {
@@ -947,6 +948,7 @@ describe("ControlFlowGenerator", () => {
             operator: createMockAssignmentOperator("<-"),
           }),
         }),
+        expr: createMockExpression({ text: "i < 10" }),
       });
       const input = createMockInput();
       const state = createMockState();
@@ -1007,6 +1009,7 @@ describe("ControlFlowGenerator", () => {
         init: createMockForInit({
           varDecl: createMockForVarDecl(),
         }),
+        expr: createMockExpression({ text: "i < 10" }),
       });
       const input = createMockInput();
       const state = createMockState();

--- a/tests/control-flow/forever-disguised-dowhile.expected.error
+++ b/tests/control-flow/forever-disguised-dowhile.expected.error
@@ -1,0 +1,2 @@
+1:0 Code generation failed: Error E0707: loop condition '1=1' is always true
+  help: write 'forever { ... }' for an intentional infinite loop

--- a/tests/control-flow/forever-disguised-dowhile.test.cnx
+++ b/tests/control-flow/forever-disguised-dowhile.test.cnx
@@ -1,0 +1,8 @@
+// Coverage: ADR-113 / #1075 - always-true do-while literal condition (E0707)
+// test-error
+void run() {
+    u8 state <- 0;
+    do {
+        state <- 1;
+    } while (1 = 1);
+}

--- a/tests/control-flow/forever-disguised-for-cond.expected.error
+++ b/tests/control-flow/forever-disguised-for-cond.expected.error
@@ -1,0 +1,2 @@
+1:0 Code generation failed: Error E0707: loop condition '1=1' is always true
+  help: write 'forever { ... }' for an intentional infinite loop

--- a/tests/control-flow/forever-disguised-for-cond.test.cnx
+++ b/tests/control-flow/forever-disguised-for-cond.test.cnx
@@ -1,0 +1,8 @@
+// Coverage: ADR-113 / #1075 - always-true for-loop literal condition (E0707)
+// test-error
+void run() {
+    u8 state <- 0;
+    for (u8 i <- 0; 1 = 1; i +<- 1) {
+        state <- 1;
+    }
+}

--- a/tests/control-flow/forever-disguised-for-empty.expected.error
+++ b/tests/control-flow/forever-disguised-for-empty.expected.error
@@ -1,0 +1,2 @@
+1:0 Code generation failed: Error E0707: for-loop has no controlling expression (infinite loop)
+  help: write 'forever { ... }' for an intentional infinite loop

--- a/tests/control-flow/forever-disguised-for-empty.test.cnx
+++ b/tests/control-flow/forever-disguised-for-empty.test.cnx
@@ -1,0 +1,8 @@
+// Coverage: ADR-113 / #1075 - empty for(;;) is forbidden, steered to forever (E0707)
+// test-error
+void run() {
+    u8 state <- 0;
+    for (;;) {
+        state <- 1;
+    }
+}

--- a/tests/control-flow/forever-disguised-while-bool.expected.error
+++ b/tests/control-flow/forever-disguised-while-bool.expected.error
@@ -1,0 +1,2 @@
+1:0 Code generation failed: Error E0707: loop condition 'true=true' is always true
+  help: write 'forever { ... }' for an intentional infinite loop

--- a/tests/control-flow/forever-disguised-while-bool.test.cnx
+++ b/tests/control-flow/forever-disguised-while-bool.test.cnx
@@ -1,0 +1,8 @@
+// Coverage: ADR-113 / #1075 - always-true boolean literal condition (E0707)
+// test-error
+void run() {
+    u8 state <- 0;
+    while (true = true) {
+        state <- 1;
+    }
+}

--- a/tests/control-flow/forever-disguised-while-eq.expected.error
+++ b/tests/control-flow/forever-disguised-while-eq.expected.error
@@ -1,0 +1,2 @@
+1:0 Code generation failed: Error E0707: loop condition '1=1' is always true
+  help: write 'forever { ... }' for an intentional infinite loop

--- a/tests/control-flow/forever-disguised-while-eq.test.cnx
+++ b/tests/control-flow/forever-disguised-while-eq.test.cnx
@@ -1,0 +1,8 @@
+// Coverage: ADR-113 / #1075 - always-true literal while condition forbidden (E0707)
+// test-error
+void run() {
+    u8 state <- 0;
+    while (1 = 1) {
+        state <- 1;
+    }
+}

--- a/tests/control-flow/forever-disguised-while-rel.expected.error
+++ b/tests/control-flow/forever-disguised-while-rel.expected.error
@@ -1,0 +1,2 @@
+1:0 Code generation failed: Error E0707: loop condition '5>3' is always true
+  help: write 'forever { ... }' for an intentional infinite loop

--- a/tests/control-flow/forever-disguised-while-rel.test.cnx
+++ b/tests/control-flow/forever-disguised-while-rel.test.cnx
@@ -1,0 +1,8 @@
+// Coverage: ADR-113 / #1075 - always-true relational literal condition (E0707)
+// test-error
+void run() {
+    u8 state <- 0;
+    while (5 > 3) {
+        state <- 1;
+    }
+}


### PR DESCRIPTION
Implements the **v0.2.18 literal slice** of ADR-113's "Forbidding the Disguised Infinite Loop". With `forever` now the single source form (#1074), the disguised forms are rejected and steered to it.

Closes #1075.

## What's included
- **E0707 — `for (;;)`**: a for-loop with no controlling expression is rejected in `generateFor`.
- **E0707 — always-true literal condition**: `while`/`for`/`do-while` conditions that are a single comparison of integer/bool literals evaluating to true (`1 = 1`, `5 > 3`, `true = true`, `1 != 2`) are rejected via `TypeValidator.validateLoopConditionNotAlwaysTrue` (wired through `IOrchestrator`, called after the E0701 boolean check).

## Scope (literal slice only)
No symbol resolution. **Not** flagged — deferred to full MISRA 14.3 (#1076):
- named constants / non-literal or compound operands (`MAX > 0`, `1 + 0 = 1`)
- float operands (`5.0 > 3.0`)
- always-**false** conditions (`1 = 2`, `5 < 3`)

MISRA 14.3 moves **Not Enforced → Partial**. Repo audit confirmed **zero** pre-existing `for (;;)` / `while (1 = 1)` in source (the one case was migrated in #1074), so this breaking change flags nothing existing.

## Tests
- 6 `test-error` integration cases: `for(;;)`, `while` (eq / relational / bool), `do-while`, `for` condition.
- 24 `TypeValidator` unit tests: all 6 operators, the always-false boundary, and the non-literal / compound / float / `||` / `&&` skip paths.
- Updated the `ControlFlowGenerator` unit mock + the now-obsolete `for(;;)` generation test (it encoded the pre-E0707 behavior).

## Verification
- Unit: **5790 passed** · Integration: **991 passed**
- oxlint / prettier / cspell clean
- cppcheck MISRA: no new violation class

🤖 Generated with [Claude Code](https://claude.com/claude-code)