### PR TITLE
docs: correct merge guidance in CONTRIBUTING (never squash)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -109,7 +109,7 @@ npm run typecheck
 4. **Update documentation** (README, ADRs, learn-cnext)
 5. **Create a Pull Request** with complete description
 6. **Address review feedback** until approved
-7. **Squash and merge** into main
+7. **Merge** into main with a merge commit (never squash)
 
 ---
 


### PR DESCRIPTION
Workflow step 7 in `CONTRIBUTING.md` said **"Squash and merge into main"**, which contradicts the project's never-squash rule (always use merge commits). This corrects it to merge-commit guidance.

Docs-only; one-line change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)