### PR TITLE
ADR-062: Sink-aware auto-const for array parameters (Proposed)

### DIFF
--- a/docs/cnext-ai-reference.md
+++ b/docs/cnext-ai-reference.md
@@ -345,12 +345,34 @@ void increment(u32 x) {     // transpiles to: void increment(uint32_t *x)
 increment(myVar);            // transpiles to: increment(&myVar);
 ```
 
+**Arrays are the exception — never auto-const** (ADR-006, c-next #986). A read-only array param stays a plain **mutable** pointer, so it can pass straight through to C APIs that expect `uint8_t*` (auto-const used to break that with a `const` mismatch error). For const-correctness (MISRA C:2012 Rule 8.13, or to accept read-only/flash buffers) write **explicit** `const`:
+
+```cnx
+void copy(const u8[8] src, u8[8] dst) {   // src read-only → EXPLICIT const required
+    for (u8 i <- 0; i < 8; i +<- 1) { dst[i] <- src[i]; }
+}
+// -> void copy(const uint8_t src[8], uint8_t dst[8])
+// A read-only STRUCT param DOES auto-const:  void f(Msg m) -> void f(const Msg* m)
+```
+
 **Consequence:** Cannot pass literals to functions (no addressable location).
 
 ```cnx
 const u32 LED_PIN <- 13;
 init(LED_PIN);                // OK: LED_PIN has an address
 // init(13);                  // ERROR: literal has no address
+```
+
+**Exposing a scope constant to C/C++:** a `public const` inside a `scope` becomes an
+`extern const` header symbol named `Scope_NAME` (a private const stays file-local). Use
+it to publish module constants (a PGN, a size, an interval):
+
+```cnx
+scope Protocol {
+    public const u16 PGN <- 0xFFDC;      // -> extern const uint16_t Protocol_PGN;  (in .h)
+    const u8 RETRIES <- 3;               // private -> not exported
+}
+// C++ / C consumer:  uint16_t p = Protocol_PGN;
 ```
 
 ## Control Flow
@@ -1189,6 +1211,23 @@ i32 wide <- raw;                        // ERROR: sign change (unsigned → sign
 i32 wide <- raw[0, 16];                 // explicit 16-bit extraction → i32
 ```
 
+### 18. Expecting read-only array params to be const
+
+Read-only **struct** params auto-const, but read-only **array** params do NOT
+(ADR-006 / c-next #986 — kept mutable for C-API passthrough). Write `const` yourself
+for const-correctness (MISRA C:2012 Rule 8.13, read-only/flash buffers).
+
+```cnx
+// WRONG — expecting const; it's a plain mutable pointer
+void decode(u8[8] data, Msg m) { }       // -> void decode(uint8_t data[8], Msg* m)
+
+// RIGHT — explicit const for a read-only array input
+void decode(const u8[8] data, Msg m) { } // -> void decode(const uint8_t data[8], Msg* m)
+
+// (a read-only STRUCT param auto-consts on its own:)
+void encode(Msg m, u8[8] out) { }        // -> void encode(const Msg* m, uint8_t out[8])
+```
+
 ---
 
 # Part 4: Transpilation Reference
@@ -1201,6 +1240,8 @@ i32 wide <- raw[0, 16];                 // explicit 16-bit extraction → i32
 | `if (x = 5)`                      | `if (x == 5)`                                             |
 | `x +<- 1`                         | `x += 1`                                                  |
 | `void f(u32 x)` (x modified)      | `void f(uint32_t *x)` — or `uint32_t x` if read-only      |
+| `void f(u8[8] data)` (read-only)  | `void f(uint8_t data[8])` — arrays need EXPLICIT `const`  |
+| `void f(const u8[8] data)`        | `void f(const uint8_t data[8])`                           |
 | `f(myVar)`                        | `f(&myVar)`                                               |
 | `scope S { private void f() {} }` | `static void S_f(void) {}`                                |
 | `scope S { void f() {} }`         | `void S_f(void) {}` + header (public by default)          |

--- a/docs/decisions/adr-062-sink-aware-array-auto-const.md
+++ b/docs/decisions/adr-062-sink-aware-array-auto-const.md
@@ -1,0 +1,172 @@
+# ADR-062: Sink-Aware Auto-Const for Array Parameters
+
+**Status:** Proposed
+**Date:** 2026-07-07
+**Decision Makers:** C-Next Language Design Team
+**Amends:** ADR-006 (Simplified Reference Model) — array-parameter auto-const behavior
+**Supersedes:** the blanket approach introduced in #986 ("array params no longer get auto-const")
+
+## Context
+
+C-Next infers `const` on pass-by-reference parameters a function only reads
+("auto-const", Issue #268). A parameter is const-qualified unless it is _modified_ —
+directly (`p[i] <- x`) or transitively (passed to a callee that modifies its
+corresponding parameter, via the `TransitiveModificationPropagator`, Issue #269).
+
+**#986 turned this off for arrays entirely.** The trigger was C-API passthrough:
+
+```cnx
+void sendFrame(u8[8] payload) {
+    canBusWrite(payload);          // external C API: void canBusWrite(uint8_t* buf)
+}
+```
+
+Auto-const made `sendFrame`'s signature `void sendFrame(const uint8_t payload[8])`,
+which decays to `const uint8_t*`. Forwarding that to `canBusWrite(uint8_t*)` **discards
+the `const` qualifier** — a warning in C, a hard error in C++. The fix shipped as a
+blanket rule: _arrays never auto-const; only explicit `const` in source qualifies them._
+
+### Why the blanket rule is a shortcut
+
+The passthrough break has a precise cause: the transitive modification analysis tracks
+mutation through **C-Next callees it can see the body of**, but an **external** callee has
+no body, so it never contributes a modification — the forwarded array looks read-only and
+is wrongly const-qualified. The correct signal was available all along: the external
+callee's **signature**. A non-`const` pointer parameter is, by contract, a "may modify"
+sink — regardless of what the implementation does. The blanket rule discards a precise,
+locally-available signal (callee parameter const-ness) in favor of "give up on all arrays."
+
+### What the blanket rule costs
+
+1. **Const-correctness by default is lost.** Genuinely read-only array parameters — the
+   common `decode(const u8[8] data, ...)` shape — are no longer const unless hand-annotated.
+2. **MISRA C:2012 Rule 8.13** ("a pointer should point to a const-qualified type whenever
+   possible") moves from _satisfied automatically_ to _opt-in per parameter_.
+3. **The deviation/migration signal is thrown away** (see Decision) — the one place the
+   transpiler could tell you _why_ a buffer can't be const, and what to do about it.
+
+C-Next's no-raw-pointers / no-address-of design makes the precise analysis uniquely
+tractable: an array can only escape a function by being passed as a call argument. There is
+no `&buf`, no pointer arithmetic, no aliasing through casts. **The complete set of a
+parameter's sinks is exactly its set of call-site argument positions** — a closed,
+statically enumerable set.
+
+## Decision
+
+Restore array parameters to the normal auto-const model, and extend the modification
+analysis to treat **an external callee's non-`const` pointer parameter as a mutation
+sink**. Auto-const is then decided by dataflow, per parameter:
+
+| Situation                                                                      | Result                                                              |
+| ------------------------------------------------------------------------------ | ------------------------------------------------------------------- |
+| Read-only; never forwarded to a non-`const` sink                               | **auto-`const`** (silent — just correct)                            |
+| Forwarded (directly or transitively) to a non-`const` pointer sink             | **stays mutable** + emit a **deviation diagnostic** (below)         |
+| Source declares explicit `const`, but a non-`const` sink exists                | **hard error** — the asserted guarantee is contradicted by dataflow |
+| Sink cannot be resolved (function pointer, unknown callback, interop boundary) | **stays mutable** (fail-safe), diagnostic notes "unresolved sink"   |
+
+### The deviation diagnostic is a first-class feature, not a warning to suppress
+
+When a parameter is denied auto-const because it reaches a non-`const` sink, the transpiler
+emits a located, rationalized record:
+
+```
+note[const-sink]: parameter `payload` of `sendFrame` not const-qualified
+  (MISRA C:2012 Rule 8.13 not applied) — forwarded to non-const parameter `buf`
+  of `canBusWrite` at sendFrame.cnx:2
+```
+
+This is deliberately valuable, in two ways:
+
+1. **Automated MISRA deviation evidence.** Rule 8.13 is advisory; a compliant project must
+   _document every deviation with rationale and location_. This diagnostic **is** that
+   record, generated mechanically — no hand-maintained deviation ledger.
+2. **A C→C-Next migration worklist.** Every line names an external (typically C/C++)
+   consumer whose mutable-pointer signature is the _only_ thing blocking const-correctness.
+   That is a prioritized list of "convert this consumer to C-Next next, and the buffer
+   becomes `const` for free." For a project mid-migration this signal is the point, not noise.
+
+The diagnostic is informational (never fails the build), shown by default, and suppressible
+with **`--quiet`** (for builds that don't want the deviation/migration stream); it should
+also be aggregatable into a report for audit sign-off. The **fail-safe** direction guarantees
+it can never break a build that #986 compiled: any uncertainty resolves to "mutable."
+
+## Rationale
+
+- **Reuses existing machinery.** The change is an extension of the
+  `TransitiveModificationPropagator`, not a new pass. External callees are absent from the
+  `modifiedParameters` map today; seeding each external callee's modified-set with the names
+  of its **non-`const` pointer parameters** makes `isParamModified(callee, …)` return `true`
+  for those, and the existing fixed-point iteration propagates the mutability requirement
+  backward through every forwarding chain unchanged.
+- **Feasible because of C-Next's safety model.** No `&`, no pointer arithmetic, no casts to
+  alias → sinks are exactly the argument positions. The analysis is sound without escape
+  analysis that would be intractable in raw C.
+- **`const`-by-default is the MISRA-aligned default;** deviations become the exception,
+  documented automatically.
+
+## Implementation
+
+1. **Seed external sinks.** Where the call graph is built (`CallExprGenerator`, the
+   `ICallInfo` entries feeding `TransitiveModificationPropagator`), for each callee resolve
+   its parameter const-ness from its declaration (C-Next signature or parsed C/C++ header,
+   per ADR-061 interop). Pre-seed `modifiedParameters[callee]` with every parameter whose
+   type is a **non-`const` pointer/array**. The fixed-point `propagate()` then requires no
+   change.
+2. **Remove the blanket.** In `ParameterInputAdapter._buildArrayInputFromAST`, delete the
+   hard-coded `isAutoConst: false` (and its `_buildArrayInputFromSymbol` counterpart) so
+   array parameters use the same `isAutoConst = !isModified && !isConst` path as structs.
+3. **Contradiction error.** When a parameter carries explicit source `const` but the
+   analysis marks it modified via a sink, raise a diagnostic error naming the parameter and
+   the sink.
+4. **Deviation diagnostic.** When auto-const is denied due to a resolved non-`const` sink,
+   emit the `note[const-sink]` record with parameter, sink parameter, callee, and location.
+   Shown by default; suppressed under `--quiet`.
+5. **Unresolved sinks** (function-pointer params, callbacks, opaque/interop boundaries):
+   treat as a mutation sink (fail-safe), tag the diagnostic "unresolved sink."
+
+## Consequences
+
+**Positive**
+
+- Read-only array parameters are `const` again by default (MISRA 8.13 satisfied for free).
+- The transpiler emits an auditable MISRA-8.13 deviation ledger and a C→C-Next migration
+  worklist as a byproduct of the const analysis.
+- Explicit `const` on an array is now _verified_ against dataflow rather than trusted.
+- Uses existing infrastructure; the propagator core is unchanged.
+
+**Negative / risks**
+
+- **Transitive analysis must be correct.** Unlike the blanket rule (which can never wrongly
+  const-qualify), a bug in sink seeding or propagation could const-qualify a buffer that is
+  in fact forwarded to a mutable API. Crucially, this failure mode is a **deterministic
+  compile-time build error** — the generated C/C++ won't compile the instant a `const` buffer
+  meets a non-`const` sink — caught at transpile/build time, so it can never silently reach
+  production. That bounded, loud failure mode is what makes the risk acceptable. Mitigated
+  further by the fail-safe default and a dedicated test matrix (direct sink, N-deep forwarding
+  chain, const sink, unresolved sink, explicit-const contradiction).
+- **Header const-ness must be trusted.** Legacy C APIs that take `uint8_t*` but only read
+  will (correctly, per their contract) deny auto-const. The diagnostic explains it; the
+  remedy is fixing the upstream signature or converting the consumer — both desirable.
+- Slightly less predictable than "arrays are never auto-const" — mitigated by the diagnostic
+  making every decision explicit.
+
+## Alternatives Considered
+
+1. **Status quo (#986 blanket).** Simple, zero false-positives on compilation, and treats
+   "explicit `const` is clearer intent" as a feature. Rejected because it forfeits
+   const-by-default, MISRA-8.13 automation, and the migration signal — the analysis is both
+   feasible and high-value here.
+2. **Always require explicit `const` on all pass-by-reference params (not just arrays).**
+   Consistent, but discards auto-const's ergonomics everywhere and still produces no
+   deviation/migration signal. Rejected.
+3. **Sink-aware without the diagnostic** (silently keep mutable). Rejected — the diagnostic
+   is the feature (see Decision); silence would repeat #986's core mistake of discarding the
+   signal.
+
+## References
+
+- ADR-006 — Simplified Reference Model (auto-const foundation)
+- ADR-061 — C Library Interop (external signature resolution)
+- Issue #268 — auto-const inference; Issue #269 — `TransitiveModificationPropagator`
+- #986 — the blanket array auto-const removal this supersedes
+- MISRA C:2012 Rule 8.13 (advisory) — const-qualify pointers to unmodified data


### PR DESCRIPTION
## Summary

Proposes **ADR-062** — replace #986's blanket *"array params never auto-const"* with a **dataflow rule**: an array parameter is `const`-qualified unless it is forwarded (directly or transitively) to a **non-`const` pointer sink**.

**Status: Proposed** — design only, no transpiler code in this PR. Full text: `docs/decisions/adr-062-sink-aware-array-auto-const.md`.

## Why

#986 disabled array auto-const wholesale to fix C-API passthrough (`const uint8_t*` → `uint8_t*` discards `const` → build error). But that throws away a precise, locally-available signal — the **callee parameter's const-ness**. A non-`const` pointer param is, by contract, a "may modify" sink. The blanket rule costs const-correctness by default (MISRA C:2012 **Rule 8.13**) and the diagnostic signal below.

C-Next's no-raw-pointers / no-`&` design makes this tractable: a parameter's complete sink set is exactly its call-site argument positions — a closed, statically enumerable set.

## The rule

| Situation | Result |
|---|---|
| Read-only, no non-const sink | auto-`const` (silent) |
| Forwarded to a non-const sink | stays mutable + **deviation diagnostic** |
| Explicit `const` + a non-const sink | **hard error** (dataflow contradicts the assertion) |
| Unresolvable sink | mutable (**fail-safe**) |

## The diagnostic is the feature, not noise

`note[const-sink]: param 'data' not const-qualified (MISRA 8.13 not applied) — forwarded to non-const param 'buf' of 'canBusWrite' at f.cnx:2`

Each line is (1) auto-generated **MISRA 8.13 deviation evidence** and (2) a **C→C-Next migration worklist** — the C boundary blocking const. Informational, `--quiet`-suppressible, never fails the build.

## Implementation sketch

Extend `TransitiveModificationPropagator`: seed each external callee's modified-set from its non-`const` pointer params; the existing fixed-point iteration handles transitivity. Remove the blanket `isAutoConst: false` in `ParameterInputAdapter`.

## Feedback wanted 🙏

- **Strict mode?** Diagnostic is informational + `--quiet`-gated. Also want a `--misra`/strict mode that *fails* on an undocumented deviation, or is informational-only right?
- **Contradiction = hard error** (explicit `const` + a real mutable sink) — agree it's an error, not downgrade-to-mutable-with-warning?
- **Fail-safe direction** on unresolvable sinks (function pointers, callbacks) — mutable + "unresolved" tag. Too lax?
- Any sink cases the closed-set argument does NOT cover — varargs, macro-expanded calls, unions?

Supersedes #986; amends ADR-006.
