### PR TITLE
docs: fix stale README, correct mis-compiling bit_test example, extend ADR-114 to liveness

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,10 +37,10 @@ Generates clean C:
 ```c
 #define GPIO7_DR_TOGGLE (*(volatile uint32_t*)(0x42004000 + 0x8C))
 
-uint32_t LED_BIT = 3;
+uint32_t LED_BIT = 3U;
 
 void LED_toggle(void) {
-    GPIO7_DR_TOGGLE = (1 << LED_BIT);
+    GPIO7_DR_TOGGLE = (1U << LED_BIT);
 }
 ```
 
@@ -134,19 +134,19 @@ npm link
 
 ```bash
 # Transpile to C (output alongside input file)
-cnext examples/blink.cnx
+cnext examples/teensy4/blink.cnx
 
 # Explicit output path
-cnext examples/blink.cnx -o blink.c
+cnext examples/teensy4/blink.cnx -o blink.c
 
 # Parse only (syntax check)
-cnext examples/blink.cnx --parse
+cnext examples/teensy4/blink.cnx --parse
 
 # Output as C++ (.cpp)
-cnext examples/blink.cnx --cpp
+cnext examples/teensy4/blink.cnx --cpp
 
 # Target platform for atomic code generation (ADR-049)
-cnext examples/blink.cnx --target teensy41
+cnext examples/teensy4/blink.cnx --target teensy41
 
 # Separate output directories for code and headers
 cnext src/main.cnx -o build/src --header-out build/include
@@ -210,10 +210,11 @@ This creates a pre-build script that automatically transpiles `.cnx` files befor
 
 ## Projects Using C-Next
 
-| Project                                   | Description                                                                        |
-| ----------------------------------------- | ---------------------------------------------------------------------------------- |
-| [OSSM](https://github.com/jlaustill/ossm) | Open-source stroke machine firmware using C-Next for safe embedded control         |
-| [test-teensy](test-teensy/)               | Hardware verification project — validates transpiler output on Teensy MicroMod/4.0 |
+| Project                                           | Description                                                                        |
+| ------------------------------------------------- | ---------------------------------------------------------------------------------- |
+| [OSSM](https://github.com/jlaustill/ossm)         | Open-source stroke machine firmware using C-Next for safe embedded control         |
+| [examples/teensy4](examples/teensy4/)             | Hardware verification project — validates transpiler output on Teensy MicroMod/4.0 |
+| [examples/nucleo-f446re](examples/nucleo-f446re/) | Hardware verification project — validates transpiler output on STM32 Nucleo-F446RE |
 
 _Using C-Next in your project? Open an issue to get listed!_
 
@@ -222,7 +223,7 @@ _Using C-Next in your project? Open an issue to get listed!_
 | Resource                                                      | Description                                |
 | ------------------------------------------------------------- | ------------------------------------------ |
 | [Language Guide](docs/language-guide.md)                      | Complete reference for all C-Next features |
-| [Architecture Decisions](docs/architecture-decisions.md)      | 50+ ADRs documenting design choices        |
+| [Architecture Decisions](docs/architecture-decisions.md)      | 70+ ADRs documenting design choices        |
 | [Learn C-Next in Y Minutes](docs/learn-cnext-in-y-minutes.md) | Quick syntax overview                      |
 | [Error Codes](docs/error-codes.md)                            | Compiler error reference                   |
 | [MISRA Compliance](docs/misra-compliance.md)                  | MISRA C:2012 compliance details            |
@@ -241,9 +242,12 @@ c-next/
 │   │   └── output/                     # Generation (codegen, headers)
 │   └── utils/                          # Shared utilities
 ├── examples/
-│   ├── blink.cnx                       # LED blink (Teensy verified)
-│   └── bit_test.cnx                    # Bit manipulation tests
-├── test-teensy/                        # PlatformIO test project
+│   ├── bit_test.cnx                    # Bit manipulation tests
+│   ├── references.cnx                  # Pass-by-reference examples
+│   ├── structs.cnx                     # Struct examples
+│   ├── uart_buffer.cnx                 # UART ring-buffer example
+│   ├── teensy4/                        # Teensy 4.x PlatformIO verification project
+│   └── nucleo-f446re/                  # STM32 Nucleo-F446RE verification project
 └── docs/decisions/                     # Architecture Decision Records
 ```
 

--- a/docs/decisions/adr-114-dead-code-reachability.md
+++ b/docs/decisions/adr-114-dead-code-reachability.md
@@ -3,8 +3,8 @@
 **Status:** Research
 **Date:** 2026-06-26
 **Decision Makers:** Language Design Team
-**Related ADRs:** ADR-112 (All-Paths-Return), ADR-110 (DO-178C Compliance), ADR-113 (Forever Loops)
-**Related Issues:** #849 (MISRA 2.1/2.2 — No unreachable / dead code; the active issue) — formerly part of the now-closed #839 MISRA-breakdown parent
+**Related ADRs:** ADR-112 (All-Paths-Return), ADR-110 (DO-178C Compliance), ADR-113 (Forever Loops), ADR-115 (Return-Value Use), ADR-058 (Explicit Length Properties)
+**Related Issues:** #849 (MISRA 2.1/2.2 — No unreachable / dead code; the active issue) — formerly part of the now-closed #839 MISRA-breakdown parent; #1107 (unused variables — the liveness half of this ADR, added below)
 
 ## Context
 
@@ -58,15 +58,54 @@ So a reachability pass can reuse ~90% of `ReturnPathAnalyzer`'s logic rather tha
 > This ADR is in **Research** status. The direction below reflects the current design
 > conversation; nothing here is approved or implemented.
 
-Add a compile-time **reachability analysis** that rejects any statement which cannot be reached
-on any control-flow path from the function entry (proposed **E0706 — unreachable code**).
+Add compile-time **dead-code analysis** covering the two structural flavors of dead code that
+MISRA C:2012 Rule 2.x leaves to the compiler:
 
-### Coverage
+1. **Reachability** — reject any statement that cannot be reached on any control-flow path from
+   the function entry (proposed **E0706 — unreachable code**). MISRA Rule 2.1.
+2. **Liveness** — reject any variable that is defined but never used (proposed **E0709 — unused
+   variable**; code not yet allocated). MISRA Rule 2.2's own definition of dead code — "an
+   operation whose removal would not affect program behavior" — already covers a variable whose
+   initialization and storage are never read. See **Unused objects (liveness)** below.
+
+Both belong in this one ADR (and, per _Architecture_, one analyzer) because they answer the same
+question — "is this code dead?" — over the same parse tree. Splitting them would fragment the
+"is it dead?" decision across passes, which the project's "No Duplicate Code Paths" rule forbids.
+
+### Coverage — reachability (E0706)
 
 - code after an unconditional `return`;
 - code after a `forever` loop (ADR-113);
 - code after an `if`/`else` where both branches diverge;
 - code after a `switch` with a `default` where every case diverges.
+
+### Unused objects (liveness) — #1107 (proposed E0709)
+
+C-Next performs **no liveness analysis today**. A variable defined but never used transpiles
+cleanly, for locals and globals alike:
+
+```cnx
+u32 counter <- 0;
+void t() {
+    u32 x <- counter.bit_length;   // .bit_length is compile-time (32); counter's value never read
+}
+```
+
+transpiles (verified) to `uint32_t counter = 0U;` with no diagnostic — `counter` is allocated,
+initialized, and never read or written. Both `counter` (read only via a compile-time property)
+and a plain dead local like `u32 dead <- 0;` are accepted.
+
+**Proposed coverage:**
+
+- a local variable that is never read after declaration;
+- a file-scope / global variable that is never read anywhere in the translation unit;
+- a variable read _only_ through a compile-time property (`.bit_length`, `.element_count`,
+  ADR-058) — see the open question below on whether this counts as a use.
+
+**Explicitly out of scope for v1** (each already has its own MISRA row and can be sequenced
+later): unused type declarations (2.3), unused tag declarations (2.4), unused function
+declarations (2.6), unused function parameters (2.7). This ADR's liveness pass targets
+_objects/variables_ first; the others can join the same analyzer once the primitive exists.
 
 ### Architecture (proposed)
 
@@ -86,11 +125,12 @@ on any control-flow path from the function entry (proposed **E0706 — unreachab
   "what diverges" independently would be a latent divergence bug.
 - Layer constraint respected: `logic/analysis/` does not import from `output/`.
 
-### Proposed error codes (not yet allocated)
+### Proposed error codes
 
-| Code  | Meaning          |
-| ----- | ---------------- |
-| E0706 | Unreachable code |
+| Code  | Meaning          | Status                                               |
+| ----- | ---------------- | ---------------------------------------------------- |
+| E0706 | Unreachable code | Free, reserved for this ADR (see Research Finding 4) |
+| E0709 | Unused variable  | Not yet allocated — confirm free before use          |
 
 ## Relationship to ADR-113
 
@@ -164,6 +204,19 @@ forever { loop(); } }`, with no statement after the `forever`. `scripts/__tests_
 
 ## Open Questions
 
+- **(Liveness) Does compile-time property access count as a use?** `counter.bit_length` and
+  `buffer.element_count` (ADR-058) read a property of the _type_, resolved at compile time —
+  they never touch the object's storage. Under strict liveness the object is still dead. But a
+  developer writing `u32 bits <- counter.bit_length;` clearly _intends_ `counter` to exist. v1
+  must pick one rule explicitly. Leaning toward **"compile-time property access is NOT a use"**
+  (matches the storage-liveness definition and would correctly flag `examples/bit_test.cnx`'s
+  `counter`/`buffer`), but this needs a decision — it directly changes whether that example, and
+  the ADR-058 demonstrations, compile.
+- **(Liveness) Cross-translation-unit globals.** A file-scope variable unused within its own
+  `.cnx` may be part of the module's public surface (read by an including `.c`/`.cnx`). Flagging
+  every locally-unread global would break legitimate exported state. v1 likely restricts the
+  global check to variables not exposed in the generated header, or scopes liveness to **locals
+  only** first and defers globals. Needs a decision.
 - **Function calls that never return.** Without a `never`/bottom type (see ADR-113,
   Alternative 1), a call like a future `panic()` cannot be treated as divergent, so code after
   it would be wrongly considered reachable. Scope this ADR to _structural_ divergence

--- a/examples/bit_test.cnx
+++ b/examples/bit_test.cnx
@@ -15,7 +15,7 @@ void test_bits() {
     flags[7] <- false; // Clear bit 7
 
     // Bit range operations
-    flags[4][3] <- 5; // Set 3 bits starting at bit 4 to value 5
+    flags[4, 3] <- 5; // Set 3 bits starting at bit 4 to value 5
 
     // Read bits
     bool bit3 <- flags[3];


### PR DESCRIPTION
## What this fixes

Started as a README accuracy check and uncovered three real transpiler bugs behind a stale, mis-compiling example. This PR handles the **docs/tracking half** (safe, no behavior change); the transpiler fixes are tracked as separate issues below.

### README (rotted after examples were reorganized)
- `examples/blink.cnx` → `examples/teensy4/blink.cnx` (6 refs, incl. every Usage command — all previously pointed at a non-existent file)
- `test-teensy/` removed → hardware verification now under `examples/teensy4` + `examples/nucleo-f446re`
- Quick-Example generated C missing MISRA unsigned-literal suffixes (`3`→`3U`, `1`→`1U`) — verified against current codegen
- `examples/` tree completed; "50+ ADRs" → "70+"

### `examples/bit_test.cnx`
Line 18 used `flags[4][3] <- 5`, which **silently miscompiled** to a single-bit write of `1` (dropped the width, coerced `5` to a bool). Corrected to the documented bit-range write `flags[4, 3] <- 5`, which generates a correct 3-bit field write. Verified; all 7 example-guard tests pass.

### ADR-114 (Dead-Code / Reachability, stays **Research**)
Extended to fold in **unused-variable (liveness)** detection as the MISRA 2.2 dead-code counterpart to reachability — one analyzer, one "is it dead?" decision. Added proposed **E0709**, coverage, and two open design questions (does compile-time property access count as a "use"?; cross-TU global liveness). Per maintainer direction.

## Bugs tracked upstream (not worked around)
- #1106 — scalar `x[a][b]` silently miscompiles instead of type-erroring (violates Implemented ADR-036/007)
- #1107 — no unused-variable detection (the ADR-114 liveness gap extended here)
- #1108 — duplicate system `#include` when source includes a header the transpiler also auto-injects

## Root cause the audit exposed
The examples CI guard (`examples-transpile.test.ts`, #1048) only checks that generated C **compiles**, not that it's semantically correct — so wrong-but-valid C rotted undetected. Worth a follow-up to strengthen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
