### PR TITLE
fix(codegen): dedup system #include directives (#1108)

### DIFF
--- a/src/transpiler/output/codegen/CodeGenerator.ts
+++ b/src/transpiler/output/codegen/CodeGenerator.ts
@@ -459,6 +459,10 @@ export default class CodeGenerator implements IOrchestrator {
           CodeGenState.usedSafeDivOps.add(
             `${effect.operation}_${effect.cnxType}`,
           );
+          // ADR-051 safe-div helpers return a bool error flag. Route that
+          // dependency through the single include path (#1108) rather than
+          // letting the helper emit its own #include <stdbool.h>.
+          this.requireInclude("stdbool");
           break;
 
         // Type registration effects
@@ -2451,17 +2455,40 @@ export default class CodeGenerator implements IOrchestrator {
    * Add auto-generated includes based on usage.
    */
   private addAutoIncludes(output: string[]): void {
-    const autoIncludes: string[] = [];
+    // Issue #1108: dedup auto-includes against passthrough source includes
+    // (processIncludeDirectives runs first). A source that already
+    // `#include`s e.g. <stdint.h> must not have it emitted a second time.
+    const present = new Set(
+      output
+        .map((line) => CodeGenerator.extractIncludeTarget(line))
+        .filter((target): target is string => target !== null),
+    );
 
-    if (CodeGenState.needsStdint) autoIncludes.push("#include <stdint.h>");
-    if (CodeGenState.needsStdbool) autoIncludes.push("#include <stdbool.h>");
-    if (CodeGenState.needsString) autoIncludes.push("#include <string.h>");
-    if (CodeGenState.needsCMSIS) autoIncludes.push("#include <cmsis_gcc.h>");
-    if (CodeGenState.needsLimits) autoIncludes.push("#include <limits.h>");
+    const autoIncludes: string[] = [];
+    const addInclude = (target: string): void => {
+      if (present.has(target)) return;
+      autoIncludes.push(`#include ${target}`);
+      present.add(target);
+    };
+
+    if (CodeGenState.needsStdint) addInclude("<stdint.h>");
+    if (CodeGenState.needsStdbool) addInclude("<stdbool.h>");
+    if (CodeGenState.needsString) addInclude("<string.h>");
+    if (CodeGenState.needsCMSIS) addInclude("<cmsis_gcc.h>");
+    if (CodeGenState.needsLimits) addInclude("<limits.h>");
 
     if (autoIncludes.length > 0) {
       output.push(...autoIncludes, "");
     }
+  }
+
+  /**
+   * Extract the include target (`<header.h>` or `"header.h"`) from a line,
+   * or null if the line is not a plain `#include` directive.
+   */
+  private static extractIncludeTarget(line: string): string | null {
+    const match = /^#include\s+(<[^>]+>|"[^"]+")\s*$/.exec(line.trim());
+    return match ? match[1] : null;
   }
 
   /**

--- a/src/transpiler/output/codegen/__tests__/RequireInclude.test.ts
+++ b/src/transpiler/output/codegen/__tests__/RequireInclude.test.ts
@@ -261,50 +261,44 @@ describe("CodeGenerator requireInclude", () => {
     const countOccurrences = (haystack: string, needle: string): number =>
       haystack.split(needle).length - 1;
 
-    it("emits stdint.h once when source already includes it", async () => {
-      const transpiler = new Transpiler({ input: "", noCache: true }, mockFs);
+    /**
+     * Each case reaches the same header by a different route, and every route
+     * must converge on exactly one `#include`:
+     *  - source passthrough colliding with an auto-include, and
+     *  - the ADR-051 safe-div helper, whose bool dependency now flows through
+     *    requireInclude() instead of the helper emitting its own directive.
+     */
+    const DEDUP_CASES = [
+      {
+        route: "source passthrough of stdint.h",
+        header: "#include <stdint.h>",
+        source: "#include <stdint.h>\nu8 value <- 0;",
+      },
+      {
+        route: "source passthrough of stdbool.h",
+        header: "#include <stdbool.h>",
+        source: "#include <stdbool.h>\nbool flag <- true;",
+      },
+      {
+        route: "safe-div helper needing stdbool.h",
+        header: "#include <stdbool.h>",
+        source:
+          "void t() { u32 r <- 0; bool err <- false; err <- safe_div(r, 10, 2, 0); }",
+      },
+    ];
 
-      const result = (
-        await transpiler.transpile({
-          kind: "source",
-          source: "#include <stdint.h>\nu8 value <- 0;",
-        })
-      ).files[0];
+    it.each(DEDUP_CASES)(
+      "emits the header exactly once via $route",
+      async ({ header, source }) => {
+        const transpiler = new Transpiler({ input: "", noCache: true }, mockFs);
 
-      expect(result.success).toBe(true);
-      expect(result.code).toContain("#include <stdint.h>");
-      expect(countOccurrences(result.code!, "#include <stdint.h>")).toBe(1);
-    });
+        const result = (await transpiler.transpile({ kind: "source", source }))
+          .files[0];
 
-    it("emits stdbool.h once when source already includes it", async () => {
-      const transpiler = new Transpiler({ input: "", noCache: true }, mockFs);
-
-      const result = (
-        await transpiler.transpile({
-          kind: "source",
-          source: "#include <stdbool.h>\nbool flag <- true;",
-        })
-      ).files[0];
-
-      expect(result.success).toBe(true);
-      expect(result.code).toContain("#include <stdbool.h>");
-      expect(countOccurrences(result.code!, "#include <stdbool.h>")).toBe(1);
-    });
-
-    it("emits stdbool.h once when safe division is used (helper path, #1108)", async () => {
-      const transpiler = new Transpiler({ input: "", noCache: true }, mockFs);
-
-      const result = (
-        await transpiler.transpile({
-          kind: "source",
-          source:
-            "void t() { u32 r <- 0; bool err <- false; err <- safe_div(r, 10, 2, 0); }",
-        })
-      ).files[0];
-
-      expect(result.success).toBe(true);
-      expect(result.code).toContain("#include <stdbool.h>");
-      expect(countOccurrences(result.code!, "#include <stdbool.h>")).toBe(1);
-    });
+        expect(result.success).toBe(true);
+        expect(result.code).toContain(header);
+        expect(countOccurrences(result.code!, header)).toBe(1);
+      },
+    );
   });
 });

--- a/src/transpiler/output/codegen/__tests__/RequireInclude.test.ts
+++ b/src/transpiler/output/codegen/__tests__/RequireInclude.test.ts
@@ -256,4 +256,55 @@ describe("CodeGenerator requireInclude", () => {
       expect(result.code).not.toContain("#include <string.h>");
     });
   });
+
+  describe("deduplicates auto-includes against passthrough includes (#1108)", () => {
+    const countOccurrences = (haystack: string, needle: string): number =>
+      haystack.split(needle).length - 1;
+
+    it("emits stdint.h once when source already includes it", async () => {
+      const transpiler = new Transpiler({ input: "", noCache: true }, mockFs);
+
+      const result = (
+        await transpiler.transpile({
+          kind: "source",
+          source: "#include <stdint.h>\nu8 value <- 0;",
+        })
+      ).files[0];
+
+      expect(result.success).toBe(true);
+      expect(result.code).toContain("#include <stdint.h>");
+      expect(countOccurrences(result.code!, "#include <stdint.h>")).toBe(1);
+    });
+
+    it("emits stdbool.h once when source already includes it", async () => {
+      const transpiler = new Transpiler({ input: "", noCache: true }, mockFs);
+
+      const result = (
+        await transpiler.transpile({
+          kind: "source",
+          source: "#include <stdbool.h>\nbool flag <- true;",
+        })
+      ).files[0];
+
+      expect(result.success).toBe(true);
+      expect(result.code).toContain("#include <stdbool.h>");
+      expect(countOccurrences(result.code!, "#include <stdbool.h>")).toBe(1);
+    });
+
+    it("emits stdbool.h once when safe division is used (helper path, #1108)", async () => {
+      const transpiler = new Transpiler({ input: "", noCache: true }, mockFs);
+
+      const result = (
+        await transpiler.transpile({
+          kind: "source",
+          source:
+            "void t() { u32 r <- 0; bool err <- false; err <- safe_div(r, 10, 2, 0); }",
+        })
+      ).files[0];
+
+      expect(result.success).toBe(true);
+      expect(result.code).toContain("#include <stdbool.h>");
+      expect(countOccurrences(result.code!, "#include <stdbool.h>")).toBe(1);
+    });
+  });
 });

--- a/src/transpiler/output/codegen/generators/support/HelperGenerator.ts
+++ b/src/transpiler/output/codegen/generators/support/HelperGenerator.ts
@@ -91,11 +91,11 @@ const generateSafeDivHelpers = (
 
   const lines: string[] = [];
 
-  lines.push(
-    "// ADR-051: Safe division helper functions",
-    "#include <stdbool.h>",
-    "",
-  );
+  // Issue #1108: the <stdbool.h> dependency (helpers return a bool error flag)
+  // is signalled via requireInclude("stdbool") when the safe-div effect is
+  // applied, so it flows through the single addAutoIncludes path. Emitting it
+  // here too would duplicate the include.
+  lines.push("// ADR-051: Safe division helper functions", "");
 
   const integerTypes = ["u8", "u16", "u32", "u64", "i8", "i16", "i32", "i64"];
 

--- a/src/transpiler/output/codegen/generators/support/__tests__/HelperGenerator.test.ts
+++ b/src/transpiler/output/codegen/generators/support/__tests__/HelperGenerator.test.ts
@@ -234,9 +234,12 @@ describe("HelperGenerator - generateSafeDivHelpers", () => {
       expect(code).toContain("cnx_safe_mod_u64");
     });
 
-    it("includes stdbool.h header", () => {
+    it("does not emit its own stdbool.h include (#1108)", () => {
+      // The <stdbool.h> dependency is signalled via requireInclude("stdbool")
+      // when the safe-div effect is applied, so it flows through the single
+      // addAutoIncludes path. The helper must not emit a duplicate include.
       const result = generateSafeDivHelpers(new Set(["div_u8"]));
-      expect(result.join("\n")).toContain("#include <stdbool.h>");
+      expect(result.join("\n")).not.toContain("#include <stdbool.h>");
     });
 
     it("includes ADR-051 comment", () => {

--- a/tests/arithmetic/safe-div-all-types.expected.c
+++ b/tests/arithmetic/safe-div-all-types.expected.c
@@ -7,7 +7,6 @@
 #include <stdbool.h>
 
 // ADR-051: Safe division helper functions
-#include <stdbool.h>
 
 static inline bool cnx_safe_div_u8(uint8_t* output, uint8_t numerator, uint8_t divisor, uint8_t defaultValue) {
     if (divisor == 0) {

--- a/tests/arithmetic/safe-div-all-types.expected.cpp
+++ b/tests/arithmetic/safe-div-all-types.expected.cpp
@@ -7,7 +7,6 @@
 #include <stdbool.h>
 
 // ADR-051: Safe division helper functions
-#include <stdbool.h>
 
 static inline bool cnx_safe_div_u8(uint8_t* output, uint8_t numerator, uint8_t divisor, uint8_t defaultValue) {
     if (divisor == 0) {

--- a/tests/arithmetic/safe-div-all-types.test.c
+++ b/tests/arithmetic/safe-div-all-types.test.c
@@ -7,7 +7,6 @@
 #include <stdbool.h>
 
 // ADR-051: Safe division helper functions
-#include <stdbool.h>
 
 static inline bool cnx_safe_div_u8(uint8_t* output, uint8_t numerator, uint8_t divisor, uint8_t defaultValue) {
     if (divisor == 0) {

--- a/tests/arithmetic/safe-div-all-types.test.cpp
+++ b/tests/arithmetic/safe-div-all-types.test.cpp
@@ -7,7 +7,6 @@
 #include <stdbool.h>
 
 // ADR-051: Safe division helper functions
-#include <stdbool.h>
 
 static inline bool cnx_safe_div_u8(uint8_t* output, uint8_t numerator, uint8_t divisor, uint8_t defaultValue) {
     if (divisor == 0) {

--- a/tests/arithmetic/safe-div-basic.expected.c
+++ b/tests/arithmetic/safe-div-basic.expected.c
@@ -7,7 +7,6 @@
 #include <stdbool.h>
 
 // ADR-051: Safe division helper functions
-#include <stdbool.h>
 
 static inline bool cnx_safe_div_u32(uint32_t* output, uint32_t numerator, uint32_t divisor, uint32_t defaultValue) {
     if (divisor == 0) {

--- a/tests/arithmetic/safe-div-basic.expected.cpp
+++ b/tests/arithmetic/safe-div-basic.expected.cpp
@@ -7,7 +7,6 @@
 #include <stdbool.h>
 
 // ADR-051: Safe division helper functions
-#include <stdbool.h>
 
 static inline bool cnx_safe_div_u32(uint32_t* output, uint32_t numerator, uint32_t divisor, uint32_t defaultValue) {
     if (divisor == 0) {

--- a/tests/arithmetic/safe-div-basic.test.c
+++ b/tests/arithmetic/safe-div-basic.test.c
@@ -7,7 +7,6 @@
 #include <stdbool.h>
 
 // ADR-051: Safe division helper functions
-#include <stdbool.h>
 
 static inline bool cnx_safe_div_u32(uint32_t* output, uint32_t numerator, uint32_t divisor, uint32_t defaultValue) {
     if (divisor == 0) {

--- a/tests/arithmetic/safe-div-basic.test.cpp
+++ b/tests/arithmetic/safe-div-basic.test.cpp
@@ -7,7 +7,6 @@
 #include <stdbool.h>
 
 // ADR-051: Safe division helper functions
-#include <stdbool.h>
 
 static inline bool cnx_safe_div_u32(uint32_t* output, uint32_t numerator, uint32_t divisor, uint32_t defaultValue) {
     if (divisor == 0) {

--- a/tests/arithmetic/safe-div-preserve-on-error.expected.c
+++ b/tests/arithmetic/safe-div-preserve-on-error.expected.c
@@ -7,7 +7,6 @@
 #include <stdbool.h>
 
 // ADR-051: Safe division helper functions
-#include <stdbool.h>
 
 static inline bool cnx_safe_div_u32(uint32_t* output, uint32_t numerator, uint32_t divisor, uint32_t defaultValue) {
     if (divisor == 0) {

--- a/tests/arithmetic/safe-div-preserve-on-error.expected.cpp
+++ b/tests/arithmetic/safe-div-preserve-on-error.expected.cpp
@@ -7,7 +7,6 @@
 #include <stdbool.h>
 
 // ADR-051: Safe division helper functions
-#include <stdbool.h>
 
 static inline bool cnx_safe_div_u32(uint32_t* output, uint32_t numerator, uint32_t divisor, uint32_t defaultValue) {
     if (divisor == 0) {

--- a/tests/arithmetic/safe-div-preserve-on-error.test.c
+++ b/tests/arithmetic/safe-div-preserve-on-error.test.c
@@ -7,7 +7,6 @@
 #include <stdbool.h>
 
 // ADR-051: Safe division helper functions
-#include <stdbool.h>
 
 static inline bool cnx_safe_div_u32(uint32_t* output, uint32_t numerator, uint32_t divisor, uint32_t defaultValue) {
     if (divisor == 0) {

--- a/tests/arithmetic/safe-div-preserve-on-error.test.cpp
+++ b/tests/arithmetic/safe-div-preserve-on-error.test.cpp
@@ -7,7 +7,6 @@
 #include <stdbool.h>
 
 // ADR-051: Safe division helper functions
-#include <stdbool.h>
 
 static inline bool cnx_safe_div_u32(uint32_t* output, uint32_t numerator, uint32_t divisor, uint32_t defaultValue) {
     if (divisor == 0) {

--- a/tests/arithmetic/safe-mod-basic.expected.c
+++ b/tests/arithmetic/safe-mod-basic.expected.c
@@ -7,7 +7,6 @@
 #include <stdbool.h>
 
 // ADR-051: Safe division helper functions
-#include <stdbool.h>
 
 static inline bool cnx_safe_mod_u32(uint32_t* output, uint32_t numerator, uint32_t divisor, uint32_t defaultValue) {
     if (divisor == 0) {

--- a/tests/arithmetic/safe-mod-basic.expected.cpp
+++ b/tests/arithmetic/safe-mod-basic.expected.cpp
@@ -7,7 +7,6 @@
 #include <stdbool.h>
 
 // ADR-051: Safe division helper functions
-#include <stdbool.h>
 
 static inline bool cnx_safe_mod_u32(uint32_t* output, uint32_t numerator, uint32_t divisor, uint32_t defaultValue) {
     if (divisor == 0) {

--- a/tests/arithmetic/safe-mod-basic.test.c
+++ b/tests/arithmetic/safe-mod-basic.test.c
@@ -7,7 +7,6 @@
 #include <stdbool.h>
 
 // ADR-051: Safe division helper functions
-#include <stdbool.h>
 
 static inline bool cnx_safe_mod_u32(uint32_t* output, uint32_t numerator, uint32_t divisor, uint32_t defaultValue) {
     if (divisor == 0) {

--- a/tests/arithmetic/safe-mod-basic.test.cpp
+++ b/tests/arithmetic/safe-mod-basic.test.cpp
@@ -7,7 +7,6 @@
 #include <stdbool.h>
 
 // ADR-051: Safe division helper functions
-#include <stdbool.h>
 
 static inline bool cnx_safe_mod_u32(uint32_t* output, uint32_t numerator, uint32_t divisor, uint32_t defaultValue) {
     if (divisor == 0) {

--- a/tests/comments/basic-comments.expected.c
+++ b/tests/comments/basic-comments.expected.c
@@ -7,8 +7,6 @@
 // Tests that line comments are preserved in output
 #include <stdint.h>
 
-#include <stdint.h>
-
 // Global variable with comment
 uint32_t counter = 0U;
 

--- a/tests/comments/basic-comments.expected.cpp
+++ b/tests/comments/basic-comments.expected.cpp
@@ -7,8 +7,6 @@
 // Tests that line comments are preserved in output
 #include <stdint.h>
 
-#include <stdint.h>
-
 // Global variable with comment
 uint32_t counter = 0U;
 

--- a/tests/comments/basic-comments.test.c
+++ b/tests/comments/basic-comments.test.c
@@ -7,8 +7,6 @@
 // Tests that line comments are preserved in output
 #include <stdint.h>
 
-#include <stdint.h>
-
 // Global variable with comment
 uint32_t counter = 0U;
 

--- a/tests/comments/basic-comments.test.cpp
+++ b/tests/comments/basic-comments.test.cpp
@@ -7,8 +7,6 @@
 // Tests that line comments are preserved in output
 #include <stdint.h>
 
-#include <stdint.h>
-
 // Global variable with comment
 uint32_t counter = 0U;
 

--- a/tests/comments/doc-comments.expected.c
+++ b/tests/comments/doc-comments.expected.c
@@ -7,8 +7,6 @@
 // Tests that triple-slash converts to Doxygen format
 #include <stdint.h>
 
-#include <stdint.h>
-
 /**
  * Doubles the input value
  * @param value The input to double

--- a/tests/comments/doc-comments.expected.cpp
+++ b/tests/comments/doc-comments.expected.cpp
@@ -7,8 +7,6 @@
 // Tests that triple-slash converts to Doxygen format
 #include <stdint.h>
 
-#include <stdint.h>
-
 /**
  * Doubles the input value
  * @param value The input to double

--- a/tests/comments/doc-comments.test.c
+++ b/tests/comments/doc-comments.test.c
@@ -7,8 +7,6 @@
 // Tests that triple-slash converts to Doxygen format
 #include <stdint.h>
 
-#include <stdint.h>
-
 /**
  * Doubles the input value
  * @param value The input to double

--- a/tests/comments/doc-comments.test.cpp
+++ b/tests/comments/doc-comments.test.cpp
@@ -7,8 +7,6 @@
 // Tests that triple-slash converts to Doxygen format
 #include <stdint.h>
 
-#include <stdint.h>
-
 /**
  * Doubles the input value
  * @param value The input to double

--- a/tests/comments/uri-exception.expected.c
+++ b/tests/comments/uri-exception.expected.c
@@ -7,8 +7,6 @@
 // Tests that :// patterns are allowed per MISRA Amendment 4
 #include <stdint.h>
 
-#include <stdint.h>
-
 // See documentation at https://example.com/docs
 // Reference: http://spec.org/standard
 /* API endpoint: https://api.example.com/v1

--- a/tests/comments/uri-exception.expected.cpp
+++ b/tests/comments/uri-exception.expected.cpp
@@ -7,8 +7,6 @@
 // Tests that :// patterns are allowed per MISRA Amendment 4
 #include <stdint.h>
 
-#include <stdint.h>
-
 // See documentation at https://example.com/docs
 // Reference: http://spec.org/standard
 /* API endpoint: https://api.example.com/v1

--- a/tests/comments/uri-exception.test.c
+++ b/tests/comments/uri-exception.test.c
@@ -7,8 +7,6 @@
 // Tests that :// patterns are allowed per MISRA Amendment 4
 #include <stdint.h>
 
-#include <stdint.h>
-
 // See documentation at https://example.com/docs
 // Reference: http://spec.org/standard
 /* API endpoint: https://api.example.com/v1

--- a/tests/comments/uri-exception.test.cpp
+++ b/tests/comments/uri-exception.test.cpp
@@ -7,8 +7,6 @@
 // Tests that :// patterns are allowed per MISRA Amendment 4
 #include <stdint.h>
 
-#include <stdint.h>
-
 // See documentation at https://example.com/docs
 // Reference: http://spec.org/standard
 /* API endpoint: https://api.example.com/v1

--- a/tests/forward-declarations/builtin-safe-div-valid.expected.c
+++ b/tests/forward-declarations/builtin-safe-div-valid.expected.c
@@ -4,9 +4,9 @@
  */
 
 #include <stdint.h>
+#include <stdbool.h>
 
 // ADR-051: Safe division helper functions
-#include <stdbool.h>
 
 static inline bool cnx_safe_div_u32(uint32_t* output, uint32_t numerator, uint32_t divisor, uint32_t defaultValue) {
     if (divisor == 0) {

--- a/tests/forward-declarations/builtin-safe-div-valid.expected.cpp
+++ b/tests/forward-declarations/builtin-safe-div-valid.expected.cpp
@@ -4,9 +4,9 @@
  */
 
 #include <stdint.h>
+#include <stdbool.h>
 
 // ADR-051: Safe division helper functions
-#include <stdbool.h>
 
 static inline bool cnx_safe_div_u32(uint32_t* output, uint32_t numerator, uint32_t divisor, uint32_t defaultValue) {
     if (divisor == 0) {

--- a/tests/forward-declarations/builtin-safe-div-valid.test.c
+++ b/tests/forward-declarations/builtin-safe-div-valid.test.c
@@ -4,9 +4,9 @@
  */
 
 #include <stdint.h>
+#include <stdbool.h>
 
 // ADR-051: Safe division helper functions
-#include <stdbool.h>
 
 static inline bool cnx_safe_div_u32(uint32_t* output, uint32_t numerator, uint32_t divisor, uint32_t defaultValue) {
     if (divisor == 0) {

--- a/tests/forward-declarations/builtin-safe-div-valid.test.cpp
+++ b/tests/forward-declarations/builtin-safe-div-valid.test.cpp
@@ -4,9 +4,9 @@
  */
 
 #include <stdint.h>
+#include <stdbool.h>
 
 // ADR-051: Safe division helper functions
-#include <stdbool.h>
 
 static inline bool cnx_safe_div_u32(uint32_t* output, uint32_t numerator, uint32_t divisor, uint32_t defaultValue) {
     if (divisor == 0) {

--- a/tests/null-check/valid-c-prefix-reassignment.expected.c
+++ b/tests/null-check/valid-c-prefix-reassignment.expected.c
@@ -10,8 +10,6 @@
 // cppcheck-suppress misra-c2012-21.6
 #include <stdio.h>
 
-#include <string.h>
-
 char haystack[65] = "hello world";
 
 void testReassignment(void) {

--- a/tests/null-check/valid-c-prefix-reassignment.expected.cpp
+++ b/tests/null-check/valid-c-prefix-reassignment.expected.cpp
@@ -10,8 +10,6 @@
 // cppcheck-suppress misra-c2012-21.6
 #include <stdio.h>
 
-#include <string.h>
-
 char haystack[65] = "hello world";
 
 void testReassignment(void) {

--- a/tests/null-check/valid-c-prefix-reassignment.test.c
+++ b/tests/null-check/valid-c-prefix-reassignment.test.c
@@ -10,8 +10,6 @@
 // cppcheck-suppress misra-c2012-21.6
 #include <stdio.h>
 
-#include <string.h>
-
 char haystack[65] = "hello world";
 
 void testReassignment(void) {

--- a/tests/null-check/valid-c-prefix-reassignment.test.cpp
+++ b/tests/null-check/valid-c-prefix-reassignment.test.cpp
@@ -10,8 +10,6 @@
 // cppcheck-suppress misra-c2012-21.6
 #include <stdio.h>
 
-#include <string.h>
-
 char haystack[65] = "hello world";
 
 void testReassignment(void) {

--- a/tests/null-check/valid-c-prefix-while-loop.expected.c
+++ b/tests/null-check/valid-c-prefix-while-loop.expected.c
@@ -10,8 +10,6 @@
 // cppcheck-suppress misra-c2012-21.6
 #include <stdio.h>
 
-#include <string.h>
-
 char haystack[65] = "hello hello hello";
 
 void testWhileLoop(void) {

--- a/tests/null-check/valid-c-prefix-while-loop.expected.cpp
+++ b/tests/null-check/valid-c-prefix-while-loop.expected.cpp
@@ -10,8 +10,6 @@
 // cppcheck-suppress misra-c2012-21.6
 #include <stdio.h>
 
-#include <string.h>
-
 char haystack[65] = "hello hello hello";
 
 void testWhileLoop(void) {

--- a/tests/null-check/valid-c-prefix-while-loop.test.c
+++ b/tests/null-check/valid-c-prefix-while-loop.test.c
@@ -10,8 +10,6 @@
 // cppcheck-suppress misra-c2012-21.6
 #include <stdio.h>
 
-#include <string.h>
-
 char haystack[65] = "hello hello hello";
 
 void testWhileLoop(void) {

--- a/tests/null-check/valid-c-prefix-while-loop.test.cpp
+++ b/tests/null-check/valid-c-prefix-while-loop.test.cpp
@@ -10,8 +10,6 @@
 // cppcheck-suppress misra-c2012-21.6
 #include <stdio.h>
 
-#include <string.h>
-
 char haystack[65] = "hello hello hello";
 
 void testWhileLoop(void) {

--- a/tests/preprocessor/conditional-compilation.expected.c
+++ b/tests/preprocessor/conditional-compilation.expected.c
@@ -20,9 +20,6 @@
 #else
 #endif
 
-#include <stdint.h>
-#include <stdbool.h>
-
 // Use const for values (not #define)
 const uint32_t LED_BIT = 3U;
 

--- a/tests/preprocessor/conditional-compilation.expected.cpp
+++ b/tests/preprocessor/conditional-compilation.expected.cpp
@@ -20,9 +20,6 @@
 #else
 #endif
 
-#include <stdint.h>
-#include <stdbool.h>
-
 // Use const for values (not #define)
 extern const uint32_t LED_BIT = 3U;
 

--- a/tests/preprocessor/conditional-compilation.test.c
+++ b/tests/preprocessor/conditional-compilation.test.c
@@ -20,9 +20,6 @@
 #else
 #endif
 
-#include <stdint.h>
-#include <stdbool.h>
-
 // Use const for values (not #define)
 const uint32_t LED_BIT = 3U;
 

--- a/tests/preprocessor/conditional-compilation.test.cpp
+++ b/tests/preprocessor/conditional-compilation.test.cpp
@@ -20,9 +20,6 @@
 #else
 #endif
 
-#include <stdint.h>
-#include <stdbool.h>
-
 // Use const for values (not #define)
 extern const uint32_t LED_BIT = 3U;
 

--- a/tests/preprocessor/flag-define-valid.expected.c
+++ b/tests/preprocessor/flag-define-valid.expected.c
@@ -12,8 +12,6 @@
 #define STM32F4
 #define DEBUG
 
-#include <stdint.h>
-
 // Const values (the safe way to define constants)
 const uint32_t LED_PIN = 13U;
 

--- a/tests/preprocessor/flag-define-valid.expected.cpp
+++ b/tests/preprocessor/flag-define-valid.expected.cpp
@@ -12,8 +12,6 @@
 #define STM32F4
 #define DEBUG
 
-#include <stdint.h>
-
 // Const values (the safe way to define constants)
 extern const uint32_t LED_PIN = 13U;
 

--- a/tests/preprocessor/flag-define-valid.test.c
+++ b/tests/preprocessor/flag-define-valid.test.c
@@ -12,8 +12,6 @@
 #define STM32F4
 #define DEBUG
 
-#include <stdint.h>
-
 // Const values (the safe way to define constants)
 const uint32_t LED_PIN = 13U;
 

--- a/tests/preprocessor/flag-define-valid.test.cpp
+++ b/tests/preprocessor/flag-define-valid.test.cpp
@@ -12,8 +12,6 @@
 #define STM32F4
 #define DEBUG
 
-#include <stdint.h>
-
 // Const values (the safe way to define constants)
 extern const uint32_t LED_PIN = 13U;
 


### PR DESCRIPTION
Fixes #1108.

## Problem

The generated `.c` could emit a system header twice, via two independent include paths:

1. A source that `#include`s `<stdint.h>`/`<stdbool.h>` passed it through, and `addAutoIncludes` then emitted it again from the `needs*` flags.
2. `generateSafeDivHelpers` emitted its **own** `#include <stdbool.h>` (its helpers return a `bool` error flag), independent of the `needs*` flags — a second code path for the same include.

## Fix (single include path)

- `addAutoIncludes` now dedups against includes already present in the output (passthrough source includes), via a small `extractIncludeTarget()` helper.
- The safe-div `bool` dependency is signalled through `requireInclude("stdbool")` when the safe-div effect is applied, so it flows through the one `addAutoIncludes` path. The helper no longer emits its own include. This **removes the duplicate code path** (per the project's "No Duplicate Code Paths" rule) rather than deduping around it — and makes the dependency explicit instead of relying on the incidental `bool` result declaration.

## Tests / verification

- TDD: added failing unit tests (passthrough-dedup for stdint/stdbool, and the safe-div helper path) in `RequireInclude.test.ts`; updated the `HelperGenerator` unit test to pin the new contract (helper emits no include).
- Regenerated 48 snapshots — diff is **exclusively** removed duplicate include lines plus the safe-div include relocating to the top block. Verified every changed snapshot still contains each system include exactly once.
- `npm run unit` (5899) and `npm run test:q` (1007, transpile + C compile) both green.
- Header (`.h`) path verified free of the same bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
