### PR TITLE
fix: preserve isAutoConst for cross-file function parameters (issue #1139)

### DIFF
--- a/src/transpiler/output/codegen/generators/expressions/CallExprUtils.ts
+++ b/src/transpiler/output/codegen/generators/expressions/CallExprUtils.ts
@@ -102,6 +102,7 @@ class CallExprUtils {
               baseType,
               isConst: p.isConst,
               isArray: p.isArray,
+              isAutoConst: p.isAutoConst,
             },
             isCrossFile: true,
           };


### PR DESCRIPTION
When a scope function in an included .cnx file takes a struct parameter, the transpiler was dropping the auto-const qualifier in the generated header and omitting the address-of operator in cross-file call sites.

The fix ensures that CallExprUtils.resolveTargetParam preserves the isAutoConst property when resolving cross-file function parameters, allowing proper header generation and call site construction.

Fixes #1139